### PR TITLE
fix(soil): #803 resync counter charges per completed round trip

### DIFF
--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -1951,12 +1951,22 @@ function SoilValueMapChunkEvent:run(connection)
         vm:applySyncRow(def.key, self.gyStart + (i - 1), row)
     end
 
+    -- Track this layer as streamed this round (deduped: a layer streams many
+    -- chunks, and the round starts fresh on each send's final chunk).
+    sfValueMapSyncRoundLayers[self.layerIdx] = true
+
     if self.isLast then
+        -- #803: this layer's repair round trip has landed, so a future checksum
+        -- evaluation is a fresh comparison against the applied state, not a
+        -- re-charge of an in-flight repair.
+        sfValueMapResyncInFlight[self.layerIdx] = nil
         local syncedLayers = 0
-        for _, d in ipairs(SoilValueMaps.LAYER_DEFS) do
-            if d.serverOnly ~= true then syncedLayers = syncedLayers + 1 end
+        for layerIdx in pairs(sfValueMapSyncRoundLayers) do
+            local d = SoilValueMaps.LAYER_DEFS[layerIdx]
+            if d and d.serverOnly ~= true then syncedLayers = syncedLayers + 1 end
         end
         SoilLogger.info("Client: value map sync complete (%d layers)", syncedLayers)
+        sfValueMapSyncRoundLayers = {}
         local minimapLayer = g_SoilFertilityManager and g_SoilFertilityManager.soilMinimapLayer
         if minimapLayer then minimapLayer:markDirty() end
         local mapOverlay = g_SoilFertilityManager and g_SoilFertilityManager.soilMapOverlay
@@ -2032,6 +2042,15 @@ end
 -- Per-layer client resync attempt counts for this session. Caps the storm when
 -- a layer still cannot converge after clear+reapply (e.g. transient race).
 local sfValueMapResyncAttempts = {}
+-- Per-layer "a resync for this layer is currently in flight" flag. Set when a
+-- request is actually sent, cleared when that layer's chunk stream completes.
+-- Guards the attempt counter so it charges per COMPLETED round trip, never per
+-- checksum event received (#803).
+local sfValueMapResyncInFlight = {}
+-- Distinct layers received in the current value-map send (a send is a full sync
+-- or a single-layer resync reply). Counted so "sync complete (N layers)" reports
+-- the layers actually streamed, not every syncable layer in LAYER_DEFS (#803).
+local sfValueMapSyncRoundLayers = {}
 local SF_VALUE_MAP_RESYNC_MAX = 2
 
 function SoilValueMapChecksumEvent:run(connection)
@@ -2053,24 +2072,38 @@ function SoilValueMapChecksumEvent:run(connection)
             local sumDrift = math.abs(localSum - cs.sum)
             local tolerance = math.max(64, cs.nonZero * 0.02)   -- 2% of painted cells
             if sumDrift > tolerance then
-                local attempts = sfValueMapResyncAttempts[layerIdx] or 0
-                if attempts >= SF_VALUE_MAP_RESYNC_MAX then
-                    if attempts == SF_VALUE_MAP_RESYNC_MAX then
-                        SoilLogger.warning(
-                            "Client: value map '%s' still drifted after %d resyncs (local sum=%d server=%d) - stopping requests this session",
-                            def.key, SF_VALUE_MAP_RESYNC_MAX, localSum, cs.sum)
-                        sfValueMapResyncAttempts[layerIdx] = attempts + 1  -- only log once
-                    end
+                -- A request for this layer is already on the wire and its chunk
+                -- stream has not been applied yet. The drift we are reading is
+                -- the pre-repair state; the fresh full checksum the server sends
+                -- after finishing THIS layer's own reply is the one that judges
+                -- the round trip. Charging now would double-count against the
+                -- trailing checksums of other layers repaired in the same pass
+                -- (#803). Wait for our own stream to land.
+                if sfValueMapResyncInFlight[layerIdx] then
+                    -- still awaiting the in-flight repair; skip re-charging
                 else
-                    sfValueMapResyncAttempts[layerIdx] = attempts + 1
-                    SoilLogger.warning("Client: value map '%s' drifted (local sum=%d server=%d) - requesting resync (%d/%d)",
-                        def.key, localSum, cs.sum, attempts + 1, SF_VALUE_MAP_RESYNC_MAX)
-                    if g_client then
+                    local attempts = sfValueMapResyncAttempts[layerIdx] or 0
+                    if attempts >= SF_VALUE_MAP_RESYNC_MAX then
+                        if attempts == SF_VALUE_MAP_RESYNC_MAX then
+                            SoilLogger.warning(
+                                "Client: value map '%s' still drifted after %d resyncs (local sum=%d server=%d) - stopping requests this session",
+                                def.key, SF_VALUE_MAP_RESYNC_MAX, localSum, cs.sum)
+                            sfValueMapResyncAttempts[layerIdx] = attempts + 1  -- only log once
+                        end
+                    elseif g_client then
+                        -- Charge the attempt ONLY on the branch that actually sends a
+                        -- request, so a checksum that evaluates a layer but sends
+                        -- nothing cannot burn the cap (#803, Claude(A)'s addition).
+                        sfValueMapResyncAttempts[layerIdx] = attempts + 1
+                        sfValueMapResyncInFlight[layerIdx] = true
+                        SoilLogger.warning("Client: value map '%s' drifted (local sum=%d server=%d) - requesting resync (%d/%d)",
+                            def.key, localSum, cs.sum, attempts + 1, SF_VALUE_MAP_RESYNC_MAX)
                         g_client:getServerConnection():sendEvent(SoilRequestValueMapEvent.new(layerIdx))
                     end
                 end
             else
                 sfValueMapResyncAttempts[layerIdx] = 0
+                sfValueMapResyncInFlight[layerIdx] = nil
             end
         end
     end


### PR DESCRIPTION
## What

Fixes the dedicated-server value-map resync storm cap so the attempt counter charges per COMPLETED round trip, not per checksum event received. Also fixes the misleading `sync complete (N layers)` log count.

## Why

Issue #803 (certified by Sasha 2026-08-09, sorted FAST TRACK by Claude(A) 2026-08-09): on a dedicated server, each single-layer resync request is served synchronously and ends with a fresh FULL checksum event covering all layers. Every arriving checksum event re-evaluates all 12 layers and increments each drifted layer's counter against the cap of 2. So the acknowledgements of earlier layers' own repairs burn the budget of the layers still queued behind them � deterministic: any drift episode touching 3+ layers strands every layer after the second. Six drifted on join, exactly two recovered.

## What changed (`NetworkEvents.lua`)

- **Per-round-trip charging**: added `sfValueMapResyncInFlight[layerIdx]`, set when a request is actually sent and cleared when that layer's chunk stream completes (`isLast`). `SoilValueMapChecksumEvent:run` skips re-charging a layer whose repair is still in flight, so a layer can never be charged by the trailing full checksums of other layers repaired in the same pass.
- **Claude(A)'s addition honored**: the counter now charges ONLY on the branch that actually sends a request (inside the `g_client` guard). Previously the counter incremented before the `if g_client` send guard, so a path that sent no request still burned the cap.
- **Honest sync count**: `sync complete (N layers)` now counts the layers actually streamed this round (tracked in `sfValueMapSyncRoundLayers`) instead of printing every syncable layer regardless of how many were resent � a single-layer resend no longer announces 12.

## Verification

Full suite green: 2772 assertions passed, 0 failed across 65 files. Lua 5.1 syntax + lint clean. No `goto` (Lua 5.1 constraint).
