### PR TITLE
docs: one feature, one PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,13 +145,34 @@ All mods live under the **Mods Base Directory** above:
 
 ---
 
-## Git Workflow
+## Git Workflow — ONE FEATURE, ONE PR
 
-- **Work branch:** `development` - all commits and pushes go here.
-- **Stable branch:** `main` - only updated via pull requests from `development`.
-- Never commit or push directly to `main`. Always work on `development` and PR to `main`.
+> **Tyson's ruling, 2026-08-10. BINDING on every human and every agent seat, including Bob, Fred and Sasha, because those seats are the ones opening PRs.**
 
----
+- **Every feature, fix or brief gets its OWN BRANCH**, cut fresh from `development`:
+  `feat/<ID>-<slug>`, `fix/<ID>-<slug>`, or `docs/<slug>` / `chore/<slug>` for non-code work
+  (e.g. `feat/SCS-037-caught-up-hour`).
+  Commit **only that one item** on it.
+- **The PR is `feat/...` → `development`.** One item per PR, always. Delete the branch on merge.
+- **NEVER open a feature PR from `development` itself.** `development` is the trunk: a PR based on it
+  silently absorbs every commit that lands while it is open, under a title that still describes the
+  first one. **This happened twice in two days**, the second time to the seat that had just reported it.
+- **`development` → `main` is a RELEASE PR only**, titled `Release vX.Y.Z`. It may carry many features
+  *by design* and its body lists them. It is never a feature PR.
+- **Never commit or push directly to `main`.** Check your branch at the start of every session.
+- If a PR does end up carrying more than its title says: **retitle, rebody with the full commit list,
+  and refresh every approval.** An old approval never covers code it did not see.
+
+```bash
+git checkout development && git pull
+git checkout -b feat/SCS-037-caught-up-hour
+#   ...commit the ONE feature...
+git push -u origin feat/SCS-037-caught-up-hour
+gh pr create --base development
+#   -> Sasha approves -> Tyson merges -> branch deleted
+```
+
+**Sasha approves, Tyson merges.** No seat both approves and lands the same PR.
 
 ## Architecture
 


### PR DESCRIPTION
## ONE FEATURE, ONE PR

**Tyson's ruling, 2026-08-10.** Adds the canonical Git Workflow block to this repo's `CLAUDE.md` so the rule is readable from inside the repo rather than only from the global config.

**Why the rule exists, stated from the incident rather than in the abstract:** `development` is the trunk, so a PR opened from it silently absorbs every commit that lands while it is open, under a title that still describes the first one. **That happened twice in two days.** The second time it happened to the seat that had reported it the day before, on the very next PR that seat opened, which is what makes it a branch-model problem rather than an attention problem.

**The rule:** every feature, fix or brief gets its own branch cut from `development`, and the PR is that branch into `development`. One item per PR. `development` to `main` becomes a **release PR only**, which may carry many features by design.

**This PR follows the rule it introduces** (own branch, single item), which is the point.

The identical change is going to every FS25 repo, the global config, the OpenWork handoff pack and the ecosystem ledger.
