### PR TITLE
feat(ui): align health summary under sidebar column + per-layer info box

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -70,6 +70,10 @@
 ## 2026-08-12 (Fred): map sidebar trimmed to Disable Overlay + Help
 - [x] The soil layer tab sidebar drew four action buttons (Farm Overview, Treatment Plan, Disable Overlay, Help). The first two were redundant doors to the deep PDA screen and are removed: the sidebar now draws only Disable Overlay and Help, and the dead report/treatment click branches in onSideBarClick are gone. The deep screen remains reachable from the Esc panel (Rotation Planner and Field Detail buttons). Untested in-game.
 
+## 2026-08-12 (Fred): map sidebar footer - health summary aligned + per-layer info box
+- [x] The Average Soil Health summary was anchored to the map footer buttons, so it sat well below the layer buttons. It now stacks directly under the column content (below the legend when a layer is active), so it aligns with the sidebar. In-game observation pending.
+- [x] A small black info box (matching Wizard's RF_InfoBoxBg style) now renders under the health summary when a layer is selected, showing the layer name plus a one-line explanation. Twelve new sf_map_layer_desc_* keys ship across all 27 translation files. Untested in-game.
+
 ## 2026-08-07 (Fred): module page dots always visible
 - [x] The Esc RF module selector hid its page dots when Worker Costs or Market Dynamics was the active module. Soil and Crop Stress always showed theirs, so WC never read as the 3rd module and the left panel was inconsistent. All four RfPdaMenuPage copies now keep the dots visible (dots = N, chrome unchanged, per the esc-rf-pda umbrella brief). Built, deployed, PR open.
 

--- a/TODO.md
+++ b/TODO.md
@@ -69,6 +69,7 @@
 - [x] Rotation Planner and Field Detail open from the Esc RF panel bottom bar (MENU_EXTRA_2 / MENU_ACTIVATE), selectedFieldId passed through (nil allowed). DONE in code, deployed.
 - [x] Map sidebar report/treatment buttons restored via retained-page pattern (SoilPDAScreen._retainedDeepScreen + _ensureDeepPageInjectable). DONE in code, deployed.
 - [x] 2026-08-12: the map sidebar report/treatment buttons removed again (the soil layer tab now draws only Disable Overlay and Help). The retained-page pattern stays for the Esc deep screens; the PDA deep page remains reachable from the Esc panel. In-game observation pending for the trimmed sidebar.
+- [x] 2026-08-12: health summary re-anchored to stack under the sidebar column (was sitting well below the layer buttons), and a black per-layer info box added under it, shown when a layer is selected (12 new sf_map_layer_desc_* keys in all 27 translation files). In-game observation pending for both.
 
 ## SF #764 Courseplay empty-tank (2026-08-07)
 - [x] Root-caused via diagnostic trace: tank hits zero but fill type stays LIME (sub-threshold residual above the 0.00001 reset line); AI out-of-fill stop never fires. FIXED in code (complete the drain in appended onEndWorkAreaProcessing), built and deployed.

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -19,6 +19,31 @@ local function tr(key, fallback)
     return fallback or key
 end
 
+-- Word-wrap a string into lines that fit maxWidth at the given size. Uses the
+-- engine's getTextWidth so measurement matches renderText exactly; keeps the
+-- current bold state, so callers set setTextBold before this.
+local function wrapText(text, size, maxWidth)
+    if type(text) ~= "string" or text == "" then return { "" } end
+    if getTextWidth == nil or maxWidth <= 0 then return { text } end
+    local words = {}
+    for w in text:gmatch("%S+") do
+        words[#words + 1] = w
+    end
+    if #words == 0 then return { "" } end
+    local lines, cur = {}, ""
+    for _, w in ipairs(words) do
+        local probe = cur == "" and w or (cur .. " " .. w)
+        if cur ~= "" and getTextWidth(size, probe) > maxWidth then
+            lines[#lines + 1] = cur
+            cur = w
+        else
+            cur = probe
+        end
+    end
+    if cur ~= "" then lines[#lines + 1] = cur end
+    return lines
+end
+
 -- ── Constants ─────────────────────────────────────────────
 SoilMapOverlay.LAYER_COUNT    = 12
 SoilMapOverlay.ALPHA          = 0.72
@@ -144,6 +169,39 @@ SoilMapOverlay.LAYER_KEYS = {
     [10] = "sf_map_layer_compaction",
     [11] = "sf_map_layer_yield",
     [12] = "sf_map_layer_organic_status",
+}
+
+-- i18n key per layer description, shown in the info box under the health
+-- summary when that layer is selected (mirrors LAYER_KEYS indices).
+SoilMapOverlay.LAYER_DESC_KEYS = {
+    [1]  = "sf_map_layer_desc_n",
+    [2]  = "sf_map_layer_desc_p",
+    [3]  = "sf_map_layer_desc_k",
+    [4]  = "sf_map_layer_desc_ph",
+    [5]  = "sf_map_layer_desc_om",
+    [6]  = "sf_map_layer_desc_urgency",
+    [7]  = "sf_map_layer_desc_weed",
+    [8]  = "sf_map_layer_desc_pest",
+    [9]  = "sf_map_layer_desc_disease",
+    [10] = "sf_map_layer_desc_compaction",
+    [11] = "sf_map_layer_desc_yield",
+    [12] = "sf_map_layer_desc_organic_status",
+}
+
+-- English fallback so the info box still reads if a translation is missing.
+SoilMapOverlay.LAYER_DESC_FALLBACK = {
+    [1]  = "Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure.",
+    [2]  = "Phosphorus. Slow depletion, root crops. Apply MAP or DAP.",
+    [3]  = "Potassium. Root crops deplete this heavily. Apply Potash.",
+    [4]  = "Soil acidity. Target range: 6.5 - 7.0.",
+    [5]  = "Organic matter. Builds slowly over many seasons.",
+    [6]  = "Fields that need treatment soonest, highest first.",
+    [7]  = "Weed pressure per field.",
+    [8]  = "Pest pressure per field.",
+    [9]  = "Disease pressure per field. Unscouted ground reads unknown.",
+    [10] = "Soil compaction from heavy machinery.",
+    [11] = "Expected yield level from current soil.",
+    [12] = "Organic certification: conventional, transition or certified.",
 }
 
 -- Inverted layers: high value = bad (urgency / pressures). Yield (11) is NOT here:
@@ -1544,21 +1602,27 @@ function SoilMapOverlay:onDrawHud(frame)
         self:drawLegend(panelX, currentY - sepGap, panelWidth)
     end
 
-    -- 5. Draw Health Summary (Anchored to BOTTOM area per DMF pattern)
-    local _, summaryH = getNormalizedScreenValues(0, 74)
-    local _, panelMargin = getNormalizedScreenValues(0, 8)
-    local _, safeY = getNormalizedScreenValues(0, 6)
-    local _, upOffset = getNormalizedScreenValues(0, 15) -- Extra push up
-    
-    local summaryY = safeY + panelMargin + upOffset
-    -- Check if native buttons exist and are visible
-    if frame.buttonDeselectAllText ~= nil and frame.buttonDeselectAllText:getIsVisible() then
-        summaryY = frame.buttonDeselectAllText.absPosition[2] + frame.buttonDeselectAllText.absSize[2] + panelMargin + upOffset
-    elseif frame.buttonHelpText ~= nil and frame.buttonHelpText:getIsVisible() then
-        summaryY = frame.buttonHelpText.absPosition[2] + frame.buttonHelpText.absSize[2] + panelMargin + upOffset
+    -- 5. Draw Health Summary (stacked directly under the column content so it
+    --    aligns with the layer buttons instead of hanging near the map footer)
+    local _, summaryH   = getNormalizedScreenValues(0, 74)
+    local _, summaryGap = getNormalizedScreenValues(0, 8)
+    local _, legendH    = getNormalizedScreenValues(0, 24)
+
+    local summaryY = currentY
+    if activeIdx > 0 then
+        -- legend occupies [currentY - sepGap - legendH, currentY - sepGap]
+        summaryY = currentY - sepGap - legendH
     end
-    
+    summaryY = summaryY - summaryGap - summaryH
+
     self:drawSummaryAt(frame, panelX, summaryY, panelWidth, summaryH)
+
+    -- 6. Layer info box: a small black box (Wizard's RF_InfoBoxBg style) that
+    --    explains the selected layer, shown under the health summary.
+    if activeIdx > 0 then
+        local _, infoGap = getNormalizedScreenValues(0, 8)
+        self:drawLayerInfoBox(panelX, summaryY - infoGap, panelWidth, activeIdx)
+    end
 end
 
 function SoilMapOverlay:drawSummaryAt(frame, panelX, panelY, panelWidth, panelHeight)
@@ -1606,6 +1670,55 @@ function SoilMapOverlay:drawSummaryAt(frame, panelX, panelY, panelWidth, panelHe
     renderText(barX, statusY, statusSize, statusText)
     
     setTextColor(1, 1, 1, 1)
+end
+
+--- Draw a small black info box (Wizard's RF_InfoBoxBg style: blank.png tinted
+--- 0 0 0 0.35) explaining the selected layer. Panel Y is the bottom edge; the
+--- box grows upward. Returns the height drawn, so callers can stack under it.
+function SoilMapOverlay:drawLayerInfoBox(panelX, panelY, panelWidth, layerIdx)
+    local nameKey = SoilMapOverlay.LAYER_KEYS[layerIdx]
+    local descKey = SoilMapOverlay.LAYER_DESC_KEYS[layerIdx]
+    if nameKey == nil or descKey == nil then return 0 end
+
+    local padX, padY = getNormalizedScreenValues(10, 5)
+    local _, titleSize = getNormalizedScreenValues(0, 13)
+    local _, bodySize  = getNormalizedScreenValues(0, 11)
+    local _, lineGap   = getNormalizedScreenValues(0, 3)
+
+    local name = tr(nameKey, "Layer")
+    local desc = tr(descKey, SoilMapOverlay.LAYER_DESC_FALLBACK[layerIdx] or "")
+
+    -- Wrap the description to the panel width (bold off for the body measure).
+    setTextBold(false)
+    local maxTextW = panelWidth - padX * 2
+    local lines = wrapText(desc, bodySize, maxTextW)
+    local bodyH = #lines * (bodySize + lineGap)
+    local titleH = titleSize + lineGap
+    local boxH = padY * 2 + titleH + bodyH
+
+    -- Wizard's black info box: blank.png tinted 0 0 0 0.35, thin border.
+    drawFilledRect(panelX, panelY, panelWidth, boxH, 0, 0, 0, 0.35)
+    self:drawThinBorder(panelX, panelY, panelWidth, boxH, 0.62, 0.62, 0.62, 0.5)
+
+    -- Title: the layer name, bold.
+    setTextBold(true)
+    setTextColor(0.93, 0.93, 0.93, 1)
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    renderText(panelX + padX, panelY + boxH - padY - titleSize, titleSize, name)
+
+    -- Body: the wrapped description, below the title.
+    setTextBold(false)
+    setTextColor(0.80, 0.80, 0.80, 1)
+    local lineY = panelY + boxH - padY - titleSize - lineGap - bodySize
+    for _, line in ipairs(lines) do
+        renderText(panelX + padX, lineY, bodySize, line)
+        lineY = lineY - (bodySize + lineGap)
+    end
+
+    setTextBold(false)
+    setTextColor(1, 1, 1, 1)
+    setTextAlignment(RenderText.ALIGN_LEFT)
+    return boxH
 end
 
 -- ── Color Legend ─────────────────────────────────────────

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -1597,30 +1597,25 @@ function SoilMapOverlay:onDrawHud(frame)
         currentY = currentY - actionH - actionMargin
     end
 
-    -- 4. Color legend (only when a layer is active)
+    -- 5. Health Summary + 6. Layer info box, in a FIXED slot below the column.
+    --    The legend slot is always reserved (sepGap + legendH), so toggling a
+    --    layer on or off never moves the summary or the info box.
+    local _, legendH    = getNormalizedScreenValues(0, 24)
+    local _, summaryH   = getNormalizedScreenValues(0, 74)
+    local _, summaryGap = getNormalizedScreenValues(0, 16)
+
+    local summaryY = currentY - sepGap - legendH - summaryGap - summaryH
+
+    -- Legend goes into the reserved slot above the summary when a layer is on.
     if activeIdx > 0 then
         self:drawLegend(panelX, currentY - sepGap, panelWidth)
     end
 
-    -- 5. Draw Health Summary (stacked directly under the column content so it
-    --    aligns with the layer buttons instead of hanging near the map footer)
-    local _, summaryH   = getNormalizedScreenValues(0, 74)
-    local _, summaryGap = getNormalizedScreenValues(0, 8)
-    local _, legendH    = getNormalizedScreenValues(0, 24)
-
-    local summaryY = currentY
-    if activeIdx > 0 then
-        -- legend occupies [currentY - sepGap - legendH, currentY - sepGap]
-        summaryY = currentY - sepGap - legendH
-    end
-    summaryY = summaryY - summaryGap - summaryH
-
     self:drawSummaryAt(frame, panelX, summaryY, panelWidth, summaryH)
 
-    -- 6. Layer info box: a small black box (Wizard's RF_InfoBoxBg style) that
-    --    explains the selected layer, shown under the health summary.
+    -- Info box: fixed below the summary, drawn only when a layer is selected.
     if activeIdx > 0 then
-        local _, infoGap = getNormalizedScreenValues(0, 8)
+        local _, infoGap = getNormalizedScreenValues(0, 10)
         self:drawLayerInfoBox(panelX, summaryY - infoGap, panelWidth, activeIdx)
     end
 end
@@ -1673,9 +1668,9 @@ function SoilMapOverlay:drawSummaryAt(frame, panelX, panelY, panelWidth, panelHe
 end
 
 --- Draw a small black info box (Wizard's RF_InfoBoxBg style: blank.png tinted
---- 0 0 0 0.35) explaining the selected layer. Panel Y is the bottom edge; the
---- box grows upward. Returns the height drawn, so callers can stack under it.
-function SoilMapOverlay:drawLayerInfoBox(panelX, panelY, panelWidth, layerIdx)
+--- 0 0 0 0.35) explaining the selected layer. Panel Y is the TOP edge; the box
+--- grows downward, so it never climbs over the summary panel above it.
+function SoilMapOverlay:drawLayerInfoBox(panelX, panelTopY, panelWidth, layerIdx)
     local nameKey = SoilMapOverlay.LAYER_KEYS[layerIdx]
     local descKey = SoilMapOverlay.LAYER_DESC_KEYS[layerIdx]
     if nameKey == nil or descKey == nil then return 0 end
@@ -1697,19 +1692,20 @@ function SoilMapOverlay:drawLayerInfoBox(panelX, panelY, panelWidth, layerIdx)
     local boxH = padY * 2 + titleH + bodyH
 
     -- Wizard's black info box: blank.png tinted 0 0 0 0.35, thin border.
-    drawFilledRect(panelX, panelY, panelWidth, boxH, 0, 0, 0, 0.35)
-    self:drawThinBorder(panelX, panelY, panelWidth, boxH, 0.62, 0.62, 0.62, 0.5)
+    local boxY = panelTopY - boxH
+    drawFilledRect(panelX, boxY, panelWidth, boxH, 0, 0, 0, 0.35)
+    self:drawThinBorder(panelX, boxY, panelWidth, boxH, 0.62, 0.62, 0.62, 0.5)
 
-    -- Title: the layer name, bold.
+    -- Title: the layer name, bold, near the top of the box.
     setTextBold(true)
     setTextColor(0.93, 0.93, 0.93, 1)
     setTextAlignment(RenderText.ALIGN_LEFT)
-    renderText(panelX + padX, panelY + boxH - padY - titleSize, titleSize, name)
+    renderText(panelX + padX, panelTopY - padY - titleSize, titleSize, name)
 
     -- Body: the wrapped description, below the title.
     setTextBold(false)
     setTextColor(0.80, 0.80, 0.80, 1)
-    local lineY = panelY + boxH - padY - titleSize - lineGap - bodySize
+    local lineY = panelTopY - padY - titleSize - lineGap - bodySize
     for _, line in ipairs(lines) do
         renderText(panelX + padX, lineY, bodySize, line)
         lineY = lineY - (bodySize + lineGap)

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -363,16 +363,27 @@
     <!-- Soil Map Overlay (SoilMapOverlay.lua) -->
     <e k="sf_map_layer_off" v="Mapa do Solo: Desligado" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Nitrogênio" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fósforo" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Potássio" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Matéria Orgânica" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Urgência do Campo" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Pressão de Ervas Daninhas" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Pressão de Pragas" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Pressão de Doenças" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Compactação" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Ciclar Camada de Solo" eh="032fdac7" />
     <e k="sf_map_page_title" v="Camadas de Solo" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Camada do Mapa de Solo" eh="81332549" />
@@ -1183,6 +1194,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -362,16 +362,27 @@
     <!-- Soil Map Overlay (SoilMapOverlay.lua) -->
     <e k="sf_map_layer_off" v="土壤地图：关闭" eh="3e654ade" />
     <e k="sf_map_layer_n" v="氮元素" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="磷元素" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="钾元素" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="酸碱度" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="有机质" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="田地紧急度" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="杂草压力" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="虫害压力" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="病害压力" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="土壤板结" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="产量" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M：切换土壤图层" eh="032fdac7" />
     <e k="sf_map_page_title" v="土壤图层" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="土壤地图图层" eh="81332549" />
@@ -1157,6 +1168,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -362,16 +362,27 @@
     <!-- Soil Map Overlay (SoilMapOverlay.lua) -->
     <e k="sf_map_layer_off" v="土壤地圖：關閉" eh="3e654ade" />
     <e k="sf_map_layer_n" v="氮" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="磷" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="鉀" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH 值" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="有機質" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="田地緊迫性" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="雜草壓力" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="害蟲壓力" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="疾病壓力" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="[EN] Compaction" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: 切換土壤圖層" eh="032fdac7" />
     <e k="sf_map_page_title" v="土壤圖層" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="土壤地圖圖層" eh="81332549" />
@@ -1195,6 +1206,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -363,16 +363,27 @@
     <!-- Soil Map Overlay (SoilMapOverlay.lua) -->
     <e k="sf_map_layer_off" v="Půdní mapa: Vypnuto" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Dusík" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fosfor" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Draslík" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Organická hmota" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Naléhavost pole" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Tlak plevele" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Tlak škůdců" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Tlak chorob" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Zhutnění" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Přepnout vrstvu půdy" eh="032fdac7" />
     <e k="sf_map_page_title" v="Půdní vrstvy" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Vrstva půdní mapy" eh="81332549" />
@@ -1175,6 +1186,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -348,16 +348,27 @@
 
     <e k="sf_map_layer_off" v="Jordkort: Fra" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Kvælstof" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fosfor" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Kalium" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Organisk materiale" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Markhastegrad" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Ukrudtstryk" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Skadedyrstryk" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Sygdomstryk" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Pakning" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Skift+M: Skift jordlag" eh="032fdac7" />
     <e k="sf_map_page_title" v="Jordlag" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Jordkortlag" eh="81332549" />
@@ -1132,6 +1143,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -365,16 +365,27 @@
 
     <e k="sf_map_layer_off" v="Bodenkarte: Aus" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Stickstoff" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Phosphor" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Kalium" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH-Wert" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Organische Substanz" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Zustand" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Unkraut" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Sch├ñdlinge" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Krankheiten" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Verdichtung" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="Ertrag" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Umschalt+M: Bodenebene wechseln" eh="032fdac7" />
     <e k="sf_map_page_title" v="Feldmonitor" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Bodenkartenebene" eh="81332549" />
@@ -1153,6 +1164,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -348,16 +348,27 @@
 
     <e k="sf_map_layer_off" v="Mapa Suelo: Off" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Nitrógeno" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fósforo" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Potasio" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Materia Orgánica" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Urgencia de Campo" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Presión de Maleza" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Presión de Plagas" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Presión de Enfermedad" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Compactación" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Ciclar Capa de Suelo" eh="032fdac7" />
     <e k="sf_map_page_title" v="Capas de Suelo" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Capa del Mapa" eh="81332549" />
@@ -1135,6 +1146,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -362,16 +362,27 @@
     <!-- Soil Map Overlay (SoilMapOverlay.lua) -->
     <e k="sf_map_layer_off" v="Soil Map: Off" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Phosphorus" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Potassium" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Organic Matter" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Field Urgency" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Weed Pressure" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Pest Pressure" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Disease Pressure" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Compaction" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Cycle Soil Layer" eh="032fdac7" />
     <e k="sf_map_page_title" v="Soil Layers" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Soil Map Layer" eh="81332549" />
@@ -1199,6 +1210,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="Organic Status" eh="037de0fd" />
     

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -348,16 +348,27 @@
 
     <e k="sf_map_layer_off" v="Mapa suelo: Off" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Nitrógeno" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fósforo" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Potasio" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Materia orgánica" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Urgencia de campo" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Presión de maleza" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Presión de plagas" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Presión de enfermedad" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Compactación" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Ciclar capa de suelo" eh="032fdac7" />
     <e k="sf_map_page_title" v="Capas de suelo" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Capa de mapa" eh="81332549" />
@@ -1135,6 +1146,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -362,16 +362,27 @@
     <!-- Soil Map Overlay (SoilMapOverlay.lua) -->
     <e k="sf_map_layer_off" v="土壤地图：关闭" eh="3e654ade" />
     <e k="sf_map_layer_n" v="氮元素" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="磷元素" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="钾元素" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="酸碱度" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="有机质" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="田地紧急度" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="杂草压力" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="虫害压力" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="病害压力" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="土壤板结" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M：切换土壤图层" eh="032fdac7" />
     <e k="sf_map_page_title" v="土壤图层" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="土壤地图图层" eh="81332549" />
@@ -1195,6 +1206,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -349,16 +349,27 @@
 
     <e k="sf_map_layer_off" v="Maaperäkartta: Pois" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Typpi" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fosfori" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Kalium" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Orgaaninen aines" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Pellon kiireellisyys" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Rikkakasvipaine" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Tuholaispaine" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Tautipaine" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Tiivistyminen" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Vaihda karttatasoa" eh="032fdac7" />
     <e k="sf_map_page_title" v="Maaperätasot" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Maaperän karttataso" eh="81332549" />
@@ -1136,6 +1147,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -343,16 +343,27 @@
     <!-- Couche de carte des sols (SoilMapOverlay.lua) -->
     <e k="sf_map_layer_off" v="Carte des sols : désactivée" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Azote" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Phosphore" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Potassium" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Matière organique" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Urgence des champs" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Pression des mauvaises herbes" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Pression des ravageurs" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Pression des maladies" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Compaction du sol" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
 	<e k="sf_map_layer_yield" v="Rendement" eh="97345487" />
+	<e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Maj+M : changer de couche de sol" eh="032fdac7" />
     <e k="sf_map_page_title" v="Couches du sol" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Couche de carte des sols" eh="81332549" />
@@ -1135,6 +1146,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="Fongicide à base d'hydroxyde de cuivre, compatible agriculture biologique (liquide)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="Non inspecté" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="Statut biologique" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="Statut biologique" eh="037de0fd" />
     

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -363,16 +363,27 @@
     <!-- Soil Map Overlay (SoilMapOverlay.lua) -->
     <e k="sf_map_layer_off" v="Talajtérkép: Ki" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Nitrogén" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Foszfor" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Kálium" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Szerves anyag" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Mező sürgősség" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Gyomnyomás" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Kártevőnyomás" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Betegségnyomás" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Tömörödés" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Talajréteg váltása" eh="032fdac7" />
     <e k="sf_map_page_title" v="Talajrétegek" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Talajtérkép réteg" eh="81332549" />
@@ -1155,6 +1166,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -362,16 +362,27 @@
     <!-- Soil Map Overlay (SoilMapOverlay.lua) -->
     <e k="sf_map_layer_off" v="Peta Tanah: Mati" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fosfor" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Kalium" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Bahan Organik" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Urgensi Lahan" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Tekanan Gulma" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Tekanan Hama" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Tekanan Penyakit" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Pemadatan" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Siklus Lapisan Tanah" eh="032fdac7" />
     <e k="sf_map_page_title" v="Lapisan Tanah" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Lapisan Peta Tanah" eh="81332549" />
@@ -1182,6 +1193,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -362,16 +362,27 @@
     <!-- Soil Map Overlay (SoilMapOverlay.lua) -->
     <e k="sf_map_layer_off" v="Mappa del Suolo: Off" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Azoto" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fosforo" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Potassio" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Sostanza Organica" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Urgenza Campo" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Pressione Infestanti" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Pressione Parassiti" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Pressione Malattie" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Compattazione" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Maiusc+M: Cicla Livelli Suolo" eh="032fdac7" />
     <e k="sf_map_page_title" v="Livelli del Suolo" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Livello Mappa del Suolo" eh="81332549" />
@@ -1182,6 +1193,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -362,16 +362,27 @@
     <!-- Soil Map Overlay (SoilMapOverlay.lua) -->
     <e k="sf_map_layer_off" v="土壌マップ: オフ" eh="3e654ade" />
     <e k="sf_map_layer_n" v="窒素" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="リン" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="カリウム" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="有機物" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="対応優先度" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="雑草圧" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="害虫圧" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="病害圧" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="踏み固め" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: 土壌レイヤー切替" eh="032fdac7" />
     <e k="sf_map_page_title" v="土壌レイヤー" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="土壌マップレイヤー" eh="81332549" />
@@ -1162,6 +1173,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -361,16 +361,27 @@
     <!-- Soil Map Overlay -->
     <e k="sf_map_layer_off" v="토양 지도: 끔" eh="3e654ade" />
     <e k="sf_map_layer_n" v="질소" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="인산" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="칼륨" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="유기물" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="필드 긴급도" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="잡초 발생 정도" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="해충 발생 정도" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="병해 발생 정도" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="압축도" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: 토양 레이어 전환" eh="032fdac7" />
     <e k="sf_map_page_title" v="토양 레이어" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="토양 지도 레이어" eh="81332549" />
@@ -1163,6 +1174,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -362,16 +362,27 @@
     <!-- Soil Map Overlay -->
     <e k="sf_map_layer_off" v="Bodemkaart: Uit" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Stikstof" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fosfor" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Kalium" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Organische stof" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Veld urgentie" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Onkruiddruk" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Plagendruk" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Ziektedruk" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Bodemverdichting" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Wissel bodemlaag" eh="032fdac7" />
     <e k="sf_map_page_title" v="Bodemlagen" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Bodemkaartlaag" eh="81332549" />
@@ -1166,6 +1177,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -362,16 +362,27 @@
     <!-- Soil Map Overlay -->
     <e k="sf_map_layer_off" v="Jordkart: Av" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Nitrogen" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fosfor" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Kalium" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Organisk materiale" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Felt-hast" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Ugresstrykk" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Skadedyrtrykk" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Sykdomstrykk" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Jordpakking" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Bytt jordlag" eh="032fdac7" />
     <e k="sf_map_page_title" v="Jordlag" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Jordkartlag" eh="81332549" />
@@ -1164,6 +1175,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -362,16 +362,27 @@
     <!-- Soil Map Overlay -->
     <e k="sf_map_layer_off" v="Mapa gleby: Wył" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Azot" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fosfor" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Potas" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Materia organiczna" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Pilność pola" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Presja chwastów" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Presja szkodników" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Presja chorób" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Zagęszczenie" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Zmień warstwę gleby" eh="032fdac7" />
     <e k="sf_map_page_title" v="Warstwy gleby" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Warstwa mapy gleby" eh="81332549" />
@@ -1164,6 +1175,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -363,16 +363,27 @@
     <!-- Soil Map Overlay (SoilMapOverlay.lua) -->
     <e k="sf_map_layer_off" v="Mapa do Solo: Desligado" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Nitrogénio" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fósforo" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Potássio" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Matéria Orgânica" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Urgência do Campo" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Pressão de Ervas Daninhas" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Pressão de Pragas" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Pressão de Doenças" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Compactação" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Ciclar Camada de Solo" eh="032fdac7" />
     <e k="sf_map_page_title" v="Camadas de Solo" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Camada do Mapa de Solo" eh="81332549" />
@@ -1183,6 +1194,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -363,16 +363,27 @@
     <!-- Soil Map Overlay (SoilMapOverlay.lua) -->
     <e k="sf_map_layer_off" v="Hartă Sol: Oprit" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Azot" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fosfor" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Potasiu" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Materie Organică" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Urgență Câmp" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Presiune Buruieni" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Presiune Dăunători" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Presiune Boli" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Compactare" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Schimbă Stratul de Sol" eh="032fdac7" />
     <e k="sf_map_page_title" v="Straturi Sol" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Strat Hartă Sol" eh="81332549" />
@@ -1183,6 +1194,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -349,16 +349,27 @@
 
     <e k="sf_map_layer_off" v="Карта почв: Выкл." eh="3e654ade" />
     <e k="sf_map_layer_n" v="Азот" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Фосфор" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Калий" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Органика" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Срочность" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Сорняки" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Вредители" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Болезни" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Уплотнение" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Переключить слой" eh="032fdac7" />
     <e k="sf_map_page_title" v="Слои почвы" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Слой карты почв" eh="81332549" />
@@ -1124,6 +1135,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -348,16 +348,27 @@
 
     <e k="sf_map_layer_off" v="Markkarta: Av" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Kväve" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fosfor" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Kalium" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Organiskt material" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Fältbrådska" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Ogrästryck" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Skadedjurstryck" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Sjukdomstryck" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Packning" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Skift+M: Bläddra bland marklager" eh="032fdac7" />
     <e k="sf_map_page_title" v="Marklager" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Markkartlager" eh="81332549" />
@@ -1135,6 +1146,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -349,16 +349,27 @@
 
     <e k="sf_map_layer_off" v="Toprak Haritası: Kapalı" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Azot" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Fosfor" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Potasyum" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Organik Madde" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Tarla Aciliyeti" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Yabancı Ot Baskısı" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Zararlı Baskısı" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Hastalık Baskısı" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Sıkışma" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Toprak Katmanını Değiştir" eh="032fdac7" />
     <e k="sf_map_page_title" v="Toprak Katmanları" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Toprak Harita Katmanı" eh="81332549" />
@@ -1136,6 +1147,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -348,16 +348,27 @@
 
     <e k="sf_map_layer_off" v="Карта ґрунту: Вимк" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Азот" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Фосфор" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Калій" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Органічна речовина" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Терміновість поля" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Забур'яненість" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Тиск шкідників" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Тиск хвороб" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Ущільнення" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Перемкнути шар ґрунту" eh="032fdac7" />
     <e k="sf_map_page_title" v="Шари ґрунту" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Шари карти ґрунту" eh="81332549" />
@@ -1135,6 +1146,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -348,16 +348,27 @@
 
     <e k="sf_map_layer_off" v="Bản đồ đất: Tắt" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Đạm" eh="1e9ef3ba" />
+    <e k="sf_map_layer_desc_n" v="[EN] Nitrogen. Depletes fast, every harvest. Apply UAN, urea or manure." />
     <e k="sf_map_layer_p" v="Lân" eh="eb4f2688" />
+    <e k="sf_map_layer_desc_p" v="[EN] Phosphorus. Slow depletion, root crops. Apply MAP or DAP." />
     <e k="sf_map_layer_k" v="Kali" eh="3a4edc67" />
+    <e k="sf_map_layer_desc_k" v="[EN] Potassium. Root crops deplete heavily. Apply Potash." />
     <e k="sf_map_layer_ph" v="pH" eh="397dff20" />
+    <e k="sf_map_layer_desc_ph" v="[EN] Soil acidity. Target range 6.5 - 7.0." />
     <e k="sf_map_layer_om" v="Chất hữu cơ" eh="6305f4bb" />
+    <e k="sf_map_layer_desc_om" v="[EN] Organic matter. Builds slowly over many seasons." />
     <e k="sf_map_layer_urgency" v="Độ khẩn cấp" eh="419ea5af" />
+    <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Áp lực cỏ dại" eh="53f8b936" />
+    <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
     <e k="sf_map_layer_pest" v="Áp lực sâu bệnh" eh="18a7c2be" />
+    <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Áp lực bệnh hại" eh="2b805cc9" />
+    <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
     <e k="sf_map_layer_compaction" v="Nén chặt" eh="19cf3ee7" />
+    <e k="sf_map_layer_desc_compaction" v="[EN] Soil compaction from heavy machinery." />
     <e k="sf_map_layer_yield" v="[EN] Yield" eh="97345487" />
+    <e k="sf_map_layer_desc_yield" v="[EN] Expected yield level." />
     <e k="sf_map_overlay_cycle" v="Shift+M: Chuyển lớp đất" eh="032fdac7" />
     <e k="sf_map_page_title" v="Lớp đất" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Lớp bản đồ đất" eh="81332549" />
@@ -1135,6 +1146,7 @@
     <e k="sf_bigBag_copper_hydroxide_function" v="[EN] Copper Hydroxide fungicide, organic-approved (liquid)" eh="ee1a16b8" />
     <e k="sf_unscouted" v="[EN] Unscouted" eh="a773e76d" />
 <e k="sf_map_layer_organic_status" v="[EN] Organic Status" eh="037de0fd" />
+<e k="sf_map_layer_desc_organic_status" v="[EN] Organic certification: conventional, transition or certified." />
     
 <e k="sf_layer_12" v="[EN] Organic Status" eh="037de0fd" />
     


### PR DESCRIPTION
feat(ui): align health summary under the sidebar column + add a per-layer info box

Two changes to the soil layer tab sidebar:

1. The Average Soil Health panel was anchored to the map footer buttons, so it sat well below the layer buttons (about 30% under the frame). It now stacks directly under the column content, below the legend when a layer is active, so it aligns with the rest of the sidebar.

2. A small black info box in Wizard's RF_InfoBoxBg style (blank.png tinted black) renders under the health summary when a layer is selected, showing the layer name plus a one-line explanation. Twelve new sf_map_layer_desc_* keys ship across all 27 translation files, with English fallbacks in code for robustness.

Verified: suite 2772/0 across 65 files, Lua 5.1 syntax and lint clean, built and deployed. In-game observation of the aligned summary and the new info box is pending.
