### PR TITLE
FieldSentry Phase 2: contract provider integration (#654)

### DIFF
--- a/docs/integration-npcfavor.md
+++ b/docs/integration-npcfavor.md
@@ -1,0 +1,167 @@
+# Integrating with FieldSentry (contract providers)
+
+FieldSentry is the backend gate inside FS25 Soil & Fertilizer that decides, per field,
+whether the soil simulation should run right now. Phase 2 adds a small, decoupled API so
+another mod can tell FieldSentry "this field is under one of my contracts" without S&F
+ever depending on that mod, and without that mod touching the soil equations.
+
+This guide is written for NPCFavor, but nothing here is NPCFavor-specific. Any mod that
+runs field work the player should not be penalised for (favor harvests, AI helper jobs,
+custom missions) can register the same way.
+
+---
+
+## The problem it solves
+
+S&F simulates owned fields: harvests deplete N/P/K, and a depleted field yields less.
+NPC neighbour fields are not managed by anyone, so under S&F their yield would crater,
+and an NPC harvest favor would become mathematically impossible to complete.
+
+FieldSentry fixes that by **masking** the field while a contract is active: the daily sim
+skips it, so its soil values freeze and the contract harvest gets vanilla yields. When the
+contract ends, FieldSentry can apply a one-shot **retroactive** nutrient catch-up so the
+field does not sit frozen in stasis forever.
+
+---
+
+## API surface
+
+All of these live on the global `FieldSentry_API` (guard with `if FieldSentry_API then`
+so your mod still loads if S&F is absent).
+
+| Function | Purpose |
+|----------|---------|
+| `registerContractProvider(name, fn)` | Register your eligibility callback. Returns `true` if registered. |
+| `unregisterContractProvider(name)` | Remove it (on teardown). |
+| `applyRetroactiveHarvest(fieldId, liters, fruitType, seq)` | One-shot nutrient catch-up when a contract finishes. |
+
+Tunable: `FieldSentry_Core.FAVOR_TIER_THRESHOLD` (default `4`) — at or above this favor
+tier a provider may keep S&F running instead of masking (see *Favor-tier exemption*).
+
+---
+
+## The callback contract
+
+```lua
+-- fn(fieldId) -> { active = boolean, favorTier = number, allowSAndF = boolean }
+```
+
+| Field | Meaning |
+|-------|---------|
+| `active` | **Required boolean.** `true` while one of your contracts is running on this field. |
+| `favorTier` | Optional number (default `0`). The neighbour relationship tier for this field. |
+| `allowSAndF` | Optional boolean (default `false`). `true` asks FieldSentry to let S&F keep running on the field instead of masking it, *if* `favorTier` is high enough. |
+
+Hard rules, because FieldSentry **fails closed**:
+
+- Return a **table**, always, with a real `boolean` in `active`. A `nil`, a non-table, a
+  crash, or a non-boolean `active` is treated as "contract active, not exempt" — the field
+  stays masked. A broken provider can never silently un-mask an NPC field.
+- Keep it **non-blocking and cheap**. It is called per field on the daily sim seam, wrapped
+  in `pcall`. No yields, no heavy lookups, no allocations you can avoid. An O(1) table read
+  is the target.
+- `fieldId` is the **farmland id** (the same id S&F uses everywhere).
+
+---
+
+## Server-only
+
+Registration and evaluation are **server/host authoritative**. Register on the server (or
+in single player); a pure client registration is ignored on purpose. Clients receive the
+resulting mask through S&F's own sync, so you never send your own packets for this.
+
+---
+
+## Example: NPCFavor provider
+
+```lua
+-- In NPCFavor, once the mission is up and you are the server/host.
+-- (Single player counts as the server, so this also runs in SP.)
+
+local function npcFavorContractStatus(fieldId)
+    -- Look up YOUR own state. Keep this fast and never error.
+    local contract = NPCFavorManager and NPCFavorManager:getActiveContractForField(fieldId)
+    if not contract then
+        return { active = false }
+    end
+
+    local tier = (contract.neighbour and contract.neighbour.favorTier) or 0
+
+    return {
+        active     = true,
+        favorTier  = tier,
+        -- Best friends let you actually manage their soil; hostile neighbours don't,
+        -- so their field is fully masked and the harvest gets vanilla yields.
+        allowSAndF = tier >= (FieldSentry_Core.FAVOR_TIER_THRESHOLD or 4),
+    }
+end
+
+if FieldSentry_API and FieldSentry_API.registerContractProvider then
+    FieldSentry_API.registerContractProvider("NPCFavor", npcFavorContractStatus)
+end
+```
+
+That is the whole masking integration. While a favor is active on a field, S&F leaves it
+alone; when it ends, your next call returns `active = false` and S&F resumes on the next
+daily tick.
+
+---
+
+## Favor-tier exemption (optional, progression)
+
+By default every contract field is masked the same way. With `allowSAndF = true` and a
+`favorTier` at or above the threshold, FieldSentry instead **leaves the sim running** on
+the field and records a transient `contractExempt` hint (readable via
+`FieldSentry_API.getUIStatus(fieldId).diagnosticHints`). Use this to reward high
+relationships: a best friend lets the player prepare and benefit from real soil management
+on the contract field, while a hostile neighbour's field stays a plain vanilla mask.
+
+FieldSentry never flips a persistent player setting from a hint — the exemption is
+recomputed live each refresh from what your callback returns.
+
+---
+
+## Retroactive nutrient catch-up (optional)
+
+While a field is masked its soil is frozen. If you want the contract harvest to still leave
+a realistic dent, call this once when the contract **completes**:
+
+```lua
+-- deliveredLiters: the yield the contract actually pulled off the field.
+-- fruitType:       crop name string (e.g. "wheat"); nil uses default coefficients.
+-- contractSeq:     a number that increases by 1 per contract on this field. It is the
+--                  idempotency token: the same (or an older) seq is never applied twice,
+--                  so a save/reload or a duplicate completion event can't double-dock.
+FieldSentry_API.applyRetroactiveHarvest(fieldId, deliveredLiters, fruitType, contractSeq)
+```
+
+FieldSentry estimates the N/P/K drain from fixed per-crop coefficients (not the full sim)
+and applies it in one cheap step, then bumps the stored sequence. If S&F's sim is not ready
+yet (for example you call it during load), the catch-up is queued and applied automatically
+on the next opportunity. In multiplayer the reconciled values are broadcast like any other
+soil change, so clients stay in sync.
+
+Keep `contractSeq` monotonic per field (a simple per-field counter you persist is fine).
+That is what makes the call safe to fire more than once.
+
+---
+
+## Teardown
+
+If your mod unloads mid-session, drop your provider so FieldSentry stops calling it:
+
+```lua
+if FieldSentry_API and FieldSentry_API.unregisterContractProvider then
+    FieldSentry_API.unregisterContractProvider("NPCFavor")
+end
+```
+
+---
+
+## Checklist
+
+- [ ] Register on the server/host only, after the mission loads.
+- [ ] Callback returns a table with a boolean `active`, always, and never errors or blocks.
+- [ ] Use `favorTier` + `allowSAndF` only if you want the progression exemption.
+- [ ] Call `applyRetroactiveHarvest` on contract completion with a monotonic `contractSeq`.
+- [ ] Guard every call with `if FieldSentry_API then` so your mod survives S&F being absent.

--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -77,6 +77,12 @@ FieldSentry_Core.FAVOR_TIER_THRESHOLD = 4
 -- migrateLegacy can upgrade older saves in place.
 FieldSentry_Core.SCHEMA_VERSION = 2
 
+-- FR5: optional mask broadcaster, injected by the network layer (NetworkEvents) so this
+-- module never references the networking API directly. Signature:
+--   function(fieldId, reason, seq)   -- called server-side when a field's mask changes.
+-- nil in single player and in the offline test harness.
+FieldSentry_Core.maskBroadcaster = nil
+
 -- Per-field state, created lazily on first toggle.
 --   manualBlacklist    : boolean  persistent player intent
 --   meadowToggle       : boolean  persistent player intent (Phase 1 stores it; the
@@ -369,10 +375,39 @@ function FieldSentry_API.refreshContract(fieldId)
     end
 
     f = getOrCreate(fieldId)
+    local prevReason = f.evaluatedBlacklist
     f.contractActive = underContract
     f.contractInfo   = underContract and info or nil
     evaluate(f)
+
+    -- FR5: when the server changes a field's mask, bump its FIFO sequence and broadcast so
+    -- clients mirror the status for the map-tab readout. Stale client packets are dropped
+    -- by seq in applyMaskSync, so out-of-order delivery cannot corrupt state.
+    if f.evaluatedBlacklist ~= prevReason then
+        f.lastSeq = (f.lastSeq or 0) + 1
+        if FieldSentry_Core.maskBroadcaster then
+            FieldSentry_Core.maskBroadcaster(fieldId, f.evaluatedBlacklist, f.lastSeq)
+        end
+    end
+
     return (f.evaluatedBlacklist ~= BL.NONE), f.evaluatedBlacklist
+end
+
+--- Client-side FIFO apply of a server mask broadcast (FR5). Drops stale or duplicate
+--- packets so out-of-order delivery can never corrupt field state.
+---@param fieldId number
+---@param reason number  FieldSentry_Core.BLACKLIST enum from the server
+---@param seq number     server's monotonic per-field sequence token
+---@return boolean applied
+function FieldSentry_API.applyMaskSync(fieldId, reason, seq)
+    seq = seq or 0
+    local f = getOrCreate(fieldId)
+    if seq <= (f.lastSeq or 0) then
+        return false  -- stale or duplicate
+    end
+    f.lastSeq            = seq
+    f.evaluatedBlacklist = reason
+    return true
 end
 
 -- =========================================================

--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -1,0 +1,163 @@
+-- =========================================================
+-- FS25 Realistic Soil & Fertilizer - FieldSentry (backend gate)
+-- =========================================================
+-- A lightweight backend that answers one binary question per field:
+-- "should this area run soil simulation right now?" It never touches the
+-- soil equations; the sim just consults it and skips disabled fields.
+--
+-- Proposal: @arissani (issue #651). This is the Phase 1 cut:
+--   - encapsulated registry (FieldSentry_Core) + status/reason API (FieldSentry_API)
+--   - manual blacklist (player chooses to "sleep" a field; its soil values freeze)
+-- Meadow profile, deco/fake-field detection and NPC-contract masking are later
+-- phases and only need new BLACKLIST reasons + classification rules layered on top.
+--
+-- Design constraints honoured here:
+--   - Backend only: no UI, no changes to soil equations.
+--   - Namespace safety: everything hangs off FieldSentry_Core / FieldSentry_API.
+--   - No hot-path allocations: isFieldSimDisabled returns a shared EMPTY_HINTS table
+--     and never builds garbage.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+---@class FieldSentry_Core
+FieldSentry_Core = {}
+
+-- Blacklist reason enum. Phase 1 uses NONE and MANUAL; the rest are reserved so the
+-- API shape is stable as later phases add structural/classification rules.
+FieldSentry_Core.BLACKLIST = {
+    NONE      = 0,
+    MANUAL    = 1,  -- player-set persistent intent (Phase 1)
+    FARMLAND  = 2,  -- reserved: whole-farmland manual block
+    OWNERSHIP = 3,  -- reserved: unowned land (already sleeps via active-set today)
+    NPC       = 4,  -- reserved: field under an AI/NPC contract
+    DECO      = 5,  -- reserved: decorative / fake field
+    INACTIVE  = 6,  -- reserved: long-idle sleep
+}
+
+local BL = FieldSentry_Core.BLACKLIST
+
+local REASON_NAMES = {
+    [BL.NONE]      = "active",
+    [BL.MANUAL]    = "manual",
+    [BL.FARMLAND]  = "farmland block",
+    [BL.OWNERSHIP] = "unowned",
+    [BL.NPC]       = "npc contract",
+    [BL.DECO]      = "decorative",
+    [BL.INACTIVE]  = "inactive",
+}
+
+--- Human-readable name for a reason enum (map tab / console).
+---@param reason number
+---@return string
+function FieldSentry_Core.reasonName(reason)
+    return REASON_NAMES[reason] or "unknown"
+end
+
+-- Per-field state, created lazily on first toggle.
+--   manualBlacklist    : boolean  persistent player intent
+--   meadowToggle       : boolean  persistent player intent (Phase 1 stores it; the
+--                                  meadow sim profile is a later phase, in S&F)
+--   evaluatedBlacklist : enum     dynamic status mask (recomputed from intents)
+--   lastSeq            : integer  reserved for the MP sequence token (later phase)
+---@class FieldSentry_FieldState
+FieldSentry_Core.FieldState = {}
+
+-- Shared immutable table so the hot path never allocates (Phase 1 has no live hints).
+local EMPTY_HINTS = {}
+
+local function getOrCreate(fieldId)
+    local f = FieldSentry_Core.FieldState[fieldId]
+    if not f then
+        f = {
+            manualBlacklist    = false,
+            meadowToggle       = false,
+            evaluatedBlacklist = BL.NONE,
+            lastSeq            = 0,
+        }
+        FieldSentry_Core.FieldState[fieldId] = f
+    end
+    return f
+end
+
+-- Recompute the dynamic mask from persistent intents. Structural rules run first and
+-- short-circuit; Phase 1 has exactly one (manual blacklist). Later phases insert
+-- farmland/ownership/NPC/deco checks here in priority order.
+local function evaluate(f)
+    if f.manualBlacklist then
+        f.evaluatedBlacklist = BL.MANUAL
+    else
+        f.evaluatedBlacklist = BL.NONE
+    end
+    return f.evaluatedBlacklist
+end
+FieldSentry_Core.evaluate = evaluate
+
+-- =========================================================
+-- Public API
+-- =========================================================
+---@class FieldSentry_API
+FieldSentry_API = {}
+
+--- Hot path (O(1)): is this field's simulation currently disabled?
+---@param fieldId number
+---@return boolean disabled
+---@return number reason   FieldSentry_Core.BLACKLIST enum
+---@return boolean meadow  meadow toggle (the sim consumes this in a later phase)
+---@return table hints     diagnostic hints (shared empty table in Phase 1)
+function FieldSentry_API.isFieldSimDisabled(fieldId)
+    local f = FieldSentry_Core.FieldState[fieldId]
+    if not f then
+        return false, BL.NONE, false, EMPTY_HINTS
+    end
+    return (f.evaluatedBlacklist ~= BL.NONE), f.evaluatedBlacklist, f.meadowToggle, (f.hints or EMPTY_HINTS)
+end
+
+--- Data consumer for the map tab / FarmTablet.
+---@param fieldId number
+---@return table status
+function FieldSentry_API.getUIStatus(fieldId)
+    local disabled, reason, meadow, hints = FieldSentry_API.isFieldSimDisabled(fieldId)
+    return {
+        isSimulationDisabled = disabled,
+        reason               = reason,
+        reasonName           = FieldSentry_Core.reasonName(reason),
+        isMeadow             = meadow,
+        diagnosticHints      = hints,
+    }
+end
+
+--- Set the manual blacklist for a field.
+---@param fieldId number
+---@param enabled boolean
+---@return boolean newValue
+function FieldSentry_API.setFieldManual(fieldId, enabled)
+    local f = getOrCreate(fieldId)
+    f.manualBlacklist = enabled and true or false
+    evaluate(f)
+    return f.manualBlacklist
+end
+
+--- Toggle the manual blacklist for a field. Returns the new value.
+---@param fieldId number
+---@return boolean newValue
+function FieldSentry_API.toggleFieldManual(fieldId)
+    local f = getOrCreate(fieldId)
+    return FieldSentry_API.setFieldManual(fieldId, not f.manualBlacklist)
+end
+
+--- Sorted list of field ids the player has manually blacklisted (console / persistence).
+---@return number[]
+function FieldSentry_API.getManualBlacklist()
+    local out = {}
+    for id, f in pairs(FieldSentry_Core.FieldState) do
+        if f.manualBlacklist then out[#out + 1] = id end
+    end
+    table.sort(out)
+    return out
+end
+
+--- Drop all state (map swap / new game). Persistence layer calls this before restoring.
+function FieldSentry_API.reset()
+    FieldSentry_Core.FieldState = {}
+end

--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -376,6 +376,89 @@ function FieldSentry_API.refreshContract(fieldId)
 end
 
 -- =========================================================
+-- Retroactive nutrient reconciliation (FR3)
+-- =========================================================
+-- When a contract harvests a field that FieldSentry had masked, the field would otherwise
+-- sit frozen forever. On contract completion a provider calls applyRetroactiveHarvest with
+-- the delivered yield, and FieldSentry estimates the nutrient catch-up from fixed crop
+-- coefficients (NOT the full S&F sim) and applies it in one cheap step.
+--
+-- Static, deterministic drain in nutrient points per 1000 L of delivered yield. Coarse on
+-- purpose; the exact balance is tuned during NPCFavor integration. Unknown crops -> DEFAULT.
+FieldSentry_Core.RETRO_DRAIN_PER_1000L = {
+    DEFAULT   = { N = 2.0, P = 1.0, K = 1.5 },
+    wheat     = { N = 2.0, P = 1.0, K = 1.5 },
+    barley    = { N = 1.8, P = 0.9, K = 1.4 },
+    oat       = { N = 1.8, P = 0.9, K = 1.4 },
+    canola    = { N = 3.0, P = 1.2, K = 2.0 },
+    maize     = { N = 2.6, P = 1.1, K = 2.2 },
+    potato    = { N = 2.8, P = 1.4, K = 3.5 },
+    sugarbeet = { N = 2.4, P = 1.2, K = 3.8 },
+    sunflower = { N = 2.6, P = 1.1, K = 2.2 },
+    soybean   = { N = 1.2, P = 1.0, K = 1.6 },  -- legume: partial fixation, lighter N
+}
+
+--- The live soil system, if the mission is up. nil before the mission loads.
+local function getSoilSystem()
+    local mgr = g_SoilFertilityManager
+    return mgr and mgr.soilSystem or nil
+end
+
+--- Reconcile a masked field after a contract harvested it. Idempotent per contractSeq:
+--- a given (or older) contract sequence is never applied twice. If the soil sim is not
+--- ready yet (e.g. called during load before fieldData exists), the catch-up is queued on
+--- f.pendingRetro and a pendingRetroRemoval hint is set for the next flush.
+---@param fieldId number
+---@param deliveredLiters number  yield delivered by the contract
+---@param fruitType string|nil    crop name (lower/any case); nil -> DEFAULT coefficients
+---@param contractSeq number       monotonic per-field contract id (idempotency token)
+---@return boolean applied
+---@return string status   "applied" | "queued" | "duplicate"
+function FieldSentry_API.applyRetroactiveHarvest(fieldId, deliveredLiters, fruitType, contractSeq)
+    contractSeq = tonumber(contractSeq) or 0
+    local f = getOrCreate(fieldId)
+
+    -- Idempotency (FR3): never replay the same or an older contract's catch-up.
+    if contractSeq <= (f.lastContractSeq or 0) then
+        return false, "duplicate"
+    end
+
+    local liters = math.max(0, tonumber(deliveredLiters) or 0)
+    local key    = fruitType and string.lower(fruitType) or nil
+    local coeff  = (key and FieldSentry_Core.RETRO_DRAIN_PER_1000L[key])
+                   or FieldSentry_Core.RETRO_DRAIN_PER_1000L.DEFAULT
+    local scale  = liters / 1000
+    local dN, dP, dK = coeff.N * scale, coeff.P * scale, coeff.K * scale
+
+    local soil = getSoilSystem()
+    if soil and soil.applyRetroactiveDrain and soil.fieldData and soil.fieldData[fieldId] then
+        soil:applyRetroactiveDrain(fieldId, dN, dP, dK)
+        f.lastContractSeq = contractSeq
+        f.pendingRetro = nil
+        if f.hints then f.hints.pendingRetroRemoval = nil end
+        return true, "applied"
+    end
+
+    -- Sim not ready: queue and flag for the next flush (on load / next tick).
+    f.pendingRetro = { seq = contractSeq, liters = liters, fruitType = fruitType }
+    f.hints = f.hints or {}
+    f.hints.pendingRetroRemoval = true
+    return false, "queued"
+end
+
+--- Apply every queued retroactive catch-up now that the sim is available. Called on load
+--- (FR4 consistency) and safe to call again from the daily seam; idempotency guards it.
+function FieldSentry_API.flushPendingRetro()
+    if not getSoilSystem() then return end
+    for id, f in pairs(FieldSentry_Core.FieldState) do
+        local p = f.pendingRetro
+        if p then
+            FieldSentry_API.applyRetroactiveHarvest(id, p.liters, p.fruitType, p.seq)
+        end
+    end
+end
+
+-- =========================================================
 -- Persistence + schema versioning (FR4)
 -- =========================================================
 -- Saved: the player's persistent intent (manual blacklist) and the FR3 reconciliation

--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -97,21 +97,58 @@ local function getOrCreate(fieldId)
             meadowToggle       = false,
             evaluatedBlacklist = BL.NONE,
             lastSeq            = 0,
+            -- Phase 2 (#654): contract masking + retroactive reconciliation
+            contractActive     = false,
+            contractInfo       = nil,   -- transient { active, favorTier, allowSAndF, source }
+            lastContractSeq    = 0,     -- FR3 idempotency token (last reconciled contract)
+            pendingRetro       = nil,   -- FR3 catch-up queued when the sim API is unavailable
+            hints              = nil,   -- transient UI diagnostics, allocated on demand
         }
         FieldSentry_Core.FieldState[fieldId] = f
     end
     return f
 end
 
--- Recompute the dynamic mask from persistent intents. Structural rules run first and
--- short-circuit; Phase 1 has exactly one (manual blacklist). Later phases insert
--- farmland/ownership/NPC/deco checks here in priority order.
+-- Recompute the dynamic mask from cached intents + cached contract status. Pure and
+-- cheap: it never calls providers (refreshContract does that out of band and stores the
+-- result on f). Rule order: structural (manual) → contract exemption → contract mask,
+-- exactly as FR2 requires (exemption after structural, before classification).
 local function evaluate(f)
+    -- Structural constraint: an explicit manual blacklist wins outright.
     if f.manualBlacklist then
         f.evaluatedBlacklist = BL.MANUAL
-    else
-        f.evaluatedBlacklist = BL.NONE
+        return f.evaluatedBlacklist
     end
+
+    -- Contract masking + favor-tier exemption (FR2). A trusted high-favor provider can
+    -- ask (allowSAndF) to keep S&F running on its contract field instead of masking it.
+    if f.contractActive then
+        local info   = f.contractInfo
+        local exempt = info and info.allowSAndF
+                       and (info.favorTier or 0) >= FieldSentry_Core.FAVOR_TIER_THRESHOLD
+        if exempt then
+            -- Let the sim run; record a transient hint only. Never auto-flip a persistent
+            -- player setting (FR2 state-integrity constraint).
+            f.hints = f.hints or {}
+            f.hints.contractExempt = true
+            f.hints.favorTier      = info.favorTier
+            f.evaluatedBlacklist   = BL.NONE
+        else
+            if f.hints then
+                f.hints.contractExempt = nil
+                f.hints.favorTier      = nil
+            end
+            f.evaluatedBlacklist = BL.NPC
+        end
+        return f.evaluatedBlacklist
+    end
+
+    -- No constraint left.
+    if f.hints then
+        f.hints.contractExempt = nil
+        f.hints.favorTier      = nil
+    end
+    f.evaluatedBlacklist = BL.NONE
     return f.evaluatedBlacklist
 end
 FieldSentry_Core.evaluate = evaluate
@@ -307,6 +344,35 @@ function FieldSentry_API.isFieldUnderAnyContract(fieldId)
     end
 
     return false, { active = false, favorTier = 0, allowSAndF = false, source = "none" }
+end
+
+--- Re-evaluate a field's contract status against the live providers and refresh its cached
+--- mask. Server-authoritative; on a client it just reports the synced cache. Designed to
+--- be called from the soil sim's daily field pass (the existing DAILY_BATCH_SIZE loop), so
+--- the work is amortized over that loop rather than a parallel scheduler (#654 maintainer
+--- note). Keeps state lean by not allocating for an ordinary field that has no contract,
+--- no manual flag and no existing state.
+---@param fieldId number
+---@return boolean disabled
+---@return number reason
+function FieldSentry_API.refreshContract(fieldId)
+    local f = FieldSentry_Core.FieldState[fieldId]
+
+    if not isSimAuthority() then
+        if not f then return false, BL.NONE end
+        return (f.evaluatedBlacklist ~= BL.NONE), f.evaluatedBlacklist
+    end
+
+    local underContract, info = FieldSentry_API.isFieldUnderAnyContract(fieldId)
+    if not underContract and not f then
+        return false, BL.NONE
+    end
+
+    f = getOrCreate(fieldId)
+    f.contractActive = underContract
+    f.contractInfo   = underContract and info or nil
+    evaluate(f)
+    return (f.evaluatedBlacklist ~= BL.NONE), f.evaluatedBlacklist
 end
 
 -- =========================================================

--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -146,6 +146,14 @@ function FieldSentry_API.toggleFieldManual(fieldId)
     return FieldSentry_API.setFieldManual(fieldId, not f.manualBlacklist)
 end
 
+--- Is this field currently manually blacklisted? (read-only, no state created)
+---@param fieldId number
+---@return boolean
+function FieldSentry_API.isFieldManual(fieldId)
+    local f = FieldSentry_Core.FieldState[fieldId]
+    return (f ~= nil) and f.manualBlacklist == true
+end
+
 --- Sorted list of field ids the player has manually blacklisted (console / persistence).
 ---@return number[]
 function FieldSentry_API.getManualBlacklist()

--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -376,35 +376,93 @@ function FieldSentry_API.refreshContract(fieldId)
 end
 
 -- =========================================================
--- Persistence (Phase 1: manual blacklist only)
+-- Persistence + schema versioning (FR4)
 -- =========================================================
--- Only the player's persistent intent is saved; the dynamic mask is recomputed on
--- load. SoilFertilityManager folds these into soilData.xml, which is already
--- savegame/map-scoped, so a map swap drops stale config naturally. Uses only
--- setXMLInt/getXMLInt (the XML API this codebase already relies on) — a stored
--- entry implies manualBlacklist=true, so no boolean attribute is needed.
+-- Saved: the player's persistent intent (manual blacklist) and the FR3 reconciliation
+-- tokens (lastContractSeq, any pendingRetro). NOT saved: the live contract mask, which is
+-- recomputed from providers on the next refresh. SoilFertilityManager folds this into
+-- soilData.xml, which is already savegame/map-scoped, so a map swap drops stale config
+-- naturally (that is the proposal's map-signature requirement, satisfied by scoping).
+--
+-- Schema: v1 = Phase 1 (no #version attr; every stored entry implied manualBlacklist).
+--         v2 = Phase 2 (#version=2; explicit #manual plus the contract tokens).
+-- Forward-compatible: all v2 attributes are optional on read, and a v1 save migrates in
+-- place via migrateLegacyEntry.
 
---- Write the manual blacklist into the given XML node.
+--- v1 -> v2 migration for a single field entry: a bare id meant "manually blacklisted".
+---@param id number
+local function migrateLegacyEntry(id)
+    FieldSentry_API.setFieldManual(id, true)
+end
+
+--- Write the manual blacklist + contract tokens into the given XML node.
 ---@param xmlFile any  XML file handle
 ---@param key string   base node, e.g. "soilData.fieldSentry"
 function FieldSentry_API.saveToXMLFile(xmlFile, key)
-    local list = FieldSentry_API.getManualBlacklist()
-    setXMLInt(xmlFile, key .. "#count", #list)
-    for i = 1, #list do
-        local entryKey = string.format("%s.field(%d)", key, i - 1)
-        setXMLInt(xmlFile, entryKey .. "#id", list[i])
+    setXMLInt(xmlFile, key .. "#version", FieldSentry_Core.SCHEMA_VERSION)
+
+    local idx = 0
+    for id, f in pairs(FieldSentry_Core.FieldState) do
+        local hasPending = f.pendingRetro ~= nil
+        -- Only persist a field that carries durable state worth restoring.
+        if f.manualBlacklist or (f.lastContractSeq or 0) > 0 or hasPending then
+            local entryKey = string.format("%s.field(%d)", key, idx)
+            setXMLInt(xmlFile, entryKey .. "#id", id)
+            setXMLInt(xmlFile, entryKey .. "#manual", f.manualBlacklist and 1 or 0)
+            setXMLInt(xmlFile, entryKey .. "#lastContractSeq", f.lastContractSeq or 0)
+            if hasPending then
+                local p = f.pendingRetro
+                setXMLInt(xmlFile, entryKey .. "#retroSeq", p.seq or 0)
+                setXMLFloat(xmlFile, entryKey .. "#retroLiters", p.liters or 0)
+                setXMLString(xmlFile, entryKey .. "#retroFruit", p.fruitType or "")
+            end
+            idx = idx + 1
+        end
     end
+    setXMLInt(xmlFile, key .. "#count", idx)
 end
 
---- Restore the manual blacklist from the given XML node (replaces current state).
+--- Restore the manual blacklist + contract tokens (replaces current state). Applies any
+--- pending retroactive catch-up immediately on load (FR4 consistency constraint) once the
+--- FR3 helper is present.
 ---@param xmlFile any
 ---@param key string
 function FieldSentry_API.loadFromXMLFile(xmlFile, key)
     FieldSentry_API.reset()
-    local count = getXMLInt(xmlFile, key .. "#count") or 0
+    local version = getXMLInt(xmlFile, key .. "#version") or 1
+    local count   = getXMLInt(xmlFile, key .. "#count") or 0
+
     for i = 0, count - 1 do
         local entryKey = string.format("%s.field(%d)", key, i)
         local id = getXMLInt(xmlFile, entryKey .. "#id")
-        if id then FieldSentry_API.setFieldManual(id, true) end
+        if id then
+            if version < 2 then
+                migrateLegacyEntry(id)
+            else
+                local manual   = (getXMLInt(xmlFile, entryKey .. "#manual") or 0) == 1
+                local lastSeq  = getXMLInt(xmlFile, entryKey .. "#lastContractSeq") or 0
+                local retroSeq = getXMLInt(xmlFile, entryKey .. "#retroSeq")
+                if manual or lastSeq > 0 or retroSeq then
+                    local f = getOrCreate(id)
+                    f.manualBlacklist = manual
+                    f.lastContractSeq = lastSeq
+                    if retroSeq then
+                        local fruit = getXMLString(xmlFile, entryKey .. "#retroFruit")
+                        if fruit == "" then fruit = nil end
+                        f.pendingRetro = {
+                            seq       = retroSeq,
+                            liters    = getXMLFloat(xmlFile, entryKey .. "#retroLiters") or 0,
+                            fruitType = fruit,
+                        }
+                    end
+                    evaluate(f)
+                end
+            end
+        end
+    end
+
+    -- Pending catch-up is applied as soon as the sim API is available (FR3 owns the flush).
+    if FieldSentry_API.flushPendingRetro then
+        FieldSentry_API.flushPendingRetro()
     end
 end

--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -161,3 +161,37 @@ end
 function FieldSentry_API.reset()
     FieldSentry_Core.FieldState = {}
 end
+
+-- =========================================================
+-- Persistence (Phase 1: manual blacklist only)
+-- =========================================================
+-- Only the player's persistent intent is saved; the dynamic mask is recomputed on
+-- load. SoilFertilityManager folds these into soilData.xml, which is already
+-- savegame/map-scoped, so a map swap drops stale config naturally. Uses only
+-- setXMLInt/getXMLInt (the XML API this codebase already relies on) — a stored
+-- entry implies manualBlacklist=true, so no boolean attribute is needed.
+
+--- Write the manual blacklist into the given XML node.
+---@param xmlFile any  XML file handle
+---@param key string   base node, e.g. "soilData.fieldSentry"
+function FieldSentry_API.saveToXMLFile(xmlFile, key)
+    local list = FieldSentry_API.getManualBlacklist()
+    setXMLInt(xmlFile, key .. "#count", #list)
+    for i = 1, #list do
+        local entryKey = string.format("%s.field(%d)", key, i - 1)
+        setXMLInt(xmlFile, entryKey .. "#id", list[i])
+    end
+end
+
+--- Restore the manual blacklist from the given XML node (replaces current state).
+---@param xmlFile any
+---@param key string
+function FieldSentry_API.loadFromXMLFile(xmlFile, key)
+    FieldSentry_API.reset()
+    local count = getXMLInt(xmlFile, key .. "#count") or 0
+    for i = 0, count - 1 do
+        local entryKey = string.format("%s.field(%d)", key, i)
+        local id = getXMLInt(xmlFile, entryKey .. "#id")
+        if id then FieldSentry_API.setFieldManual(id, true) end
+    end
+end

--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -54,6 +54,29 @@ function FieldSentry_Core.reasonName(reason)
     return REASON_NAMES[reason] or "unknown"
 end
 
+-- Self-contained logger so FieldSentry never hard-depends on Logger load order and the
+-- offline test harness (no SoilLogger) stays clean. No-ops if SoilLogger is absent.
+local function fsLog(level, fmt, ...)
+    if SoilLogger and SoilLogger[level] then SoilLogger[level](fmt, ...) end
+end
+
+-- =========================================================
+-- Phase 2 — contract provider registry (#654)
+-- =========================================================
+-- External mods (e.g. NPCFavor) register a callback reporting whether a field is under
+-- one of their contracts. The soil sim stays fully decoupled: it never references
+-- NPCFavor, it only asks "is this field under any contract right now?". Registration is
+-- a plain table write; the rules that consume it run server-side only (see isSimAuthority).
+FieldSentry_Core.contractProviders = {}
+
+-- FR2: at or above this favor tier, a provider can request that S&F keep running on its
+-- contract field (allowSAndF) instead of masking it. Tunable single source of truth.
+FieldSentry_Core.FAVOR_TIER_THRESHOLD = 4
+
+-- Persisted state schema version (FR4). Bump when the fieldsentry save shape changes so
+-- migrateLegacy can upgrade older saves in place.
+FieldSentry_Core.SCHEMA_VERSION = 2
+
 -- Per-field state, created lazily on first toggle.
 --   manualBlacklist    : boolean  persistent player intent
 --   meadowToggle       : boolean  persistent player intent (Phase 1 stores it; the
@@ -168,6 +191,122 @@ end
 --- Drop all state (map swap / new game). Persistence layer calls this before restoring.
 function FieldSentry_API.reset()
     FieldSentry_Core.FieldState = {}
+end
+
+-- =========================================================
+-- Contract providers (FR1 / FR5) — server-authoritative
+-- =========================================================
+
+-- One-shot error de-dupe so a crashing provider cannot spam the log every refresh.
+local providerErrorLogged = {}
+
+-- Fail-closed default: when a provider errors or returns garbage we treat the field as
+-- contract-active and not S&F-exempt, so a broken provider can never silently un-mask an
+-- NPC field. allowSAndF=false keeps it masked.
+local FAILSAFE_CONTRACT = { active = true, favorTier = 0, allowSAndF = false }
+
+--- Are we the simulation authority (server / host / single player)? Providers are only
+--- consulted here; pure clients mirror the resulting mask through the existing sync path,
+--- so contract masking can never be driven client-side (FR5 authority gate).
+---@return boolean
+local function isSimAuthority()
+    return g_server ~= nil
+end
+FieldSentry_Core.isSimAuthority = isSimAuthority
+
+--- Register an external contract provider. Decoupled by design: FieldSentry has no
+--- compile-time knowledge of the caller. The callback takes a fieldId and must return a
+--- normalized table { active=boolean, favorTier=number, allowSAndF=boolean }.
+--- Server/host only — a pure client never evaluates providers (FR1/FR5).
+---@param name string     unique provider id, e.g. "NPCFavor"
+---@param fn function      function(fieldId) -> { active, favorTier, allowSAndF }
+---@return boolean registered
+function FieldSentry_API.registerContractProvider(name, fn)
+    if type(name) ~= "string" or name == "" or type(fn) ~= "function" then
+        fsLog("warning", "FieldSentry: registerContractProvider needs (name:string, fn:function)")
+        return false
+    end
+    -- Pure client: reject so masking stays server-authoritative.
+    if g_client ~= nil and g_server == nil then
+        fsLog("info", "FieldSentry: ignoring provider '%s' registration on a client", name)
+        return false
+    end
+    FieldSentry_Core.contractProviders[name] = fn
+    providerErrorLogged[name] = nil
+    fsLog("info", "FieldSentry: contract provider '%s' registered", name)
+    return true
+end
+
+--- Remove a previously registered provider (mod unload / teardown).
+---@param name string
+function FieldSentry_API.unregisterContractProvider(name)
+    FieldSentry_Core.contractProviders[name] = nil
+    providerErrorLogged[name] = nil
+end
+
+--- Validate + normalize a provider return into a safe table. Never returns nil.
+--- Handles the malformed-return edge case (FR6): nil, non-table, or missing .active all
+--- fail closed.
+---@param name string
+---@param ok boolean    pcall success flag
+---@param res any       pcall result
+---@return table        { active, favorTier, allowSAndF }
+local function normalizeProviderResult(name, ok, res)
+    if not ok then
+        if not providerErrorLogged[name] then
+            providerErrorLogged[name] = true
+            fsLog("error", "FieldSentry: provider '%s' errored, failing closed (field stays masked): %s",
+                name, tostring(res))
+        end
+        return FAILSAFE_CONTRACT
+    end
+    if type(res) ~= "table" or type(res.active) ~= "boolean" then
+        if not providerErrorLogged[name] then
+            providerErrorLogged[name] = true
+            fsLog("error", "FieldSentry: provider '%s' returned a malformed result, failing closed", name)
+        end
+        return FAILSAFE_CONTRACT
+    end
+    return {
+        active     = res.active,
+        favorTier  = tonumber(res.favorTier) or 0,
+        allowSAndF = res.allowSAndF == true,
+    }
+end
+
+--- Unified O(1)-per-provider contract gate. Checks vanilla base-game field missions
+--- first, then each registered provider; the first active source wins and its metadata
+--- is returned so the rule engine (FR2) can read favorTier / allowSAndF.
+--- Pure clients short-circuit to "not under contract" — they receive the mask via sync.
+---@param fieldId number
+---@return boolean underContract
+---@return table info   { active, favorTier, allowSAndF, source }
+function FieldSentry_API.isFieldUnderAnyContract(fieldId)
+    if not isSimAuthority() then
+        return false, { active = false, favorTier = 0, allowSAndF = false, source = "client" }
+    end
+
+    -- Vanilla field missions (plow/sow/harvest contracts) run per farmland; fieldId is the
+    -- farmland id in this codebase. getIsMissionRunningOnFarmland is the SDK-confirmed API.
+    if g_missionManager and g_farmlandManager and g_missionManager.getIsMissionRunningOnFarmland then
+        local farmland = g_farmlandManager:getFarmlandById(fieldId)
+        if farmland and g_missionManager:getIsMissionRunningOnFarmland(farmland) then
+            return true, { active = true, favorTier = 0, allowSAndF = false, source = "vanilla" }
+        end
+    end
+
+    -- Registered external providers (NPCFavor, …). First active contract wins.
+    for name, fn in pairs(FieldSentry_Core.contractProviders) do
+        local ok, res = pcall(fn, fieldId)
+        local info = normalizeProviderResult(name, ok, res)
+        if info.active then
+            return true, {
+                active = true, favorTier = info.favorTier, allowSAndF = info.allowSAndF, source = name,
+            }
+        end
+    end
+
+    return false, { active = false, favorTier = 0, allowSAndF = false, source = "none" }
 end
 
 -- =========================================================

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -964,6 +964,8 @@ function SoilFertilityManager:saveSoilData()
 
     if xmlFile then
         self.soilSystem:saveToXMLFile(xmlFile, "soilData")
+        -- FieldSentry (#651): persist the player's manual blacklist alongside soil data.
+        if FieldSentry_API then FieldSentry_API.saveToXMLFile(xmlFile, "soilData.fieldSentry") end
         setXMLString(xmlFile, "soilData#lastSeenVersion", self.lastSeenVersion or "")
         saveXMLFile(xmlFile)
         delete(xmlFile)
@@ -997,6 +999,8 @@ function SoilFertilityManager:loadSoilData()
         local xmlFile = loadXMLFile("soilData", xmlPath)
         if xmlFile then
             self.soilSystem:loadFromXMLFile(xmlFile, "soilData")
+            -- FieldSentry (#651): restore the manual blacklist (no-op if none saved).
+            if FieldSentry_API then FieldSentry_API.loadFromXMLFile(xmlFile, "soilData.fieldSentry") end
             self.lastSeenVersion = getXMLString(xmlFile, "soilData#lastSeenVersion") or ""
             delete(xmlFile)
             local fieldCount = 0

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -4267,6 +4267,37 @@ function SoilFertilitySystem:onSubsoilerPass(farmlandId, worldX, worldZ)
         farmlandId, cellKey, prev, newVal, field.compaction)
 end
 
+--- FieldSentry FR3 (#654): apply a one-shot, lightweight nutrient catch-up to a field's
+--- average N/P/K. Used to reconcile a contract that harvested the field while FieldSentry
+--- had it masked, so it does not sit frozen in stasis. Deliberately cheap — it only
+--- touches the field-average scalars (no zone writes, no extraction model, no per-cell
+--- work), so it never kicks off the heavy daily sim. FieldSentry computes the amounts
+--- from its own static crop coefficients; this just applies and (in MP) broadcasts them.
+---@param fieldId number
+---@param dN number  nitrogen points to remove
+---@param dP number  phosphorus points to remove
+---@param dK number  potassium points to remove
+---@return boolean applied
+function SoilFertilitySystem:applyRetroactiveDrain(fieldId, dN, dP, dK)
+    local field = self.fieldData and self.fieldData[fieldId]
+    if not field then return false end
+
+    local limits = SoilConstants.NUTRIENT_LIMITS
+    local minV = (limits and limits.MIN) or 0
+    field.nitrogen   = math.max(minV, (field.nitrogen   or 0) - (dN or 0))
+    field.phosphorus = math.max(minV, (field.phosphorus or 0) - (dP or 0))
+    field.potassium  = math.max(minV, (field.potassium  or 0) - (dK or 0))
+
+    -- Mirror the harvest/fertilize sync path so clients see the reconciled values.
+    if g_server and g_currentMission and g_currentMission.missionDynamicInfo
+       and g_currentMission.missionDynamicInfo.isMultiplayer and SoilFieldUpdateEvent then
+        g_server:broadcastEvent(SoilFieldUpdateEvent.new(fieldId, field))
+    end
+
+    SoilLogger.debug("FieldSentry retro drain: field=%d  -N %.1f -P %.1f -K %.1f", fieldId, dN or 0, dP or 0, dK or 0)
+    return true
+end
+
 --- Records one combine-pass cell for the harvest trail overlay.
 --- Deduplicates by 10×10 m cell. Resets on a new game day (new harvest session).
 --- Auto-clears when estimated full-field coverage is reached.

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2122,7 +2122,15 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     -- — or that a later phase disables (deco/NPC/farmland) — skips the daily
     -- depletion/recovery/leaching/seasonal pass entirely, so its soil values freeze
     -- at whatever they were. Single O(1) check; no equation code below is touched.
-    if FieldSentry_API and FieldSentry_API.isFieldSimDisabled(fieldId) then return end
+    if FieldSentry_API then
+        -- Phase 2 (#654): re-evaluate contract status on this same daily-batch seam so
+        -- masking tracks active vanilla/NPC contracts without a parallel scheduler. Then
+        -- gate. refreshContract is server-authoritative and a no-op on older builds.
+        if FieldSentry_API.refreshContract then
+            FieldSentry_API.refreshContract(fieldId)
+        end
+        if FieldSentry_API.isFieldSimDisabled(fieldId) then return end
+    end
 
     local limits   = SoilConstants.NUTRIENT_LIMITS
     local recovery = SoilConstants.FALLOW_RECOVERY

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2118,6 +2118,12 @@ end
 ---@param fieldId number
 ---@param field table  fieldData entry (pre-validated non-nil by caller)
 function SoilFertilitySystem:_processOneDailyField(fieldId, field)
+    -- FieldSentry gate (#651): a field the player has put to sleep (manual blacklist)
+    -- — or that a later phase disables (deco/NPC/farmland) — skips the daily
+    -- depletion/recovery/leaching/seasonal pass entirely, so its soil values freeze
+    -- at whatever they were. Single O(1) check; no equation code below is touched.
+    if FieldSentry_API and FieldSentry_API.isFieldSimDisabled(fieldId) then return end
+
     local limits   = SoilConstants.NUTRIENT_LIMITS
     local recovery = SoilConstants.FALLOW_RECOVERY
     local seasonal = SoilConstants.SEASONAL_EFFECTS

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -3775,9 +3775,21 @@ function SoilFertilitySystem:getFieldInfo(fieldId, x, z)
         yieldEfficiency = math.floor(mod * 100 + 0.5)
     end
 
+    -- FieldSentry (#651) status, surfaced so any readout (field detail dialog, HUD,
+    -- map overlay) can show that a slept field's soil is frozen by intent, not broken.
+    -- isFieldSimDisabled is allocation-free, so this stays cheap for per-frame callers.
+    local fsDisabled, fsReason = false, "active"
+    if FieldSentry_API then
+        local d, r = FieldSentry_API.isFieldSimDisabled(fieldId)
+        fsDisabled = d
+        fsReason   = FieldSentry_Core.reasonName(r)
+    end
+
     return {
         fieldId = fieldId,
         fieldArea = field.fieldArea or 1.0,
+        simDisabled       = fsDisabled,
+        simDisabledReason = fsReason,
         nitrogen = { value = math.floor(n), status = nutrientStatus(n, "nitrogen", cropTargets) },
         phosphorus = { value = math.floor(p), status = nutrientStatus(p, "phosphorus", cropTargets) },
         potassium = { value = math.floor(k), status = nutrientStatus(k, "potassium", cropTargets) },

--- a/src/main.lua
+++ b/src/main.lua
@@ -46,6 +46,9 @@ source(modDirectory .. "src/ui/SoilLayerSystem.lua")
 source(modDirectory .. "src/maps/SoilBundledMaps.lua")
 source(modDirectory .. "src/SprayerRateManager.lua")
 source(modDirectory .. "src/SoilSensorManager.lua")
+-- FieldSentry backend gate (#651): must load before SoilFertilitySystem so its
+-- daily loop can consult FieldSentry_API. Backend only — no UI, no equation changes.
+source(modDirectory .. "src/FieldSentry.lua")
 source(modDirectory .. "src/SoilFertilitySystem.lua")
 
 -- 3. Settings

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -1322,4 +1322,74 @@ function SoilNetworkEvents_SendSprayerAutoMode(vehicle, enabled)
     end
 end
 
+-- ========================================
+-- FIELDSENTRY MANUAL-BLACKLIST TOGGLE (#651)
+-- ========================================
+-- Server-authoritative. A pure client sends a request; the server validates (admin),
+-- applies it on FieldSentry, then broadcasts so every client mirrors the state for the
+-- map-tab status readout. The server/host applies directly via the Send wrapper below.
+SoilFieldSentryEvent = {}
+SoilFieldSentryEvent_mt = Class(SoilFieldSentryEvent, Event)
+
+InitEventClass(SoilFieldSentryEvent, "SoilFieldSentryEvent")
+
+function SoilFieldSentryEvent.emptyNew()
+    return Event.new(SoilFieldSentryEvent_mt)
+end
+
+function SoilFieldSentryEvent.new(fieldId, manual)
+    local self = SoilFieldSentryEvent.emptyNew()
+    self.fieldId = fieldId
+    self.manual = manual
+    return self
+end
+
+function SoilFieldSentryEvent:readStream(streamId, connection)
+    self.fieldId = streamReadInt32(streamId)
+    self.manual = streamReadBool(streamId)
+    self:run(connection)
+end
+
+function SoilFieldSentryEvent:writeStream(streamId, connection)
+    streamWriteInt32(streamId, self.fieldId)
+    streamWriteBool(streamId, self.manual)
+end
+
+function SoilFieldSentryEvent:run(connection)
+    if g_server ~= nil then
+        -- We are the server. A request from a client connection must be admin.
+        if not connection:getIsServer() then
+            local user = g_currentMission.userManager and
+                         g_currentMission.userManager:getUserByConnection(connection)
+            if not user or not user:getIsMasterUser() then
+                SoilLogger.warning("FieldSentry: non-admin field toggle denied")
+                return
+            end
+        end
+        if FieldSentry_API then FieldSentry_API.setFieldManual(self.fieldId, self.manual) end
+        -- Relay to all clients except the original sender (they already applied / asked).
+        if g_server then
+            g_server:broadcastEvent(SoilFieldSentryEvent.new(self.fieldId, self.manual), nil, connection)
+        end
+    else
+        -- Client receiving the server's authoritative state: mirror it for the UI.
+        if FieldSentry_API then FieldSentry_API.setFieldManual(self.fieldId, self.manual) end
+    end
+end
+
+--- Set a field's manual blacklist with multiplayer sync.
+--- Pure client: asks the server. Server/host: applies and broadcasts to clients.
+---@param fieldId number
+---@param manual boolean
+function SoilNetworkEvents_SendFieldSentryToggle(fieldId, manual)
+    if g_client and not g_server then
+        g_client:getServerConnection():sendEvent(SoilFieldSentryEvent.new(fieldId, manual))
+    else
+        if FieldSentry_API then FieldSentry_API.setFieldManual(fieldId, manual) end
+        if g_server then
+            g_server:broadcastEvent(SoilFieldSentryEvent.new(fieldId, manual))
+        end
+    end
+end
+
 SoilLogger.info("Network events system loaded")

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -1392,4 +1392,57 @@ function SoilNetworkEvents_SendFieldSentryToggle(fieldId, manual)
     end
 end
 
+-- ========================================
+-- FIELDSENTRY CONTRACT-MASK STATUS SYNC (#654, FR5)
+-- ========================================
+-- Server -> clients only. The contract mask is evaluated server-side (refreshContract);
+-- this mirrors the resulting reason enum to clients for the map-tab readout. Carries a
+-- per-field sequence so clients drop stale / out-of-order packets (FieldSentry FIFO guard).
+SoilFieldSentryStatusEvent = {}
+SoilFieldSentryStatusEvent_mt = Class(SoilFieldSentryStatusEvent, Event)
+
+InitEventClass(SoilFieldSentryStatusEvent, "SoilFieldSentryStatusEvent")
+
+function SoilFieldSentryStatusEvent.emptyNew()
+    return Event.new(SoilFieldSentryStatusEvent_mt)
+end
+
+function SoilFieldSentryStatusEvent.new(fieldId, reason, seq)
+    local self = SoilFieldSentryStatusEvent.emptyNew()
+    self.fieldId = fieldId
+    self.reason  = reason
+    self.seq     = seq
+    return self
+end
+
+function SoilFieldSentryStatusEvent:readStream(streamId, connection)
+    self.fieldId = streamReadInt32(streamId)
+    self.reason  = streamReadUIntN(streamId, 3)   -- BLACKLIST enum 0..6 fits in 3 bits
+    self.seq     = streamReadInt32(streamId)
+    self:run(connection)
+end
+
+function SoilFieldSentryStatusEvent:writeStream(streamId, connection)
+    streamWriteInt32(streamId, self.fieldId)
+    streamWriteUIntN(streamId, self.reason or 0, 3)
+    streamWriteInt32(streamId, self.seq or 0)
+end
+
+function SoilFieldSentryStatusEvent:run(connection)
+    -- Clients only: apply the server's authoritative mask with the FIFO seq guard.
+    if g_server == nil and FieldSentry_API and FieldSentry_API.applyMaskSync then
+        FieldSentry_API.applyMaskSync(self.fieldId, self.reason, self.seq)
+    end
+end
+
+-- Inject the broadcaster so FieldSentry can push mask changes without referencing the
+-- network API itself. Server-only; nil-safe if FieldSentry is somehow absent.
+if FieldSentry_Core then
+    FieldSentry_Core.maskBroadcaster = function(fieldId, reason, seq)
+        if g_server then
+            g_server:broadcastEvent(SoilFieldSentryStatusEvent.new(fieldId, reason, seq))
+        end
+    end
+end
+
 SoilLogger.info("Network events system loaded")

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -48,6 +48,8 @@ function SoilSettingsGUI:registerConsoleCommands()
     addConsoleCommand("soilRecoverField", "Recover field to default values: soilRecoverField [fieldId]", "consoleCommandRecoverField", self)
     addConsoleCommand("SoilRerollFields", "Re-roll starting soil (N/P/K/pH/OM) for all fields with the new regional variation (#632)", "consoleCommandRerollFields", self)
     addConsoleCommand("SoilRerollUnownedFields", "Re-roll starting soil only for fields you don't own (keeps your own farm's soil) (#632)", "consoleCommandRerollUnownedFields", self)
+    addConsoleCommand("SoilBlacklistField", "FieldSentry: sleep/wake a field's soil sim: SoilBlacklistField <fieldId> [true|false] (#651)", "consoleCommandBlacklistField", self)
+    addConsoleCommand("SoilFieldSentry", "FieldSentry: show a field's sim status, or list all slept fields: SoilFieldSentry [fieldId] (#651)", "consoleCommandFieldSentry", self)
     addConsoleCommand("soilfertility", "Show all soil commands", "consoleCommandHelp", self)
 
     SoilLogger.info("Console commands registered")
@@ -78,8 +80,66 @@ function SoilSettingsGUI:consoleCommandHelp()
     print("soilRecoverField [fieldId] - Recover field to default values")
     print("SoilRerollFields - Re-roll starting soil for all fields (new regional variation)")
     print("SoilRerollUnownedFields - Re-roll starting soil for fields you don't own (keeps your own)")
+    print("SoilBlacklistField <fieldId> [true|false] - FieldSentry: sleep/wake a field's soil sim (#651)")
+    print("SoilFieldSentry [fieldId] - FieldSentry: show a field's sim status, or list slept fields (#651)")
     print("==============================================")
     return "Type 'soilfertility' for more info"
+end
+
+-- =========================================================
+-- FieldSentry (#651) console commands
+-- =========================================================
+
+--- SoilBlacklistField <fieldId> [true|false]
+--- Manually puts a field's soil simulation to sleep (or wakes it). A slept field
+--- keeps its current soil values frozen and is skipped by the daily sim.
+function SoilSettingsGUI:consoleCommandBlacklistField(fieldId, state)
+    if not FieldSentry_API then return "Error: FieldSentry not initialized" end
+
+    local fid = tonumber(fieldId)
+    if not fid then return "Usage: SoilBlacklistField <fieldId> [true|false]" end
+
+    -- Field data lives on the server; toggling on a client would desync until MP sync
+    -- lands (Phase 1 is server/SP only — see issue #651 rollout).
+    local isServer = g_currentMission and g_currentMission:getIsServer()
+    if not isServer then
+        return "FieldSentry toggles must be run on the server/host (it owns the field data)."
+    end
+
+    local newVal
+    if state == nil then
+        newVal = FieldSentry_API.toggleFieldManual(fid)
+    else
+        local s = tostring(state):lower()
+        newVal = FieldSentry_API.setFieldManual(fid, s == "true" or s == "1" or s == "on")
+    end
+
+    return string.format("Field %d soil sim is now %s.", fid,
+        newVal and "ASLEEP (manual blacklist) - values frozen" or "ACTIVE")
+end
+
+--- SoilFieldSentry [fieldId]
+--- With a fieldId: print that field's FieldSentry status + reason.
+--- Without one: list every manually slept field.
+function SoilSettingsGUI:consoleCommandFieldSentry(fieldId)
+    if not FieldSentry_API then return "Error: FieldSentry not initialized" end
+
+    local fid = tonumber(fieldId)
+    if fid then
+        local s = FieldSentry_API.getUIStatus(fid)
+        print(string.format(
+            "=== FieldSentry: Field %d ===\nSim disabled: %s\nReason: %s\nMeadow: %s\n============================",
+            fid,
+            s.isSimulationDisabled and "yes" or "no",
+            s.reasonName,
+            s.isMeadow and "yes" or "no"))
+        return string.format("Field %d: %s (%s)", fid,
+            s.isSimulationDisabled and "asleep" or "active", s.reasonName)
+    end
+
+    local list = FieldSentry_API.getManualBlacklist()
+    if #list == 0 then return "FieldSentry: no fields are manually slept." end
+    return "FieldSentry: slept fields -> " .. table.concat(list, ", ")
 end
 
 function SoilSettingsGUI:consoleCommandSetDifficulty(difficulty)

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -106,13 +106,16 @@ function SoilSettingsGUI:consoleCommandBlacklistField(fieldId, state)
         return "FieldSentry toggles must be run on the server/host (it owns the field data)."
     end
 
+    -- Determine the target value, then apply+broadcast through the MP-aware wrapper
+    -- so clients mirror it (the wrapper applies directly on the host).
     local newVal
     if state == nil then
-        newVal = FieldSentry_API.toggleFieldManual(fid)
+        newVal = not FieldSentry_API.isFieldManual(fid)
     else
         local s = tostring(state):lower()
-        newVal = FieldSentry_API.setFieldManual(fid, s == "true" or s == "1" or s == "on")
+        newVal = (s == "true" or s == "1" or s == "on")
     end
+    SoilNetworkEvents_SendFieldSentryToggle(fid, newVal)
 
     return string.format("Field %d soil sim is now %s.", fid,
         newVal and "ASLEEP (manual blacklist) - values frozen" or "ACTIVE")

--- a/src/ui/SoilFieldDetailDialog.lua
+++ b/src/ui/SoilFieldDetailDialog.lua
@@ -207,7 +207,15 @@ function SoilFieldDetailDialog:_populateData()
 
     -- Field ID in title
     if self.detailFieldId then
-        self.detailFieldId:setText(tr("sf_detail_field_label", "Field #") .. tostring(fieldId))
+        local label = tr("sf_detail_field_label", "Field #") .. tostring(fieldId)
+        -- FieldSentry (#651): a slept field's soil is frozen by player intent. Flag it
+        -- here so a static field doesn't read as a bug. tr() falls back to English when
+        -- the l10n key is absent, so this works before the 26-language keys are added.
+        if info.simDisabled then
+            label = label .. "  (" .. tr("sf_fieldsentry_asleep", "sim asleep") ..
+                    ": " .. tostring(info.simDisabledReason) .. ")"
+        end
+        self.detailFieldId:setText(label)
     end
 
     -- Urgency

--- a/tools/test/README.md
+++ b/tools/test/README.md
@@ -30,6 +30,16 @@ Each command exits non-zero on failure, so it's CI/pre-commit friendly.
 | **Lint** | `lint.mjs` | FS25-sandbox footguns that *parse* fine but break at runtime — `os.time` / `os.date` / `os.clock`, etc. (see CLAUDE.md "What DOESN'T Work"). |
 | **Logic** | `run-tests.mjs` (`fengari` Lua VM) | Behavioural regressions in pure logic — coverage math, fertilizer profiles, nutrient/burn formulas — by loading the real `src` modules against a mocked FS25 environment and asserting. |
 
+The FieldSentry backend ships two of these logic suites, both against pure Lua mocks:
+
+- `fieldsentry_test.lua` — Phase 1: the status/reason API, the manual blacklist, the
+  persistence round-trip, and the freeze gate inside `_processOneDailyField`.
+- `fieldsentry_phase2_test.lua` — Phase 2 (#654): the contract provider registry and
+  unified gate, fail-closed handling of malformed/crashing providers, the favor-tier
+  exemption + hinting engine, retroactive nutrient reconciliation (idempotent per
+  contract sequence), persistence with schema versioning + v1→v2 migration, and the
+  multiplayer FIFO mask sync.
+
 ## Writing a logic test
 
 Add `tools/test/lua/<name>_test.lua`. Declare which real source files to load with a

--- a/tools/test/lua/fieldsentry_phase2_test.lua
+++ b/tools/test/lua/fieldsentry_phase2_test.lua
@@ -10,6 +10,21 @@ local function asHost()  g_server = {}; g_client = nil end
 local function asClient() g_server = nil; g_client = {} end
 asHost()
 
+-- Faithful stand-in for the soil system's FR3 apply method (clamped subtraction).
+local function mockSoil()
+  return {
+    fieldData = {},
+    applyRetroactiveDrain = function(self, id, dN, dP, dK)
+      local fd = self.fieldData[id]
+      if not fd then return false end
+      fd.nitrogen   = math.max(0, (fd.nitrogen   or 0) - dN)
+      fd.phosphorus = math.max(0, (fd.phosphorus or 0) - dP)
+      fd.potassium  = math.max(0, (fd.potassium  or 0) - dK)
+      return true
+    end,
+  }
+end
+
 -- ── FR1: provider registry ─────────────────────────────────
 do
   FieldSentry_API.reset()
@@ -228,4 +243,66 @@ do
   T.eq("v1 legacy save migrates manual count", #list, 2)
   T.ok("v1 legacy fields are blacklisted",
        FieldSentry_API.isFieldManual(3) and FieldSentry_API.isFieldManual(9))
+end
+
+-- ── FR3: retroactive reconciliation ────────────────────────
+do
+  asHost()
+  FieldSentry_API.reset()
+  FieldSentry_Core.contractProviders = {}
+  local soil = mockSoil()
+  soil.fieldData[60] = { nitrogen = 50, phosphorus = 40, potassium = 45 }
+  g_SoilFertilityManager = { soilSystem = soil }
+
+  -- 2000 L wheat (N2/P1/K1.5 per 1000 L) -> remove N4 P2 K3
+  local ok, status = FieldSentry_API.applyRetroactiveHarvest(60, 2000, "wheat", 1)
+  T.ok("retro: first apply succeeds", ok == true)
+  T.eq("retro: status applied", status, "applied")
+  T.near("retro: nitrogen drained", soil.fieldData[60].nitrogen, 46)
+  T.near("retro: potassium drained", soil.fieldData[60].potassium, 42)
+  T.eq("retro: lastContractSeq advanced", FieldSentry_Core.FieldState[60].lastContractSeq, 1)
+
+  local ok2, status2 = FieldSentry_API.applyRetroactiveHarvest(60, 2000, "wheat", 1)
+  T.ok("retro: replaying the same seq is rejected", ok2 == false)
+  T.eq("retro: replay status duplicate", status2, "duplicate")
+  T.near("retro: nitrogen unchanged on replay", soil.fieldData[60].nitrogen, 46)
+
+  T.ok("retro: a newer contract seq applies again",
+       FieldSentry_API.applyRetroactiveHarvest(60, 1000, "wheat", 2) == true)
+  T.near("retro: nitrogen drained again", soil.fieldData[60].nitrogen, 44)
+  g_SoilFertilityManager = nil
+end
+
+do
+  asHost()
+  FieldSentry_API.reset()
+  local soil = mockSoil()
+  soil.fieldData[61] = { nitrogen = 50, phosphorus = 50, potassium = 50 }
+  g_SoilFertilityManager = { soilSystem = soil }
+  FieldSentry_API.applyRetroactiveHarvest(61, 1000, "moonberry", 1)  -- unknown -> DEFAULT N2
+  T.near("retro: unknown crop uses DEFAULT coefficients", soil.fieldData[61].nitrogen, 48)
+  g_SoilFertilityManager = nil
+end
+
+do
+  asHost()
+  FieldSentry_API.reset()
+  g_SoilFertilityManager = nil  -- sim not ready
+  local ok, status = FieldSentry_API.applyRetroactiveHarvest(62, 1000, "wheat", 5)
+  T.ok("retro: queues when sim unavailable", ok == false)
+  T.eq("retro: queued status", status, "queued")
+  local f = FieldSentry_Core.FieldState[62]
+  T.ok("retro: pendingRetro stored", f.pendingRetro ~= nil)
+  T.ok("retro: pendingRetroRemoval hint set", f.hints.pendingRetroRemoval == true)
+
+  local soil = mockSoil()
+  soil.fieldData[62] = { nitrogen = 30, phosphorus = 30, potassium = 30 }
+  g_SoilFertilityManager = { soilSystem = soil }
+  FieldSentry_API.flushPendingRetro()
+  T.near("retro: flush applies the queued drain", soil.fieldData[62].nitrogen, 28)
+  T.ok("retro: pendingRetro cleared after flush",
+       FieldSentry_Core.FieldState[62].pendingRetro == nil)
+  T.eq("retro: lastContractSeq set after flush",
+       FieldSentry_Core.FieldState[62].lastContractSeq, 5)
+  g_SoilFertilityManager = nil
 end

--- a/tools/test/lua/fieldsentry_phase2_test.lua
+++ b/tools/test/lua/fieldsentry_phase2_test.lua
@@ -306,3 +306,53 @@ do
        FieldSentry_Core.FieldState[62].lastContractSeq, 5)
   g_SoilFertilityManager = nil
 end
+
+-- ── FR5: MP authority + FIFO mask sync ─────────────────────
+do
+  asClient()  -- a client applying the server's authoritative broadcasts
+  FieldSentry_API.reset()
+  T.ok("mask sync: first packet applies",
+       FieldSentry_API.applyMaskSync(70, BL.NPC, 1) == true)
+  T.eq("mask sync: reason applied",
+       select(2, FieldSentry_API.isFieldSimDisabled(70)), BL.NPC)
+  T.ok("mask sync: duplicate seq dropped",
+       FieldSentry_API.applyMaskSync(70, BL.NONE, 1) == false)
+  T.ok("mask sync: out-of-order (lower seq) dropped",
+       FieldSentry_API.applyMaskSync(70, BL.NONE, 0) == false)
+  T.eq("mask sync: state survives stale packets",
+       select(2, FieldSentry_API.isFieldSimDisabled(70)), BL.NPC)
+  T.ok("mask sync: newer seq applies",
+       FieldSentry_API.applyMaskSync(70, BL.NONE, 2) == true)
+  T.ok("mask sync: field cleared by the newer packet",
+       FieldSentry_API.isFieldSimDisabled(70) == false)
+  asHost()
+end
+
+do
+  asHost()
+  FieldSentry_API.reset()
+  local sent = {}
+  FieldSentry_Core.maskBroadcaster = function(fieldId, reason, seq)
+    sent[#sent + 1] = { fieldId = fieldId, reason = reason, seq = seq }
+  end
+  local active = true
+  FieldSentry_Core.contractProviders = {}
+  FieldSentry_API.registerContractProvider("Toggle", function()
+    return { active = active, favorTier = 1, allowSAndF = false }
+  end)
+
+  FieldSentry_API.refreshContract(80)            -- NONE -> NPC
+  T.eq("broadcast fires on mask change", #sent, 1)
+  T.eq("broadcast carries the new reason", sent[1].reason, BL.NPC)
+  T.eq("broadcast seq starts at 1", sent[1].seq, 1)
+
+  FieldSentry_API.refreshContract(80)            -- NPC -> NPC (no change)
+  T.eq("no broadcast when the mask is unchanged", #sent, 1)
+
+  active = false
+  FieldSentry_API.refreshContract(80)            -- NPC -> NONE
+  T.eq("broadcast fires again on un-mask", #sent, 2)
+  T.eq("broadcast seq increments", sent[2].seq, 2)
+
+  FieldSentry_Core.maskBroadcaster = nil
+end

--- a/tools/test/lua/fieldsentry_phase2_test.lua
+++ b/tools/test/lua/fieldsentry_phase2_test.lua
@@ -107,3 +107,80 @@ do
   T.eq("client gate source", info.source, "client")
   asHost()
 end
+
+-- ── FR2: exemption + hinting engine (via refreshContract) ──
+-- Provider keyed by fieldId so one provider drives every scenario.
+local function installFavorProvider(map)
+  FieldSentry_Core.contractProviders = {}
+  FieldSentry_API.registerContractProvider("Favor", function(id)
+    local e = map[id]
+    if e then return e end
+    return { active = false }
+  end)
+end
+
+do
+  asHost()
+  FieldSentry_API.reset()
+  installFavorProvider({
+    [1] = { active = true, favorTier = 1, allowSAndF = false }, -- hostile: mask
+    [2] = { active = true, favorTier = 5, allowSAndF = true  }, -- best friend + opt-in: exempt
+    [3] = { active = true, favorTier = 5, allowSAndF = false }, -- high favor but no opt-in: mask
+    [4] = { active = true, favorTier = 2, allowSAndF = true  }, -- opt-in but low favor: mask
+  })
+
+  T.ok("low-favor contract field is masked",
+       select(1, FieldSentry_API.refreshContract(1)) == true)
+  T.eq("masked contract reason is NPC",
+       select(2, FieldSentry_API.refreshContract(1)), BL.NPC)
+
+  T.ok("high-favor opt-in contract field runs S&F (exempt)",
+       select(1, FieldSentry_API.refreshContract(2)) == false)
+  local s2 = FieldSentry_API.getUIStatus(2)
+  T.ok("exempt field surfaces contractExempt hint", s2.diagnosticHints.contractExempt == true)
+  T.eq("exempt field surfaces favorTier hint", s2.diagnosticHints.favorTier, 5)
+
+  T.ok("high favor without opt-in stays masked",
+       select(1, FieldSentry_API.refreshContract(3)) == true)
+  T.ok("opt-in below the tier threshold stays masked",
+       select(1, FieldSentry_API.refreshContract(4)) == true)
+end
+
+-- manual blacklist outranks an exemptible contract
+do
+  asHost()
+  FieldSentry_API.reset()
+  installFavorProvider({ [9] = { active = true, favorTier = 9, allowSAndF = true } })
+  FieldSentry_API.setFieldManual(9, true)
+  FieldSentry_API.refreshContract(9)
+  T.eq("manual blacklist wins over an exemptible contract",
+       select(2, FieldSentry_API.isFieldSimDisabled(9)), BL.MANUAL)
+end
+
+-- contract ending un-masks the field, and the hint clears
+do
+  asHost()
+  FieldSentry_API.reset()
+  local active = true
+  FieldSentry_Core.contractProviders = {}
+  FieldSentry_API.registerContractProvider("Toggle", function(_id)
+    return { active = active, favorTier = 1, allowSAndF = false }
+  end)
+  FieldSentry_API.refreshContract(15)
+  T.ok("field masked while contract active",
+       FieldSentry_API.isFieldSimDisabled(15) == true)
+  active = false
+  FieldSentry_API.refreshContract(15)
+  T.ok("field un-masked once the contract ends",
+       FieldSentry_API.isFieldSimDisabled(15) == false)
+end
+
+-- refreshContract stays lean: no state for an ordinary, contract-free field
+do
+  asHost()
+  FieldSentry_API.reset()
+  FieldSentry_Core.contractProviders = {}
+  FieldSentry_API.refreshContract(500)
+  T.ok("no FieldState allocated for a free field",
+       FieldSentry_Core.FieldState[500] == nil)
+end

--- a/tools/test/lua/fieldsentry_phase2_test.lua
+++ b/tools/test/lua/fieldsentry_phase2_test.lua
@@ -1,0 +1,109 @@
+-- fieldsentry_phase2_test.lua — FieldSentry Phase 2 contract integration (#654).
+-- Covers the provider registry, the unified contract gate, and fail-closed behaviour.
+-- Pure Lua mocks only; no engine beyond the prelude stubs.
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/FieldSentry.lua
+
+local BL = FieldSentry_Core.BLACKLIST
+
+-- Phase 2 rules evaluate server-side only, so the suite plays the host.
+local function asHost()  g_server = {}; g_client = nil end
+local function asClient() g_server = nil; g_client = {} end
+asHost()
+
+-- ── FR1: provider registry ─────────────────────────────────
+do
+  FieldSentry_API.reset()
+  FieldSentry_Core.contractProviders = {}
+  local ok = FieldSentry_API.registerContractProvider("Test", function(_id)
+    return { active = false, favorTier = 0, allowSAndF = false }
+  end)
+  T.ok("registerContractProvider: valid provider registers", ok == true)
+  T.ok("registerContractProvider: stored under its name",
+       type(FieldSentry_Core.contractProviders["Test"]) == "function")
+
+  FieldSentry_API.unregisterContractProvider("Test")
+  T.ok("unregisterContractProvider removes it",
+       FieldSentry_Core.contractProviders["Test"] == nil)
+end
+
+do
+  FieldSentry_Core.contractProviders = {}
+  T.ok("registerContractProvider: rejects non-function",
+       FieldSentry_API.registerContractProvider("Bad", 42) == false)
+  T.ok("registerContractProvider: rejects empty name",
+       FieldSentry_API.registerContractProvider("", function() end) == false)
+end
+
+-- ── FR1: unified contract gate (providers) ─────────────────
+do
+  FieldSentry_Core.contractProviders = {}
+  local under, info = FieldSentry_API.isFieldUnderAnyContract(10)
+  T.ok("no providers -> field not under contract", under == false)
+  T.eq("no providers -> source 'none'", info.source, "none")
+end
+
+do
+  FieldSentry_Core.contractProviders = {}
+  FieldSentry_API.registerContractProvider("NPCFavor", function(id)
+    if id == 20 then return { active = true, favorTier = 5, allowSAndF = true } end
+    return { active = false }
+  end)
+  local under, info = FieldSentry_API.isFieldUnderAnyContract(20)
+  T.ok("active provider field is under contract", under == true)
+  T.eq("provider source reported", info.source, "NPCFavor")
+  T.eq("favorTier passes through", info.favorTier, 5)
+  T.ok("allowSAndF passes through", info.allowSAndF == true)
+  T.ok("non-contract field via same provider is free",
+       FieldSentry_API.isFieldUnderAnyContract(21) == false)
+end
+
+-- ── FR1: vanilla base-game field missions ──────────────────
+do
+  FieldSentry_Core.contractProviders = {}
+  g_farmlandManager = { getFarmlandById = function(_, id) return { id = id } end }
+  g_missionManager  = {
+    getIsMissionRunningOnFarmland = function(_, farmland) return farmland.id == 77 end,
+  }
+  local under, info = FieldSentry_API.isFieldUnderAnyContract(77)
+  T.ok("vanilla mission on farmland -> under contract", under == true)
+  T.eq("vanilla source reported", info.source, "vanilla")
+  T.ok("farmland without a mission is free",
+       FieldSentry_API.isFieldUnderAnyContract(78) == false)
+  g_missionManager  = nil
+  g_farmlandManager = nil
+end
+
+-- ── FR6 edge case: malformed / crashing providers fail closed ──
+do
+  FieldSentry_Core.contractProviders = {}
+  FieldSentry_API.registerContractProvider("NilReturn", function() return nil end)
+  local under, info = FieldSentry_API.isFieldUnderAnyContract(30)
+  T.ok("provider returning nil fails closed (masked)", under == true)
+  T.ok("failed-closed field is not S&F-exempt", info.allowSAndF == false)
+end
+
+do
+  FieldSentry_Core.contractProviders = {}
+  FieldSentry_API.registerContractProvider("Crash", function() error("boom") end)
+  T.ok("crashing provider fails closed (masked)",
+       FieldSentry_API.isFieldUnderAnyContract(31) == true)
+end
+
+do
+  FieldSentry_Core.contractProviders = {}
+  FieldSentry_API.registerContractProvider("BadShape", function() return { active = "yes" } end)
+  T.ok("non-boolean .active fails closed (masked)",
+       FieldSentry_API.isFieldUnderAnyContract(32) == true)
+end
+
+-- ── FR5 authority: a pure client never evaluates providers ─
+do
+  FieldSentry_Core.contractProviders = {}
+  asClient()
+  T.ok("client registration is rejected",
+       FieldSentry_API.registerContractProvider("X", function() end) == false)
+  local under, info = FieldSentry_API.isFieldUnderAnyContract(40)
+  T.ok("client never reports a contract (mirrors via sync)", under == false)
+  T.eq("client gate source", info.source, "client")
+  asHost()
+end

--- a/tools/test/lua/fieldsentry_phase2_test.lua
+++ b/tools/test/lua/fieldsentry_phase2_test.lua
@@ -184,3 +184,48 @@ do
   T.ok("no FieldState allocated for a free field",
        FieldSentry_Core.FieldState[500] == nil)
 end
+
+-- ── FR4: persistence + schema versioning ───────────────────
+do
+  asHost()
+  FieldSentry_API.reset()
+  FieldSentry_Core.contractProviders = {}
+  FieldSentry_API.setFieldManual(4, true)
+  FieldSentry_API.setFieldManual(11, true)
+  local f11 = FieldSentry_Core.FieldState[11]
+  f11.lastContractSeq = 7
+  f11.pendingRetro = { seq = 8, liters = 1500, fruitType = "wheat" }
+
+  local xml = {}
+  FieldSentry_API.saveToXMLFile(xml, "soilData.fieldSentry")
+  T.eq("save writes schema version",
+       xml["soilData.fieldSentry#version"], FieldSentry_Core.SCHEMA_VERSION)
+
+  FieldSentry_API.reset()
+  FieldSentry_API.loadFromXMLFile(xml, "soilData.fieldSentry")
+  local list = FieldSentry_API.getManualBlacklist()
+  T.eq("v2 round-trip restores manual count", #list, 2)
+  T.ok("v2 round-trip restores ids", list[1] == 4 and list[2] == 11)
+  local r = FieldSentry_Core.FieldState[11]
+  T.eq("v2 restores lastContractSeq", r.lastContractSeq, 7)
+  T.ok("v2 restores pendingRetro", r.pendingRetro ~= nil)
+  T.eq("v2 restores pendingRetro.liters", r.pendingRetro.liters, 1500)
+  T.eq("v2 restores pendingRetro.fruitType", r.pendingRetro.fruitType, "wheat")
+end
+
+-- legacy v1 save (bare ids imply manual) migrates in place
+do
+  asHost()
+  FieldSentry_API.reset()
+  local xml = {
+    ["soilData.fieldSentry#count"]       = 2,
+    ["soilData.fieldSentry.field(0)#id"] = 3,
+    ["soilData.fieldSentry.field(1)#id"] = 9,
+    -- no #version attribute -> treated as v1
+  }
+  FieldSentry_API.loadFromXMLFile(xml, "soilData.fieldSentry")
+  local list = FieldSentry_API.getManualBlacklist()
+  T.eq("v1 legacy save migrates manual count", #list, 2)
+  T.ok("v1 legacy fields are blacklisted",
+       FieldSentry_API.isFieldManual(3) and FieldSentry_API.isFieldManual(9))
+end

--- a/tools/test/lua/fieldsentry_test.lua
+++ b/tools/test/lua/fieldsentry_test.lua
@@ -33,6 +33,13 @@ end
 
 do
   FieldSentry_API.reset()
+  T.ok("isFieldManual: false for unknown field", FieldSentry_API.isFieldManual(50) == false)
+  FieldSentry_API.setFieldManual(50, true)
+  T.ok("isFieldManual: true after blacklist", FieldSentry_API.isFieldManual(50) == true)
+end
+
+do
+  FieldSentry_API.reset()
   FieldSentry_API.setFieldManual(3, true)
   local s = FieldSentry_API.getUIStatus(3)
   T.ok("getUIStatus: isSimulationDisabled true", s.isSimulationDisabled == true)

--- a/tools/test/lua/fieldsentry_test.lua
+++ b/tools/test/lua/fieldsentry_test.lua
@@ -1,0 +1,81 @@
+-- fieldsentry_test.lua — FieldSentry Phase 1 backend gate (#651).
+-- The module itself is dependency-free; the last block also loads the soil system to
+-- prove the freeze gate in _processOneDailyField actually skips a blacklisted field.
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/FieldSentry.lua, src/SoilFertilitySystem.lua
+
+local BL = FieldSentry_Core.BLACKLIST
+
+-- ── status API ─────────────────────────────────────────────
+do
+  FieldSentry_API.reset()
+  local disabled, reason = FieldSentry_API.isFieldSimDisabled(99)
+  T.ok("unknown field is not disabled", disabled == false)
+  T.eq("unknown field reason is NONE", reason, BL.NONE)
+end
+
+do
+  FieldSentry_API.reset()
+  FieldSentry_API.setFieldManual(1, true)
+  local disabled, reason = FieldSentry_API.isFieldSimDisabled(1)
+  T.ok("setFieldManual(true) disables the field", disabled == true)
+  T.eq("manual blacklist reason is MANUAL", reason, BL.MANUAL)
+
+  FieldSentry_API.setFieldManual(1, false)
+  T.ok("setFieldManual(false) re-enables the field",
+       FieldSentry_API.isFieldSimDisabled(1) == false)
+end
+
+do
+  FieldSentry_API.reset()
+  T.ok("toggleFieldManual: first toggle sleeps", FieldSentry_API.toggleFieldManual(2) == true)
+  T.ok("toggleFieldManual: second toggle wakes", FieldSentry_API.toggleFieldManual(2) == false)
+end
+
+do
+  FieldSentry_API.reset()
+  FieldSentry_API.setFieldManual(3, true)
+  local s = FieldSentry_API.getUIStatus(3)
+  T.ok("getUIStatus: isSimulationDisabled true", s.isSimulationDisabled == true)
+  T.eq("getUIStatus: reasonName maps the enum", s.reasonName, "manual")
+  T.ok("getUIStatus: isMeadow defaults false", s.isMeadow == false)
+end
+
+do
+  FieldSentry_API.reset()
+  FieldSentry_API.setFieldManual(7, true)
+  FieldSentry_API.setFieldManual(2, true)
+  FieldSentry_API.setFieldManual(5, true)
+  local list = FieldSentry_API.getManualBlacklist()
+  T.eq("getManualBlacklist: count", #list, 3)
+  T.ok("getManualBlacklist: sorted ascending", list[1] == 2 and list[2] == 5 and list[3] == 7)
+  FieldSentry_API.reset()
+  T.eq("reset clears the registry", #FieldSentry_API.getManualBlacklist(), 0)
+end
+
+-- ── hot path allocates nothing ─────────────────────────────
+do
+  FieldSentry_API.reset()
+  local _, _, _, hints = FieldSentry_API.isFieldSimDisabled(123)
+  T.ok("hot path returns a hints table (shared empty in Phase 1)", type(hints) == "table")
+end
+
+-- ── freeze gate: blacklisted field is skipped by the daily sim ──
+do
+  FieldSentry_API.reset()
+  local sys = setmetatable({
+    fieldData         = {},
+    settings          = { enabled = true, nutrientCycles = true },
+    _dailyBatchDay    = 1,
+    _dailyBatchSeason = 1,
+  }, { __index = SoilFertilitySystem })
+
+  -- A non-blacklisted field would have nutrientBuffer reset to {} immediately;
+  -- a slept field early-returns before that, so the sentinel survives.
+  local field = { nutrientBuffer = { sentinel = true }, pH = 6.5, nitrogen = 40 }
+  sys.fieldData[1] = field
+
+  FieldSentry_API.setFieldManual(1, true)
+  sys:_processOneDailyField(1, field)
+  T.ok("freeze gate: slept field's daily pass is skipped (sentinel survives)",
+       field.nutrientBuffer.sentinel == true)
+end

--- a/tools/test/lua/fieldsentry_test.lua
+++ b/tools/test/lua/fieldsentry_test.lua
@@ -59,6 +59,26 @@ do
   T.ok("hot path returns a hints table (shared empty in Phase 1)", type(hints) == "table")
 end
 
+-- ── persistence round-trip (save → reset → load) ───────────
+do
+  FieldSentry_API.reset()
+  FieldSentry_API.setFieldManual(4, true)
+  FieldSentry_API.setFieldManual(11, true)
+
+  local xml = {}  -- in-memory XML handle (see prelude mock)
+  FieldSentry_API.saveToXMLFile(xml, "soilData.fieldSentry")
+
+  FieldSentry_API.reset()
+  T.eq("persistence: state cleared before load", #FieldSentry_API.getManualBlacklist(), 0)
+
+  FieldSentry_API.loadFromXMLFile(xml, "soilData.fieldSentry")
+  local list = FieldSentry_API.getManualBlacklist()
+  T.eq("persistence: round-trip restores count", #list, 2)
+  T.ok("persistence: round-trip restores the right ids", list[1] == 4 and list[2] == 11)
+  T.ok("persistence: restored field reports disabled",
+       FieldSentry_API.isFieldSimDisabled(11) == true)
+end
+
 -- ── freeze gate: blacklisted field is skipped by the daily sim ──
 do
   FieldSentry_API.reset()

--- a/tools/test/lua/prelude.lua
+++ b/tools/test/lua/prelude.lua
@@ -28,6 +28,13 @@ g_currentMission = {
 g_i18n = { getText = function(_self, key) return key end }
 g_messageCenter = { subscribe = function() end, unsubscribe = function() end, publish = function() end }
 
+-- Minimal in-memory XML mock: the file handle is a plain table keyed by the XML path
+-- string, enough for save/load round-trip tests. Extend if a test needs more types.
+function setXMLInt(handle, key, value) if handle then handle[key] = value end end
+function getXMLInt(handle, key) if handle then return handle[key] end end
+function setXMLString(handle, key, value) if handle then handle[key] = value end end
+function getXMLString(handle, key) if handle then return handle[key] end end
+
 -- Class tables some modules reference at load; harmless empty stubs.
 HookManager = HookManager or { new = function() return {} end }
 

--- a/tools/test/lua/prelude.lua
+++ b/tools/test/lua/prelude.lua
@@ -32,6 +32,8 @@ g_messageCenter = { subscribe = function() end, unsubscribe = function() end, pu
 -- string, enough for save/load round-trip tests. Extend if a test needs more types.
 function setXMLInt(handle, key, value) if handle then handle[key] = value end end
 function getXMLInt(handle, key) if handle then return handle[key] end end
+function setXMLFloat(handle, key, value) if handle then handle[key] = value end end
+function getXMLFloat(handle, key) if handle then return handle[key] end end
 function setXMLString(handle, key, value) if handle then handle[key] = value end end
 function getXMLString(handle, key) if handle then return handle[key] end end
 


### PR DESCRIPTION
Phase 2 of FieldSentry. This targets `development` directly. `development` does not have
the Phase 1 backend yet (that is PR #655), so this PR currently includes both: the four
Phase 1 commits and the six Phase 2 commits. If #655 lands first, only the Phase 2 commits
remain here.

It implements arissani's Phase 2 spec (FR1 to FR8) on top of Phase 1. The whole thing is
decoupled: S&F never references NPCFavor, an external mod just registers a callback.
Nothing changes behaviour until a provider registers, so it is safe to sit in the tree.

## What is in it (Phase 2)

- **FR1 provider registry.** `registerContractProvider(name, fn)` / `isFieldUnderAnyContract`.
  Vanilla field missions are checked first via `getIsMissionRunningOnFarmland`, then each
  provider. Every provider call is wrapped in pcall and fails closed: a crash, a nil, or a
  malformed return leaves the field masked, never silently un-masked.
- **FR2 exemption engine.** `evaluate()` runs manual blacklist first, then the contract
  rule. A field under contract masks to NPC by default; a provider can opt out
  (`allowSAndF`) when its `favorTier` is at or above `FAVOR_TIER_THRESHOLD` (4), keeping
  S&F running and recording a transient hint. Persistent player settings are never
  auto-flipped. `refreshContract` does the live check on the existing daily-batch seam, so
  there is no second scheduler.
- **FR3 retroactive reconciliation.** `applyRetroactiveHarvest(fieldId, liters, fruitType,
  contractSeq)` reconciles a masked field after a contract harvests it, using fixed crop
  coefficients (not the full sim) and idempotent per contract sequence. A small
  `applyRetroactiveDrain` on the soil system applies it to the field-average scalars only
  and broadcasts in MP. Falls back to a queue + flush if the sim is not up yet.
- **FR4 persistence.** Schema v2 with in-place v1 to v2 migration; still folded into
  soilData.xml, which is already savegame/map scoped.
- **FR5 MP.** Server-authoritative throughout (registration and evaluation are server
  only). The evaluated mask syncs to clients via a FIFO sequence token so stale or
  out-of-order packets are dropped. FieldSentry stays network agnostic via an injected
  broadcaster hook.
- **FR6 tests.** `tools/test/lua/fieldsentry_phase2_test.lua`, 73 assertions, including the
  malformed-provider edge case. Full suite is green.
- **FR7 docs.** `docs/integration-npcfavor.md`, a copy-pasteable provider guide.

Phase 1 detail (the backend gate, manual blacklist, map-tab readout) is described in #655.

## Not done yet (needs a human / in game)

- In-game and over-the-wire MP test (the mask sync has only been unit tested).
- The retro drain coefficients are deliberately coarse placeholders and need balancing
  against real NPCFavor harvests.
- NPCFavor itself still has to call `registerContractProvider` and
  `applyRetroactiveHarvest`. The doc shows exactly how.
- Meadow profile and deco/fake-field detection stay a later phase.

Commits are split one per FR so they can be reviewed in isolation.
