### PR TITLE
FieldSentry Phase 1: backend gate + manual blacklist + status readout (#651)

### DIFF
--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -1,0 +1,163 @@
+-- =========================================================
+-- FS25 Realistic Soil & Fertilizer - FieldSentry (backend gate)
+-- =========================================================
+-- A lightweight backend that answers one binary question per field:
+-- "should this area run soil simulation right now?" It never touches the
+-- soil equations; the sim just consults it and skips disabled fields.
+--
+-- Proposal: @arissani (issue #651). This is the Phase 1 cut:
+--   - encapsulated registry (FieldSentry_Core) + status/reason API (FieldSentry_API)
+--   - manual blacklist (player chooses to "sleep" a field; its soil values freeze)
+-- Meadow profile, deco/fake-field detection and NPC-contract masking are later
+-- phases and only need new BLACKLIST reasons + classification rules layered on top.
+--
+-- Design constraints honoured here:
+--   - Backend only: no UI, no changes to soil equations.
+--   - Namespace safety: everything hangs off FieldSentry_Core / FieldSentry_API.
+--   - No hot-path allocations: isFieldSimDisabled returns a shared EMPTY_HINTS table
+--     and never builds garbage.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+---@class FieldSentry_Core
+FieldSentry_Core = {}
+
+-- Blacklist reason enum. Phase 1 uses NONE and MANUAL; the rest are reserved so the
+-- API shape is stable as later phases add structural/classification rules.
+FieldSentry_Core.BLACKLIST = {
+    NONE      = 0,
+    MANUAL    = 1,  -- player-set persistent intent (Phase 1)
+    FARMLAND  = 2,  -- reserved: whole-farmland manual block
+    OWNERSHIP = 3,  -- reserved: unowned land (already sleeps via active-set today)
+    NPC       = 4,  -- reserved: field under an AI/NPC contract
+    DECO      = 5,  -- reserved: decorative / fake field
+    INACTIVE  = 6,  -- reserved: long-idle sleep
+}
+
+local BL = FieldSentry_Core.BLACKLIST
+
+local REASON_NAMES = {
+    [BL.NONE]      = "active",
+    [BL.MANUAL]    = "manual",
+    [BL.FARMLAND]  = "farmland block",
+    [BL.OWNERSHIP] = "unowned",
+    [BL.NPC]       = "npc contract",
+    [BL.DECO]      = "decorative",
+    [BL.INACTIVE]  = "inactive",
+}
+
+--- Human-readable name for a reason enum (map tab / console).
+---@param reason number
+---@return string
+function FieldSentry_Core.reasonName(reason)
+    return REASON_NAMES[reason] or "unknown"
+end
+
+-- Per-field state, created lazily on first toggle.
+--   manualBlacklist    : boolean  persistent player intent
+--   meadowToggle       : boolean  persistent player intent (Phase 1 stores it; the
+--                                  meadow sim profile is a later phase, in S&F)
+--   evaluatedBlacklist : enum     dynamic status mask (recomputed from intents)
+--   lastSeq            : integer  reserved for the MP sequence token (later phase)
+---@class FieldSentry_FieldState
+FieldSentry_Core.FieldState = {}
+
+-- Shared immutable table so the hot path never allocates (Phase 1 has no live hints).
+local EMPTY_HINTS = {}
+
+local function getOrCreate(fieldId)
+    local f = FieldSentry_Core.FieldState[fieldId]
+    if not f then
+        f = {
+            manualBlacklist    = false,
+            meadowToggle       = false,
+            evaluatedBlacklist = BL.NONE,
+            lastSeq            = 0,
+        }
+        FieldSentry_Core.FieldState[fieldId] = f
+    end
+    return f
+end
+
+-- Recompute the dynamic mask from persistent intents. Structural rules run first and
+-- short-circuit; Phase 1 has exactly one (manual blacklist). Later phases insert
+-- farmland/ownership/NPC/deco checks here in priority order.
+local function evaluate(f)
+    if f.manualBlacklist then
+        f.evaluatedBlacklist = BL.MANUAL
+    else
+        f.evaluatedBlacklist = BL.NONE
+    end
+    return f.evaluatedBlacklist
+end
+FieldSentry_Core.evaluate = evaluate
+
+-- =========================================================
+-- Public API
+-- =========================================================
+---@class FieldSentry_API
+FieldSentry_API = {}
+
+--- Hot path (O(1)): is this field's simulation currently disabled?
+---@param fieldId number
+---@return boolean disabled
+---@return number reason   FieldSentry_Core.BLACKLIST enum
+---@return boolean meadow  meadow toggle (the sim consumes this in a later phase)
+---@return table hints     diagnostic hints (shared empty table in Phase 1)
+function FieldSentry_API.isFieldSimDisabled(fieldId)
+    local f = FieldSentry_Core.FieldState[fieldId]
+    if not f then
+        return false, BL.NONE, false, EMPTY_HINTS
+    end
+    return (f.evaluatedBlacklist ~= BL.NONE), f.evaluatedBlacklist, f.meadowToggle, (f.hints or EMPTY_HINTS)
+end
+
+--- Data consumer for the map tab / FarmTablet.
+---@param fieldId number
+---@return table status
+function FieldSentry_API.getUIStatus(fieldId)
+    local disabled, reason, meadow, hints = FieldSentry_API.isFieldSimDisabled(fieldId)
+    return {
+        isSimulationDisabled = disabled,
+        reason               = reason,
+        reasonName           = FieldSentry_Core.reasonName(reason),
+        isMeadow             = meadow,
+        diagnosticHints      = hints,
+    }
+end
+
+--- Set the manual blacklist for a field.
+---@param fieldId number
+---@param enabled boolean
+---@return boolean newValue
+function FieldSentry_API.setFieldManual(fieldId, enabled)
+    local f = getOrCreate(fieldId)
+    f.manualBlacklist = enabled and true or false
+    evaluate(f)
+    return f.manualBlacklist
+end
+
+--- Toggle the manual blacklist for a field. Returns the new value.
+---@param fieldId number
+---@return boolean newValue
+function FieldSentry_API.toggleFieldManual(fieldId)
+    local f = getOrCreate(fieldId)
+    return FieldSentry_API.setFieldManual(fieldId, not f.manualBlacklist)
+end
+
+--- Sorted list of field ids the player has manually blacklisted (console / persistence).
+---@return number[]
+function FieldSentry_API.getManualBlacklist()
+    local out = {}
+    for id, f in pairs(FieldSentry_Core.FieldState) do
+        if f.manualBlacklist then out[#out + 1] = id end
+    end
+    table.sort(out)
+    return out
+end
+
+--- Drop all state (map swap / new game). Persistence layer calls this before restoring.
+function FieldSentry_API.reset()
+    FieldSentry_Core.FieldState = {}
+end

--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -146,6 +146,14 @@ function FieldSentry_API.toggleFieldManual(fieldId)
     return FieldSentry_API.setFieldManual(fieldId, not f.manualBlacklist)
 end
 
+--- Is this field currently manually blacklisted? (read-only, no state created)
+---@param fieldId number
+---@return boolean
+function FieldSentry_API.isFieldManual(fieldId)
+    local f = FieldSentry_Core.FieldState[fieldId]
+    return (f ~= nil) and f.manualBlacklist == true
+end
+
 --- Sorted list of field ids the player has manually blacklisted (console / persistence).
 ---@return number[]
 function FieldSentry_API.getManualBlacklist()

--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -161,3 +161,37 @@ end
 function FieldSentry_API.reset()
     FieldSentry_Core.FieldState = {}
 end
+
+-- =========================================================
+-- Persistence (Phase 1: manual blacklist only)
+-- =========================================================
+-- Only the player's persistent intent is saved; the dynamic mask is recomputed on
+-- load. SoilFertilityManager folds these into soilData.xml, which is already
+-- savegame/map-scoped, so a map swap drops stale config naturally. Uses only
+-- setXMLInt/getXMLInt (the XML API this codebase already relies on) — a stored
+-- entry implies manualBlacklist=true, so no boolean attribute is needed.
+
+--- Write the manual blacklist into the given XML node.
+---@param xmlFile any  XML file handle
+---@param key string   base node, e.g. "soilData.fieldSentry"
+function FieldSentry_API.saveToXMLFile(xmlFile, key)
+    local list = FieldSentry_API.getManualBlacklist()
+    setXMLInt(xmlFile, key .. "#count", #list)
+    for i = 1, #list do
+        local entryKey = string.format("%s.field(%d)", key, i - 1)
+        setXMLInt(xmlFile, entryKey .. "#id", list[i])
+    end
+end
+
+--- Restore the manual blacklist from the given XML node (replaces current state).
+---@param xmlFile any
+---@param key string
+function FieldSentry_API.loadFromXMLFile(xmlFile, key)
+    FieldSentry_API.reset()
+    local count = getXMLInt(xmlFile, key .. "#count") or 0
+    for i = 0, count - 1 do
+        local entryKey = string.format("%s.field(%d)", key, i)
+        local id = getXMLInt(xmlFile, entryKey .. "#id")
+        if id then FieldSentry_API.setFieldManual(id, true) end
+    end
+end

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -964,6 +964,8 @@ function SoilFertilityManager:saveSoilData()
 
     if xmlFile then
         self.soilSystem:saveToXMLFile(xmlFile, "soilData")
+        -- FieldSentry (#651): persist the player's manual blacklist alongside soil data.
+        if FieldSentry_API then FieldSentry_API.saveToXMLFile(xmlFile, "soilData.fieldSentry") end
         setXMLString(xmlFile, "soilData#lastSeenVersion", self.lastSeenVersion or "")
         saveXMLFile(xmlFile)
         delete(xmlFile)
@@ -997,6 +999,8 @@ function SoilFertilityManager:loadSoilData()
         local xmlFile = loadXMLFile("soilData", xmlPath)
         if xmlFile then
             self.soilSystem:loadFromXMLFile(xmlFile, "soilData")
+            -- FieldSentry (#651): restore the manual blacklist (no-op if none saved).
+            if FieldSentry_API then FieldSentry_API.loadFromXMLFile(xmlFile, "soilData.fieldSentry") end
             self.lastSeenVersion = getXMLString(xmlFile, "soilData#lastSeenVersion") or ""
             delete(xmlFile)
             local fieldCount = 0

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2118,6 +2118,12 @@ end
 ---@param fieldId number
 ---@param field table  fieldData entry (pre-validated non-nil by caller)
 function SoilFertilitySystem:_processOneDailyField(fieldId, field)
+    -- FieldSentry gate (#651): a field the player has put to sleep (manual blacklist)
+    -- — or that a later phase disables (deco/NPC/farmland) — skips the daily
+    -- depletion/recovery/leaching/seasonal pass entirely, so its soil values freeze
+    -- at whatever they were. Single O(1) check; no equation code below is touched.
+    if FieldSentry_API and FieldSentry_API.isFieldSimDisabled(fieldId) then return end
+
     local limits   = SoilConstants.NUTRIENT_LIMITS
     local recovery = SoilConstants.FALLOW_RECOVERY
     local seasonal = SoilConstants.SEASONAL_EFFECTS

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -3775,9 +3775,21 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
         yieldEfficiency = math.floor(mod * 100 + 0.5)
     end
 
+    -- FieldSentry (#651) status, surfaced so any readout (field detail dialog, HUD,
+    -- map overlay) can show that a slept field's soil is frozen by intent, not broken.
+    -- isFieldSimDisabled is allocation-free, so this stays cheap for per-frame callers.
+    local fsDisabled, fsReason = false, "active"
+    if FieldSentry_API then
+        local d, r = FieldSentry_API.isFieldSimDisabled(fieldId)
+        fsDisabled = d
+        fsReason   = FieldSentry_Core.reasonName(r)
+    end
+
     return {
         fieldId = fieldId,
         fieldArea = field.fieldArea or 1.0,
+        simDisabled       = fsDisabled,
+        simDisabledReason = fsReason,
         nitrogen = { value = math.floor(n), status = nutrientStatus(n, "nitrogen", cropTargets) },
         phosphorus = { value = math.floor(p), status = nutrientStatus(p, "phosphorus", cropTargets) },
         potassium = { value = math.floor(k), status = nutrientStatus(k, "potassium", cropTargets) },

--- a/src/main.lua
+++ b/src/main.lua
@@ -46,6 +46,9 @@ source(modDirectory .. "src/ui/SoilLayerSystem.lua")
 source(modDirectory .. "src/maps/SoilBundledMaps.lua")
 source(modDirectory .. "src/SprayerRateManager.lua")
 source(modDirectory .. "src/SoilSensorManager.lua")
+-- FieldSentry backend gate (#651): must load before SoilFertilitySystem so its
+-- daily loop can consult FieldSentry_API. Backend only — no UI, no equation changes.
+source(modDirectory .. "src/FieldSentry.lua")
 source(modDirectory .. "src/SoilFertilitySystem.lua")
 
 -- 3. Settings

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -1322,4 +1322,74 @@ function SoilNetworkEvents_SendSprayerAutoMode(vehicle, enabled)
     end
 end
 
+-- ========================================
+-- FIELDSENTRY MANUAL-BLACKLIST TOGGLE (#651)
+-- ========================================
+-- Server-authoritative. A pure client sends a request; the server validates (admin),
+-- applies it on FieldSentry, then broadcasts so every client mirrors the state for the
+-- map-tab status readout. The server/host applies directly via the Send wrapper below.
+SoilFieldSentryEvent = {}
+SoilFieldSentryEvent_mt = Class(SoilFieldSentryEvent, Event)
+
+InitEventClass(SoilFieldSentryEvent, "SoilFieldSentryEvent")
+
+function SoilFieldSentryEvent.emptyNew()
+    return Event.new(SoilFieldSentryEvent_mt)
+end
+
+function SoilFieldSentryEvent.new(fieldId, manual)
+    local self = SoilFieldSentryEvent.emptyNew()
+    self.fieldId = fieldId
+    self.manual = manual
+    return self
+end
+
+function SoilFieldSentryEvent:readStream(streamId, connection)
+    self.fieldId = streamReadInt32(streamId)
+    self.manual = streamReadBool(streamId)
+    self:run(connection)
+end
+
+function SoilFieldSentryEvent:writeStream(streamId, connection)
+    streamWriteInt32(streamId, self.fieldId)
+    streamWriteBool(streamId, self.manual)
+end
+
+function SoilFieldSentryEvent:run(connection)
+    if g_server ~= nil then
+        -- We are the server. A request from a client connection must be admin.
+        if not connection:getIsServer() then
+            local user = g_currentMission.userManager and
+                         g_currentMission.userManager:getUserByConnection(connection)
+            if not user or not user:getIsMasterUser() then
+                SoilLogger.warning("FieldSentry: non-admin field toggle denied")
+                return
+            end
+        end
+        if FieldSentry_API then FieldSentry_API.setFieldManual(self.fieldId, self.manual) end
+        -- Relay to all clients except the original sender (they already applied / asked).
+        if g_server then
+            g_server:broadcastEvent(SoilFieldSentryEvent.new(self.fieldId, self.manual), nil, connection)
+        end
+    else
+        -- Client receiving the server's authoritative state: mirror it for the UI.
+        if FieldSentry_API then FieldSentry_API.setFieldManual(self.fieldId, self.manual) end
+    end
+end
+
+--- Set a field's manual blacklist with multiplayer sync.
+--- Pure client: asks the server. Server/host: applies and broadcasts to clients.
+---@param fieldId number
+---@param manual boolean
+function SoilNetworkEvents_SendFieldSentryToggle(fieldId, manual)
+    if g_client and not g_server then
+        g_client:getServerConnection():sendEvent(SoilFieldSentryEvent.new(fieldId, manual))
+    else
+        if FieldSentry_API then FieldSentry_API.setFieldManual(fieldId, manual) end
+        if g_server then
+            g_server:broadcastEvent(SoilFieldSentryEvent.new(fieldId, manual))
+        end
+    end
+end
+
 SoilLogger.info("Network events system loaded")

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -48,6 +48,8 @@ function SoilSettingsGUI:registerConsoleCommands()
     addConsoleCommand("soilRecoverField", "Recover field to default values: soilRecoverField [fieldId]", "consoleCommandRecoverField", self)
     addConsoleCommand("SoilRerollFields", "Re-roll starting soil (N/P/K/pH/OM) for all fields with the new regional variation (#632)", "consoleCommandRerollFields", self)
     addConsoleCommand("SoilRerollUnownedFields", "Re-roll starting soil only for fields you don't own (keeps your own farm's soil) (#632)", "consoleCommandRerollUnownedFields", self)
+    addConsoleCommand("SoilBlacklistField", "FieldSentry: sleep/wake a field's soil sim: SoilBlacklistField <fieldId> [true|false] (#651)", "consoleCommandBlacklistField", self)
+    addConsoleCommand("SoilFieldSentry", "FieldSentry: show a field's sim status, or list all slept fields: SoilFieldSentry [fieldId] (#651)", "consoleCommandFieldSentry", self)
     addConsoleCommand("soilfertility", "Show all soil commands", "consoleCommandHelp", self)
 
     SoilLogger.info("Console commands registered")
@@ -78,8 +80,66 @@ function SoilSettingsGUI:consoleCommandHelp()
     print("soilRecoverField [fieldId] - Recover field to default values")
     print("SoilRerollFields - Re-roll starting soil for all fields (new regional variation)")
     print("SoilRerollUnownedFields - Re-roll starting soil for fields you don't own (keeps your own)")
+    print("SoilBlacklistField <fieldId> [true|false] - FieldSentry: sleep/wake a field's soil sim (#651)")
+    print("SoilFieldSentry [fieldId] - FieldSentry: show a field's sim status, or list slept fields (#651)")
     print("==============================================")
     return "Type 'soilfertility' for more info"
+end
+
+-- =========================================================
+-- FieldSentry (#651) console commands
+-- =========================================================
+
+--- SoilBlacklistField <fieldId> [true|false]
+--- Manually puts a field's soil simulation to sleep (or wakes it). A slept field
+--- keeps its current soil values frozen and is skipped by the daily sim.
+function SoilSettingsGUI:consoleCommandBlacklistField(fieldId, state)
+    if not FieldSentry_API then return "Error: FieldSentry not initialized" end
+
+    local fid = tonumber(fieldId)
+    if not fid then return "Usage: SoilBlacklistField <fieldId> [true|false]" end
+
+    -- Field data lives on the server; toggling on a client would desync until MP sync
+    -- lands (Phase 1 is server/SP only — see issue #651 rollout).
+    local isServer = g_currentMission and g_currentMission:getIsServer()
+    if not isServer then
+        return "FieldSentry toggles must be run on the server/host (it owns the field data)."
+    end
+
+    local newVal
+    if state == nil then
+        newVal = FieldSentry_API.toggleFieldManual(fid)
+    else
+        local s = tostring(state):lower()
+        newVal = FieldSentry_API.setFieldManual(fid, s == "true" or s == "1" or s == "on")
+    end
+
+    return string.format("Field %d soil sim is now %s.", fid,
+        newVal and "ASLEEP (manual blacklist) - values frozen" or "ACTIVE")
+end
+
+--- SoilFieldSentry [fieldId]
+--- With a fieldId: print that field's FieldSentry status + reason.
+--- Without one: list every manually slept field.
+function SoilSettingsGUI:consoleCommandFieldSentry(fieldId)
+    if not FieldSentry_API then return "Error: FieldSentry not initialized" end
+
+    local fid = tonumber(fieldId)
+    if fid then
+        local s = FieldSentry_API.getUIStatus(fid)
+        print(string.format(
+            "=== FieldSentry: Field %d ===\nSim disabled: %s\nReason: %s\nMeadow: %s\n============================",
+            fid,
+            s.isSimulationDisabled and "yes" or "no",
+            s.reasonName,
+            s.isMeadow and "yes" or "no"))
+        return string.format("Field %d: %s (%s)", fid,
+            s.isSimulationDisabled and "asleep" or "active", s.reasonName)
+    end
+
+    local list = FieldSentry_API.getManualBlacklist()
+    if #list == 0 then return "FieldSentry: no fields are manually slept." end
+    return "FieldSentry: slept fields -> " .. table.concat(list, ", ")
 end
 
 function SoilSettingsGUI:consoleCommandSetDifficulty(difficulty)

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -106,13 +106,16 @@ function SoilSettingsGUI:consoleCommandBlacklistField(fieldId, state)
         return "FieldSentry toggles must be run on the server/host (it owns the field data)."
     end
 
+    -- Determine the target value, then apply+broadcast through the MP-aware wrapper
+    -- so clients mirror it (the wrapper applies directly on the host).
     local newVal
     if state == nil then
-        newVal = FieldSentry_API.toggleFieldManual(fid)
+        newVal = not FieldSentry_API.isFieldManual(fid)
     else
         local s = tostring(state):lower()
-        newVal = FieldSentry_API.setFieldManual(fid, s == "true" or s == "1" or s == "on")
+        newVal = (s == "true" or s == "1" or s == "on")
     end
+    SoilNetworkEvents_SendFieldSentryToggle(fid, newVal)
 
     return string.format("Field %d soil sim is now %s.", fid,
         newVal and "ASLEEP (manual blacklist) - values frozen" or "ACTIVE")

--- a/src/ui/SoilFieldDetailDialog.lua
+++ b/src/ui/SoilFieldDetailDialog.lua
@@ -207,7 +207,15 @@ function SoilFieldDetailDialog:_populateData()
 
     -- Field ID in title
     if self.detailFieldId then
-        self.detailFieldId:setText(tr("sf_detail_field_label", "Field #") .. tostring(fieldId))
+        local label = tr("sf_detail_field_label", "Field #") .. tostring(fieldId)
+        -- FieldSentry (#651): a slept field's soil is frozen by player intent. Flag it
+        -- here so a static field doesn't read as a bug. tr() falls back to English when
+        -- the l10n key is absent, so this works before the 26-language keys are added.
+        if info.simDisabled then
+            label = label .. "  (" .. tr("sf_fieldsentry_asleep", "sim asleep") ..
+                    ": " .. tostring(info.simDisabledReason) .. ")"
+        end
+        self.detailFieldId:setText(label)
     end
 
     -- Urgency

--- a/tools/test/lua/fieldsentry_test.lua
+++ b/tools/test/lua/fieldsentry_test.lua
@@ -33,6 +33,13 @@ end
 
 do
   FieldSentry_API.reset()
+  T.ok("isFieldManual: false for unknown field", FieldSentry_API.isFieldManual(50) == false)
+  FieldSentry_API.setFieldManual(50, true)
+  T.ok("isFieldManual: true after blacklist", FieldSentry_API.isFieldManual(50) == true)
+end
+
+do
+  FieldSentry_API.reset()
   FieldSentry_API.setFieldManual(3, true)
   local s = FieldSentry_API.getUIStatus(3)
   T.ok("getUIStatus: isSimulationDisabled true", s.isSimulationDisabled == true)

--- a/tools/test/lua/fieldsentry_test.lua
+++ b/tools/test/lua/fieldsentry_test.lua
@@ -1,0 +1,81 @@
+-- fieldsentry_test.lua — FieldSentry Phase 1 backend gate (#651).
+-- The module itself is dependency-free; the last block also loads the soil system to
+-- prove the freeze gate in _processOneDailyField actually skips a blacklisted field.
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/FieldSentry.lua, src/SoilFertilitySystem.lua
+
+local BL = FieldSentry_Core.BLACKLIST
+
+-- ── status API ─────────────────────────────────────────────
+do
+  FieldSentry_API.reset()
+  local disabled, reason = FieldSentry_API.isFieldSimDisabled(99)
+  T.ok("unknown field is not disabled", disabled == false)
+  T.eq("unknown field reason is NONE", reason, BL.NONE)
+end
+
+do
+  FieldSentry_API.reset()
+  FieldSentry_API.setFieldManual(1, true)
+  local disabled, reason = FieldSentry_API.isFieldSimDisabled(1)
+  T.ok("setFieldManual(true) disables the field", disabled == true)
+  T.eq("manual blacklist reason is MANUAL", reason, BL.MANUAL)
+
+  FieldSentry_API.setFieldManual(1, false)
+  T.ok("setFieldManual(false) re-enables the field",
+       FieldSentry_API.isFieldSimDisabled(1) == false)
+end
+
+do
+  FieldSentry_API.reset()
+  T.ok("toggleFieldManual: first toggle sleeps", FieldSentry_API.toggleFieldManual(2) == true)
+  T.ok("toggleFieldManual: second toggle wakes", FieldSentry_API.toggleFieldManual(2) == false)
+end
+
+do
+  FieldSentry_API.reset()
+  FieldSentry_API.setFieldManual(3, true)
+  local s = FieldSentry_API.getUIStatus(3)
+  T.ok("getUIStatus: isSimulationDisabled true", s.isSimulationDisabled == true)
+  T.eq("getUIStatus: reasonName maps the enum", s.reasonName, "manual")
+  T.ok("getUIStatus: isMeadow defaults false", s.isMeadow == false)
+end
+
+do
+  FieldSentry_API.reset()
+  FieldSentry_API.setFieldManual(7, true)
+  FieldSentry_API.setFieldManual(2, true)
+  FieldSentry_API.setFieldManual(5, true)
+  local list = FieldSentry_API.getManualBlacklist()
+  T.eq("getManualBlacklist: count", #list, 3)
+  T.ok("getManualBlacklist: sorted ascending", list[1] == 2 and list[2] == 5 and list[3] == 7)
+  FieldSentry_API.reset()
+  T.eq("reset clears the registry", #FieldSentry_API.getManualBlacklist(), 0)
+end
+
+-- ── hot path allocates nothing ─────────────────────────────
+do
+  FieldSentry_API.reset()
+  local _, _, _, hints = FieldSentry_API.isFieldSimDisabled(123)
+  T.ok("hot path returns a hints table (shared empty in Phase 1)", type(hints) == "table")
+end
+
+-- ── freeze gate: blacklisted field is skipped by the daily sim ──
+do
+  FieldSentry_API.reset()
+  local sys = setmetatable({
+    fieldData         = {},
+    settings          = { enabled = true, nutrientCycles = true },
+    _dailyBatchDay    = 1,
+    _dailyBatchSeason = 1,
+  }, { __index = SoilFertilitySystem })
+
+  -- A non-blacklisted field would have nutrientBuffer reset to {} immediately;
+  -- a slept field early-returns before that, so the sentinel survives.
+  local field = { nutrientBuffer = { sentinel = true }, pH = 6.5, nitrogen = 40 }
+  sys.fieldData[1] = field
+
+  FieldSentry_API.setFieldManual(1, true)
+  sys:_processOneDailyField(1, field)
+  T.ok("freeze gate: slept field's daily pass is skipped (sentinel survives)",
+       field.nutrientBuffer.sentinel == true)
+end

--- a/tools/test/lua/fieldsentry_test.lua
+++ b/tools/test/lua/fieldsentry_test.lua
@@ -59,6 +59,26 @@ do
   T.ok("hot path returns a hints table (shared empty in Phase 1)", type(hints) == "table")
 end
 
+-- ── persistence round-trip (save → reset → load) ───────────
+do
+  FieldSentry_API.reset()
+  FieldSentry_API.setFieldManual(4, true)
+  FieldSentry_API.setFieldManual(11, true)
+
+  local xml = {}  -- in-memory XML handle (see prelude mock)
+  FieldSentry_API.saveToXMLFile(xml, "soilData.fieldSentry")
+
+  FieldSentry_API.reset()
+  T.eq("persistence: state cleared before load", #FieldSentry_API.getManualBlacklist(), 0)
+
+  FieldSentry_API.loadFromXMLFile(xml, "soilData.fieldSentry")
+  local list = FieldSentry_API.getManualBlacklist()
+  T.eq("persistence: round-trip restores count", #list, 2)
+  T.ok("persistence: round-trip restores the right ids", list[1] == 4 and list[2] == 11)
+  T.ok("persistence: restored field reports disabled",
+       FieldSentry_API.isFieldSimDisabled(11) == true)
+end
+
 -- ── freeze gate: blacklisted field is skipped by the daily sim ──
 do
   FieldSentry_API.reset()

--- a/tools/test/lua/prelude.lua
+++ b/tools/test/lua/prelude.lua
@@ -28,6 +28,13 @@ g_currentMission = {
 g_i18n = { getText = function(_self, key) return key end }
 g_messageCenter = { subscribe = function() end, unsubscribe = function() end, publish = function() end }
 
+-- Minimal in-memory XML mock: the file handle is a plain table keyed by the XML path
+-- string, enough for save/load round-trip tests. Extend if a test needs more types.
+function setXMLInt(handle, key, value) if handle then handle[key] = value end end
+function getXMLInt(handle, key) if handle then return handle[key] end end
+function setXMLString(handle, key, value) if handle then handle[key] = value end end
+function getXMLString(handle, key) if handle then return handle[key] end end
+
 -- Class tables some modules reference at load; harmless empty stubs.
 HookManager = HookManager or { new = function() return {} end }
 


### PR DESCRIPTION
Implements **Phase 1** of FieldSentry (#651), the backend field-eligibility gate proposed by @arissani. Scope agreed in the issue: core backend + manual blacklist + map-tab status readout. Meadow profile, deco/NPC detection and NPCFavor integration are later phases.

It layers onto the existing active-set + `DAILY_BATCH_SIZE` loop with a single O(1) gate, rather than standing up a parallel scheduler. No soil-equation code is touched.

## Commits
- **Backend core** - `src/FieldSentry.lua`: encapsulated `FieldSentry_Core` + `FieldSentry_API` (`isFieldSimDisabled` hot path, `getUIStatus`, `setFieldManual`/`toggleFieldManual`/`isFieldManual`, `reset`). The freeze is one early return at the top of `SoilFertilitySystem:_processOneDailyField`, so a slept field skips the daily depletion/recovery/leaching pass and its values stay put.
- **Persistence** - manual blacklist saved into `soilData.xml` (already savegame/map scoped) and restored on load, using only `setXMLInt`/`getXMLInt`.
- **Multiplayer** - `SoilFieldSentryEvent` + `SoilNetworkEvents_SendFieldSentryToggle`: server-authoritative, admin-validated, broadcast to clients. Mirrors the existing setting/auto-mode events.
- **Map-tab readout** - `getFieldInfo` returns `simDisabled` + `simDisabledReason`; the field detail dialog shows `(sim asleep: <reason>)` so a frozen field reads as intentional, not as a stalled sim.

## Console (server/SP for now)
- `SoilBlacklistField <fieldId> [true|false]` - sleep/wake a field
- `SoilFieldSentry [fieldId]` - status for a field, or list slept fields

## Testing
- 21 FieldSentry assertions in the offline harness (status API, toggle, persistence round-trip, the freeze-gate integration test). Full suite green: `bash tools/test/run.sh`.

## Still to do (not blockers for Phase 1 review)
- In-game test of the MP event over a real connection, and the dialog suffix placement (the harness can't drive streams or render).
- `sf_fieldsentry_asleep` l10n key across the 26 languages (dialog falls back to English today).
- `_rebuildActiveList` filter so slept fields aren't enqueued (perf), and join-sync of the blacklist to clients who connect after a toggle.

Part of #651 (multi-phase, keep open).