### PR TITLE
chore(ui): trim soil layer tab sidebar to Disable Overlay + Help

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,7 +65,10 @@
 ## 2026-08-06 (Fred): Esc RF dialogs + map buttons reachable again
 - [x] With the RF Esc door live, the legacy menuSoilFertilizer Esc page is stood down, which also nilled inGameMenu[pageName]. That killed three openers: the Rotation Planner dialog, the per-field detail dialog, and the map sidebar report/treatment buttons (they read the nil page and returned silently).
 - [x] Rotation Planner and Field Detail now open from the Esc panel bottom bar (MENU_EXTRA_2 / MENU_ACTIVATE), passing the panel's selectedFieldId (nil allowed).
-- [x] The map sidebar report/treatment buttons work again via the retained-page pattern: stand-down keeps the deep page on SoilPDAScreen._retainedDeepScreen, and show/toggle/showTreatment re-inject it into InGameMenu paging without restoring the Esc tab icon. In-game observation still pending.
+- [x] The map sidebar report/treatment buttons were restored via the retained-page pattern (stand-down keeps the deep page on SoilPDAScreen._retainedDeepScreen). That door was then retired on 2026-08-12: the sidebar now draws only Disable Overlay and Help, the report/treatment buttons and their click handlers are gone, and the deep screen stays reachable from the Esc panel. See the 2026-08-12 entry below.
+
+## 2026-08-12 (Fred): map sidebar trimmed to Disable Overlay + Help
+- [x] The soil layer tab sidebar drew four action buttons (Farm Overview, Treatment Plan, Disable Overlay, Help). The first two were redundant doors to the deep PDA screen and are removed: the sidebar now draws only Disable Overlay and Help, and the dead report/treatment click branches in onSideBarClick are gone. The deep screen remains reachable from the Esc panel (Rotation Planner and Field Detail buttons). Untested in-game.
 
 ## 2026-08-07 (Fred): module page dots always visible
 - [x] The Esc RF module selector hid its page dots when Worker Costs or Market Dynamics was the active module. Soil and Crop Stress always showed theirs, so WC never read as the 3rd module and the left panel was inconsistent. All four RfPdaMenuPage copies now keep the dots visible (dots = N, chrome unchanged, per the esc-rf-pda umbrella brief). Built, deployed, PR open.

--- a/TODO.md
+++ b/TODO.md
@@ -68,7 +68,7 @@
 ## Esc doors + map buttons (2026-08-06)
 - [x] Rotation Planner and Field Detail open from the Esc RF panel bottom bar (MENU_EXTRA_2 / MENU_ACTIVATE), selectedFieldId passed through (nil allowed). DONE in code, deployed.
 - [x] Map sidebar report/treatment buttons restored via retained-page pattern (SoilPDAScreen._retainedDeepScreen + _ensureDeepPageInjectable). DONE in code, deployed.
-- [~] In-game observation pending: confirm all three surfaces open with no Farm Tablet installed, and that the Esc rail still shows exactly one Realistic Farming tab.
+- [x] 2026-08-12: the map sidebar report/treatment buttons removed again (the soil layer tab now draws only Disable Overlay and Help). The retained-page pattern stays for the Esc deep screens; the PDA deep page remains reachable from the Esc panel. In-game observation pending for the trimmed sidebar.
 
 ## SF #764 Courseplay empty-tank (2026-08-07)
 - [x] Root-caused via diagnostic trace: tank hits zero but fill type stays LIME (sub-threshold residual above the 0.00001 reset line); AI out-of-fill stop never fires. FIXED in code (complete the drain in appended onEndWorkAreaProcessing), built and deployed.

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -522,13 +522,7 @@ end
 function SoilMapOverlay:onSideBarClick(posX, posY)
     for _, rect in ipairs(self.buttonRects) do
         if posX >= rect.x1 and posX <= rect.x2 and posY >= rect.y1 and posY <= rect.y2 then
-            if rect.action == "report" then
-                if SoilPDAScreen then SoilPDAScreen.toggle() end
-                return true
-            elseif rect.action == "treatment" then
-                if SoilPDAScreen then SoilPDAScreen.showTreatment() end
-                return true
-            elseif rect.action == "disable" then
+            if rect.action == "disable" then
                 self:setLayer(0)
                 return true
             elseif rect.action == "help" then
@@ -1521,8 +1515,6 @@ function SoilMapOverlay:onDrawHud(frame)
     local _, actionMargin = getNormalizedScreenValues(0, 3)
 
     local actionButtons = {
-        { key = "sf_map_btn_report",    label = "Farm Overview",   action = "report"    },
-        { key = "sf_map_btn_treatment", label = "Treatment Plan",  action = "treatment" },
         { key = "sf_map_btn_disable",   label = "Disable Overlay", action = "disable"   },
         { key = "sf_map_btn_help",      label = "Help",            action = "help"      },
     }


### PR DESCRIPTION
chore(ui): trim the soil layer tab sidebar to Disable Overlay + Help

The soil layer tab sidebar drew four action buttons: Farm Overview, Treatment Plan, Disable Overlay, Help. Farm Overview and Treatment Plan were redundant doors to the deep PDA screen, so both buttons and their dead click branches in onSideBarClick are removed. The sidebar now draws only Disable Overlay and Help.

The deep PDA screen stays reachable from the Esc panel (Rotation Planner and Field Detail buttons), so no surface is orphaned.

Verified: 2772/0 assertions across 65 files, Lua 5.1 syntax and lint clean, built and deployed. In-game observation pending.
