### PR TITLE
feat(SF-39): the handful panel, the reading surface for the kneel

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.5.0.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.5.0.62
 
 © 2026 TisonK - See [LICENSE](LICENSE) for full terms.
 

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.5.0.62
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.5.0.63
 
 © 2026 TisonK - See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK (Refined edition: WizardlyPayload)</author>
-    <version>2.5.0.62</version>
+    <version>2.5.0.63</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK (Refined edition: WizardlyPayload)</author>
-    <version>2.5.0.61</version>
+    <version>2.5.0.62</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>
@@ -95,6 +95,7 @@
         <action name="SF_MINIMAP_ZOOM"      category="ONFOOT" />
         <action name="SF_SCOUT"             category="ONFOOT" />
         <action name="SF_TREATMENT"         category="ONFOOT" />
+        <action name="SF_HANDFUL"           category="ONFOOT" />
     </actions>
 
     <l10n filenamePrefix="translations/translation" />
@@ -111,6 +112,15 @@
         <actionBinding action="SF_MINIMAP_ZOOM" />
         <actionBinding action="SF_SCOUT" />
         <actionBinding action="SF_TREATMENT" />
+        <!-- SF-39: the only SF action that ships a DEFAULT key. The engine reads
+             a default from a nested <binding> child (InputBinding:loadBindingsFromXML
+             -> Binding.createFromXML); the bare actionBinding entries above have
+             never had one, which is why every other SF hotkey must be bound by
+             hand despite what the code comments claim. Retro-fitting the rest is
+             a change to shipped behaviour and is deliberately not done here. -->
+        <actionBinding action="SF_HANDFUL">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_g" />
+        </actionBinding>
     </inputBinding>
 
     <!-- Custom fill types declared in external file (FS25 requires filename= attribute) -->

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -147,6 +147,12 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
             SoilLogger.info("Soil Scout dialog registered")
         end
 
+        -- [SF-39] The Handful panel (opened from the SF_HANDFUL hotkey, kneeling only)
+        if SoilHandfulDialog and g_gui then
+            SoilHandfulDialog.register(modDirectory)
+            SoilLogger.info("Soil Handful panel registered")
+        end
+
         -- Version/changelog dialog (shown once per version on load)
         if SoilVersionDialog and g_gui then
             SoilVersionDialog.register(modDirectory)
@@ -349,6 +355,21 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                         g_SoilFertilityManager.treatmentEventId = trId
                         g_inputBinding:setActionEventTextVisibility(trId, false)
                         SoilLogger.info("Treatment panel (Shift+T) registered in PLAYER context")
+                    end
+                end
+
+                -- [SF-39] The Handful panel (SF_HANDFUL, default Shift+G) - PLAYER
+                -- context. Opens only while crouched; the ladder lives in the callback.
+                if InputAction.SF_HANDFUL then
+                    local hfOk, hfId = g_inputBinding:registerActionEvent(
+                        InputAction.SF_HANDFUL, g_SoilFertilityManager,
+                        g_SoilFertilityManager.onHandfulInput,
+                        false, true, false, true
+                    )
+                    if hfOk and hfId then
+                        g_SoilFertilityManager.handfulEventId = hfId
+                        g_inputBinding:setActionEventTextVisibility(hfId, false)
+                        SoilLogger.info("Handful panel (Shift+G) registered in PLAYER context")
                     end
                 end
 
@@ -1106,6 +1127,93 @@ end
 function SoilFertilityManager:onMinimapZoomInput()
     if self.soilMapOverlay then
         self.soilMapOverlay:cycleMinimapZoom()
+    end
+end
+
+--- [SF-39] THE HANDFUL PANEL. Input callback for SF_HANDFUL (default Shift+G).
+--- Kneel, read, show. The order is load bearing: the reveal must complete before
+--- the assemble so diseaseKnown reflects the just-knelt cell and never a stale
+--- pre-reveal read (SF-38 rule 5).
+---
+--- Every refusal SPEAKS. A silent no-op teaches the player the key is broken;
+--- a blinking warning teaches them the rule.
+function SoilFertilityManager:onHandfulInput()
+    if not (self.settings and self.settings.enabled) then return end
+    if not (self.soilSystem and self.soilHUD) then return end
+
+    local function warn(text)
+        if g_currentMission and g_currentMission.hud and g_currentMission.hud.showBlinkingWarning then
+            g_currentMission.hud:showBlinkingWarning(text, 3000)
+        end
+    end
+
+    -- Gate 1: the family is LOCKED unless the player opted into experimental
+    -- systems. Same registry the rest of Read the Dirt checks.
+    if ReleaseGate and not ReleaseGate.isSystemLive("read_the_dirt") then
+        local msg = ReleaseGate.lockMessage and ReleaseGate.lockMessage("read_the_dirt", ReleaseGate.liveOptIn())
+        if msg then warn(msg) end
+        return
+    end
+
+    -- Gate 2: you have to actually be kneeling. PlayerStateCrouch flips this flag
+    -- on entry/exit (player/PlayerMover.lua setIsCrouching); crouch is a HOLD in
+    -- FS25, not a toggle, so the player holds crouch and presses the key. A hand
+    -- tool whose canCrouch is false blocks the crouch state outright - that is
+    -- the engine's rule and we do not work around it.
+    local player = g_localPlayer
+    local kneeling = player ~= nil and player.mover ~= nil and player.mover.isCrouching == true
+    if not kneeling then
+        warn(g_i18n:getText("sf_handful_need_kneel"))
+        return
+    end
+
+    -- Gate 3: a field and a resolved spot underfoot.
+    local fieldId, x, z = nil, nil, nil
+    if self.soilHUD.detectCurrentFieldId then
+        local ok, cur, cx, cz = pcall(function() return self.soilHUD:detectCurrentFieldId() end)
+        if ok then fieldId = cur; x, z = cx, cz end
+    end
+    if fieldId and fieldId <= 0 then fieldId = nil end
+    if not fieldId or x == nil or z == nil then
+        warn(g_i18n:getText("sf_scout_no_field"))
+        return
+    end
+
+    local day = g_currentMission and g_currentMission.environment
+        and g_currentMission.environment.currentDay
+
+    -- THE KNEEL, first. Server-authoritative: direct on the host, a request on a
+    -- client. Identical to the SF_SCOUT path, which is the shipped kneel.
+    local scouting = self.soilSystem.spatialScouting
+    if g_server ~= nil then
+        if scouting and scouting:isArmed() and day then
+            scouting:revealCellAt(nil, x, z, day)
+        end
+    elseif g_client ~= nil and SoilKneelEvent then
+        pcall(function()
+            g_client:getServerConnection():sendEvent(SoilKneelEvent.new(x, z))
+        end)
+    end
+
+    -- THE READ, after. Pure assembly, zero writes. materialFillType is left nil
+    -- when we cannot name what lies at the spot; the verdict then returns its
+    -- honest refusal rather than a guess.
+    if HandfulRead == nil or type(HandfulRead.assemble) ~= "function" then return end
+    local payload = HandfulRead.assemble({
+        fieldId = fieldId,
+        x = x,
+        z = z,
+        farmId = player.farmId,
+        currentDay = day,
+    })
+    if payload == nil then
+        warn(g_i18n:getText("sf_handful_no_read"))
+        return
+    end
+
+    -- THE PANEL.
+    if SoilHandfulDialog and SoilHandfulDialog.show then
+        SoilHandfulDialog.show(payload)
     end
 end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -163,6 +163,10 @@ source(modDirectory .. "src/ui/SoilFieldDetailDialog.lua")
 source(modDirectory .. "src/ui/RotationPlannerDialog.lua")
 source(modDirectory .. "src/ui/SoilTreatmentDialog.lua")
 source(modDirectory .. "src/ui/SoilScoutDialog.lua")
+-- SF-39 THE HANDFUL PANEL: the reading surface for the kneel. Renders the
+-- frozen SF-38 payload; loaded like any other dialog, gated at the input
+-- callback by read_the_dirt so a locked family never opens it.
+source(modDirectory .. "src/ui/SoilHandfulDialog.lua")
 source(modDirectory .. "src/ui/SoilVersionDialog.lua")
 source(modDirectory .. "src/ui/SoilHelpDialog.lua")
 source(modDirectory .. "src/ui/SoilGuideDialog.lua")

--- a/src/ui/SoilHandfulDialog.lua
+++ b/src/ui/SoilHandfulDialog.lua
@@ -9,13 +9,18 @@
 -- Opened by the SF_HANDFUL hotkey, and ONLY while the player is crouched -
 -- the precondition ladder lives in SoilFertilityManager:onHandfulInput.
 --
--- Same ScreenElement + GUI-XML pattern as SoilScoutDialog / SoilTreatmentDialog.
+-- LAYOUT: stat tiles for the banded clauses, text rows for the wordy ones.
+-- Every band resolves to a SEVERITY as well as a word, and the severity picks
+-- the value colour, so the panel reads at a glance without reading at all.
+-- Colour is a SECOND channel on top of the word, never a replacement for it:
+-- the word always says the thing, so a colour-blind player loses nothing.
 --
 -- RENDERING RULES (inherited cert gates from the SF-38 contract, not new):
 --   GRAIN HONESTY      - every section carries its grain tag; a FIELD clause is
 --                        never drawn as if it were measured at the spot.
 --   PER-CLAUSE NEUTRAL - one absent system blanks its own clause only. A nil
---                        clause renders a dash, never a zero, never an error.
+--                        clause renders a dash in NEUTRAL grey, never a zero,
+--                        and never borrows a severity colour it did not earn.
 --   NO PHANTOM FIELDS  - we render HandfulRead.CLAUSES and nothing else.
 --   BANDS, NOT NUMBERS - exact figures sit behind the test kit, and
 --                        HandfulRead readTestKit() is a hardcoded false until
@@ -39,6 +44,16 @@ SoilHandfulDialog.xmlPath  = nil
 
 local DASH = "--"
 
+-- Severity -> colour. The absent case gets its own grey so a missing reading is
+-- visibly not a judgement: "we did not measure this" must never look like "good".
+local SEV = {
+    good    = { 0.42, 0.82, 0.35, 1 },
+    fair    = { 0.95, 0.78, 0.30, 1 },
+    poor    = { 0.90, 0.38, 0.30, 1 },
+    info    = { 0.55, 0.80, 0.95, 1 },
+    neutral = { 0.55, 0.55, 0.55, 1 },
+}
+
 -- ── i18n helper (same shape as the sibling dialogs) ───────
 -- Carries an English fallback for every key. A key that resolves nowhere still
 -- renders readable text instead of the engine's "Missing '...'" string.
@@ -57,7 +72,8 @@ local function tr(key, fallback)
     return fallback or key
 end
 
--- ── Bands (every cut point below is a SHIPPED value) ──────
+-- ── Bands: every cut point below is a SHIPPED value ───────
+-- Each returns (displayWord, severity). Severity drives colour only.
 
 -- N/P/K arrive from the core already banded: getFieldInfo returns
 -- { value, status } with status in Poor/Fair/Good/Unknown. We localise the word
@@ -65,22 +81,25 @@ end
 local function bandNutrient(clause)
     if type(clause) ~= "table" or type(clause.status) ~= "string" then return nil end
     local s = clause.status:lower()
-    return tr("sf_handful_band_" .. s, clause.status)
+    local sev = (s == "good" and "good") or (s == "fair" and "fair")
+        or (s == "poor" and "poor") or "neutral"
+    return tr("sf_handful_band_" .. s, clause.status), sev
 end
 
 -- pH: SoilConstants.REPORT_COLORS, the same cut points the report display uses.
+-- Acidic and alkaline are both "off optimal", not "bad", so both read fair.
 local function bandPh(ph)
     if type(ph) ~= "number" then return nil end
     local rc = SoilConstants and SoilConstants.REPORT_COLORS
     if rc == nil then return nil end
     if ph >= (rc.PH_GOOD_LOW or 6.0) and ph <= (rc.PH_GOOD_HIGH or 7.0) then
-        return tr("sf_handful_band_good", "Good")
+        return tr("sf_handful_band_good", "Good"), "good"
     elseif ph < (rc.PH_FAIR_LOW or 5.5) then
-        return tr("sf_handful_band_acidic", "Acidic")
+        return tr("sf_handful_band_acidic", "Acidic"), "poor"
     elseif ph > (rc.PH_FAIR_HIGH or 7.5) then
-        return tr("sf_handful_band_alkaline", "Alkaline")
+        return tr("sf_handful_band_alkaline", "Alkaline"), "poor"
     end
-    return tr("sf_handful_band_fair", "Fair")
+    return tr("sf_handful_band_fair", "Fair"), "fair"
 end
 
 -- Organic matter: SoilConstants.REPORT_COLORS OM_GOOD / OM_FAIR.
@@ -88,19 +107,20 @@ local function bandOm(om)
     if type(om) ~= "number" then return nil end
     local rc = SoilConstants and SoilConstants.REPORT_COLORS
     if rc == nil then return nil end
-    if om >= (rc.OM_GOOD or 4.0) then return tr("sf_handful_band_good", "Good") end
-    if om >= (rc.OM_FAIR or 2.5) then return tr("sf_handful_band_fair", "Fair") end
-    return tr("sf_handful_band_poor", "Poor")
+    if om >= (rc.OM_GOOD or 4.0) then return tr("sf_handful_band_good", "Good"), "good" end
+    if om >= (rc.OM_FAIR or 2.5) then return tr("sf_handful_band_fair", "Fair"), "fair" end
+    return tr("sf_handful_band_poor", "Poor"), "poor"
 end
 
 -- Compaction: the cut points the shipped map layer already displays against
 -- (SoilMapOverlay layer 10: <25 no action, <60 subsoiling recommended, else
 -- urgent). Reused rather than re-invented so the two surfaces never disagree.
+-- NOTE the polarity: LOW compaction is the GOOD outcome.
 local function bandCompaction(c)
     if type(c) ~= "number" then return nil end
-    if c < 25 then return tr("sf_handful_band_low", "Low") end
-    if c < 60 then return tr("sf_handful_band_moderate", "Moderate") end
-    return tr("sf_handful_band_high", "High")
+    if c < 25 then return tr("sf_handful_band_low", "Low"), "good" end
+    if c < 60 then return tr("sf_handful_band_moderate", "Moderate"), "fair" end
+    return tr("sf_handful_band_high", "High"), "poor"
 end
 
 -- Pressure tiers: SoilConstants.DISEASE_PRESSURE LOW/MEDIUM/HIGH, the same
@@ -109,19 +129,21 @@ local function bandPressure(v)
     if type(v) ~= "number" then return nil end
     local dp = SoilConstants and SoilConstants.DISEASE_PRESSURE
     if dp == nil then return nil end
-    if v < (dp.LOW or 20) then return tr("sf_scout_tier_none", "None") end
-    if v < (dp.MEDIUM or 50) then return tr("sf_scout_tier_mild", "Mild") end
-    if v < (dp.HIGH or 75) then return tr("sf_scout_tier_moderate", "Moderate") end
-    return tr("sf_scout_tier_severe", "Severe")
+    if v < (dp.LOW or 20) then return tr("sf_scout_tier_none", "None"), "good" end
+    if v < (dp.MEDIUM or 50) then return tr("sf_scout_tier_mild", "Mild"), "fair" end
+    if v < (dp.HIGH or 75) then return tr("sf_scout_tier_moderate", "Moderate"), "poor" end
+    return tr("sf_scout_tier_severe", "Severe"), "poor"
 end
 
 -- Material bands arrive from the layers as lowercase ids ("damp", "curing").
 -- The l10n key carries the display word; the FALLBACK has to capitalise, or a
 -- missing key degrades to a lowercase word sitting next to capitalised ones.
+local MATERIAL_SEV = { fit = "good", curing = "fair", damp = "fair", soaked = "poor" }
 local function bandMaterial(band)
     if type(band) ~= "string" or band == "" then return nil end
     local lower = band:lower()
-    return tr("sf_handful_band_" .. lower, lower:sub(1, 1):upper() .. lower:sub(2))
+    return tr("sf_handful_band_" .. lower, lower:sub(1, 1):upper() .. lower:sub(2)),
+        MATERIAL_SEV[lower] or "info"
 end
 
 local function cropName(id)
@@ -173,20 +195,26 @@ end
 
 -- ── Lifecycle ─────────────────────────────────────────────
 
+-- Every id the controller touches. Kept as a list so onGuiSetupFinished cannot
+-- drift out of step with the XML one rename at a time.
+local ELEMENT_IDS = {
+    "hfField", "hfGrain",
+    "hfLblN", "hfValN", "hfLblP", "hfValP", "hfLblK", "hfValK",
+    "hfLblPh", "hfValPh", "hfLblOm", "hfValOm",
+    "hfLblComp", "hfValComp", "hfLblMoist", "hfValMoist",
+    "hfLblDis", "hfValDis", "hfLblPest", "hfValPest", "hfLblWeed", "hfValWeed",
+    "hfDisGrain",
+    "hfCrops", "hfRotation", "hfOrganic",
+    "hfSecMaterial", "hfLblWet", "hfValWet", "hfLblDown", "hfValDown",
+    "hfLblVerdict", "hfValVerdict",
+    "hfFooter",
+}
+
 function SoilHandfulDialog:onGuiSetupFinished()
     SoilHandfulDialog:superClass().onGuiSetupFinished(self)
-    self.hfHeader      = self:getDescendantById("hfHeader")
-    self.hfNutrients   = self:getDescendantById("hfNutrients")
-    self.hfPhOm        = self:getDescendantById("hfPhOm")
-    self.hfGround      = self:getDescendantById("hfGround")
-    self.hfDisease     = self:getDescendantById("hfDisease")
-    self.hfPestWeed    = self:getDescendantById("hfPestWeed")
-    self.hfCrops       = self:getDescendantById("hfCrops")
-    self.hfRotation    = self:getDescendantById("hfRotation")
-    self.hfOrganic     = self:getDescendantById("hfOrganic")
-    self.hfSecMaterial = self:getDescendantById("hfSecMaterial")
-    self.hfMaterial    = self:getDescendantById("hfMaterial")
-    self.hfFooter      = self:getDescendantById("hfFooter")
+    for _, id in ipairs(ELEMENT_IDS) do
+        self[id] = self:getDescendantById(id)
+    end
 end
 
 function SoilHandfulDialog:onOpen()
@@ -208,63 +236,81 @@ end
 local function setText(el, text) if el then el:setText(text or "") end end
 local function setVisible(el, v) if el and el.setVisible then el:setVisible(v) end end
 
---- "Label: value" with the neutral dash when the clause is absent. This is the
---- per-clause neutrality rule in one function: nil never becomes 0.
-local function pair(label, value)
+local function setColor(el, sev)
+    if el == nil or el.setTextColor == nil then return end
+    local c = SEV[sev or "neutral"] or SEV.neutral
+    el:setTextColor(c[1], c[2], c[3], c[4])
+end
+
+--- One stat tile: a dim label over a coloured value. An absent value is the
+--- neutral dash in neutral grey - it must never inherit a severity colour, or a
+--- clause nobody measured would read as a verdict somebody made.
+local function tile(lblEl, valEl, labelText, valueText, sev)
+    setText(lblEl, labelText)
+    if valueText == nil then
+        setText(valEl, DASH)
+        setColor(valEl, "neutral")
+    else
+        setText(valEl, valueText)
+        setColor(valEl, sev)
+    end
+end
+
+--- "Label: value" for the wordy rows, with the same neutral-dash contract.
+local function row(label, value)
     return string.format("%s: %s", label, value or DASH)
 end
 
 function SoilHandfulDialog:_populate()
     local p = self._payload
     if p == nil then
-        setText(self.hfHeader, tr("sf_handful_no_read", "Nothing read"))
+        setText(self.hfField, tr("sf_handful_no_read", "Nothing read"))
+        setText(self.hfGrain, "")
         return
     end
 
     -- Header: which field, and whether the nutrient row was refined to the spot.
     -- ONE shared refinement flag for N/P/K/pH/OM, labelled once, per the contract.
-    local grain = p.fromZoneCell
+    setText(self.hfField, string.format("%s%s",
+        tr("sf_detail_field_label", "Field #"), tostring(p.fieldId or "?")))
+    setText(self.hfGrain, p.fromZoneCell
         and tr("sf_handful_grain_spot", "spot")
-        or tr("sf_handful_grain_field", "field average")
-    setText(self.hfHeader, string.format("%s%s   ·   %s",
-        tr("sf_detail_field_label", "Field #"), tostring(p.fieldId or "?"), grain))
+        or tr("sf_handful_grain_field", "field average"))
 
     -- Nutrients (SPOT). Bands only: testKitActive is false until the kit ships.
-    setText(self.hfNutrients, string.format("%s    %s    %s",
-        pair(tr("sf_handful_n", "N"), bandNutrient(p.N)),
-        pair(tr("sf_handful_p", "P"), bandNutrient(p.P)),
-        pair(tr("sf_handful_k", "K"), bandNutrient(p.K))))
-    setText(self.hfPhOm, string.format("%s    %s",
-        pair(tr("sf_handful_ph", "pH"), bandPh(p.pH)),
-        pair(tr("sf_handful_om", "Organic matter"), bandOm(p.OM))))
+    tile(self.hfLblN,  self.hfValN,  tr("sf_handful_n", "N"),   bandNutrient(p.N))
+    tile(self.hfLblP,  self.hfValP,  tr("sf_handful_p", "P"),   bandNutrient(p.P))
+    tile(self.hfLblK,  self.hfValK,  tr("sf_handful_k", "K"),   bandNutrient(p.K))
+    tile(self.hfLblPh, self.hfValPh, tr("sf_handful_ph", "pH"), bandPh(p.pH))
+    tile(self.hfLblOm, self.hfValOm, tr("sf_handful_om", "Organic matter"), bandOm(p.OM))
 
     -- Ground: compaction is SPOT, moisture is FIELD and UNGATED, so moisture
     -- shows its real figure rather than a band it was never gated behind.
+    tile(self.hfLblComp, self.hfValComp,
+        tr("sf_handful_compaction", "Compaction"), bandCompaction(p.compaction))
     local moisture = type(p.moisture) == "number"
         and string.format("%d%%", math.floor(p.moisture * 100 + 0.5)) or nil
-    setText(self.hfGround, string.format("%s    %s",
-        pair(tr("sf_handful_compaction", "Compaction"), bandCompaction(p.compaction)),
-        pair(tr("sf_handful_moisture", "Moisture"), moisture)))
+    tile(self.hfLblMoist, self.hfValMoist,
+        tr("sf_handful_moisture", "Moisture"), moisture, "info")
 
     -- Disease: knowledge-gated. shownDiseasePressure is nil while unscouted and
-    -- that is the honest answer, not a hole. The grain label says whether this
-    -- is the knelt cell or the whole field.
-    local disTxt
+    -- that is the honest answer, not a hole. Unscouted takes the NEUTRAL colour,
+    -- never the green of None: an unlooked-at field has not earned a clean bill.
     if p.diseasePressure == nil then
-        disTxt = tr("sf_handful_unscouted", "Unscouted")
+        tile(self.hfLblDis, self.hfValDis, tr("sf_handful_disease", "Disease"),
+            tr("sf_handful_unscouted", "Unscouted"), "neutral")
     else
-        disTxt = bandPressure(p.diseasePressure) or DASH
+        tile(self.hfLblDis, self.hfValDis, tr("sf_handful_disease", "Disease"),
+            bandPressure(p.diseasePressure))
     end
-    local disGrain = (p.diseaseGrain == "cell")
+    -- The grain label rides its own line so the tile stays a tile.
+    setText(self.hfDisGrain, (p.diseaseGrain == "cell")
         and tr("sf_handful_grain_cell", "this cell")
-        or tr("sf_handful_grain_field", "field average")
-    setText(self.hfDisease, string.format("%s   (%s)",
-        pair(tr("sf_handful_disease", "Disease pressure"), disTxt), disGrain))
+        or tr("sf_handful_grain_field", "field average"))
 
     -- Pests and weeds: FIELD grain, UNGATED at source, so no knowledge gate here.
-    setText(self.hfPestWeed, string.format("%s    %s",
-        pair(tr("sf_handful_pest", "Pests"), bandPressure(p.pestPressure)),
-        pair(tr("sf_handful_weed", "Weeds"), bandPressure(p.weedPressure))))
+    tile(self.hfLblPest, self.hfValPest, tr("sf_handful_pest", "Pests"), bandPressure(p.pestPressure))
+    tile(self.hfLblWeed, self.hfValWeed, tr("sf_handful_weed", "Weeds"), bandPressure(p.weedPressure))
 
     -- History (FIELD).
     local crops = {}
@@ -272,18 +318,18 @@ function SoilHandfulDialog:_populate()
         local n = cropName(id)
         if n then crops[#crops + 1] = n end
     end
-    setText(self.hfCrops, pair(tr("sf_handful_last_crops", "Last crops"),
+    setText(self.hfCrops, row(tr("sf_handful_last_crops", "Last crops"),
         #crops > 0 and table.concat(crops, "  >  ") or nil))
 
     local rot = p.rotationStatus
         and tr("sf_handful_rot_" .. tostring(p.rotationStatus):lower(), tostring(p.rotationStatus))
         or nil
-    local rotLine = pair(tr("sf_handful_rotation", "Rotation"), rot)
+    local rotLine = row(tr("sf_handful_rotation", "Rotation"), rot)
     if (p.rotationBonusDaysLeft or 0) > 0 then
         rotLine = rotLine .. string.format("  (%s)", string.format(
             tr("sf_handful_bonus_days", "%d bonus days left"), p.rotationBonusDaysLeft))
     end
-    rotLine = rotLine .. string.format("    %s", pair(
+    rotLine = rotLine .. string.format("    %s", row(
         tr("sf_handful_since_harvest", "Days since harvest"),
         (p.daysSinceHarvest or 0) > 0 and tostring(p.daysSinceHarvest) or nil))
     setText(self.hfRotation, rotLine)
@@ -305,32 +351,31 @@ function SoilHandfulDialog:_populate()
                 tr("sf_handful_org_breaches", "%d breaches"), org.breaches))
         end
     end
-    setText(self.hfOrganic, pair(tr("sf_handful_organic", "Organic"), orgTxt))
+    setText(self.hfOrganic, row(tr("sf_handful_organic", "Organic"), orgTxt))
 
     -- Under the hand (SPOT). The whole section hides when nothing lies there:
-    -- an "unavailable" or "refusal" status is not a value to render.
+    -- an "unavailable" or "refusal" status is not a value to render. Hiding the
+    -- container hides its children too (GuiElement:getIsVisible walks parents).
     local wet, down, verdict = p.materialWetness, p.materialDaysDown, p.materialVerdict
     local hasMaterial = type(wet) == "table" and wet.band ~= nil
     setVisible(self.hfSecMaterial, hasMaterial)
-    setVisible(self.hfMaterial, hasMaterial)
     if hasMaterial then
-        local parts = {
-            pair(tr("sf_handful_mat_wetness", "Wetness"), bandMaterial(wet.band)),
-            pair(tr("sf_handful_mat_days", "Days down"),
-                (type(down) == "table" and down.days) and tostring(down.days) or nil),
-        }
+        tile(self.hfLblWet, self.hfValWet, tr("sf_handful_mat_wetness", "Wetness"), bandMaterial(wet.band))
+        tile(self.hfLblDown, self.hfValDown, tr("sf_handful_mat_days", "Days down"),
+            (type(down) == "table" and down.days) and tostring(down.days) or nil, "info")
+        local vTxt, vSev
         if type(verdict) == "table" and verdict.status == "ok" then
-            parts[#parts + 1] = pair(tr("sf_handful_mat_verdict", "Verdict"),
-                verdict.spoiled and tr("sf_handful_mat_spoiled", "Spoiled")
-                or tr("sf_handful_mat_sound", "Sound"))
+            if verdict.spoiled then
+                vTxt, vSev = tr("sf_handful_mat_spoiled", "Spoiled"), "poor"
+            else
+                vTxt, vSev = tr("sf_handful_mat_sound", "Sound"), "good"
+            end
         end
-        setText(self.hfMaterial, table.concat(parts, "    "))
+        tile(self.hfLblVerdict, self.hfValVerdict, tr("sf_handful_mat_verdict", "Verdict"), vTxt, vSev)
     end
 
-    -- Footer: the grain legend, and the kit state that explains why the numbers
-    -- above are words.
-    local kit = p.testKitActive
+    -- Footer: the kit state that explains why the readings above are words.
+    setText(self.hfFooter, p.testKitActive
         and tr("sf_handful_kit_yes", "Soil test kit in hand: exact figures")
-        or tr("sf_handful_kit_no", "No soil test kit: readings are by hand, so they are qualitative")
-    setText(self.hfFooter, kit)
+        or tr("sf_handful_kit_no", "No soil test kit: readings are by hand, so they are qualitative"))
 end

--- a/src/ui/SoilHandfulDialog.lua
+++ b/src/ui/SoilHandfulDialog.lua
@@ -1,0 +1,336 @@
+-- =========================================================
+-- FS25 Soil & Fertilizer - THE HANDFUL PANEL (SF-39)
+-- =========================================================
+-- The reading surface for the kneel. Renders the FROZEN SF-38 payload
+-- (HandfulRead.assemble) verbatim and writes nothing at all: no getter of its
+-- own, no re-scout, no touch on the walked mask. The kneel already did the one
+-- write in this member.
+--
+-- Opened by the SF_HANDFUL hotkey, and ONLY while the player is crouched -
+-- the precondition ladder lives in SoilFertilityManager:onHandfulInput.
+--
+-- Same ScreenElement + GUI-XML pattern as SoilScoutDialog / SoilTreatmentDialog.
+--
+-- RENDERING RULES (inherited cert gates from the SF-38 contract, not new):
+--   GRAIN HONESTY      - every section carries its grain tag; a FIELD clause is
+--                        never drawn as if it were measured at the spot.
+--   PER-CLAUSE NEUTRAL - one absent system blanks its own clause only. A nil
+--                        clause renders a dash, never a zero, never an error.
+--   NO PHANTOM FIELDS  - we render HandfulRead.CLAUSES and nothing else.
+--   BANDS, NOT NUMBERS - exact figures sit behind the test kit, and
+--                        HandfulRead readTestKit() is a hardcoded false until
+--                        the kit member ships. So gated clauses render as bands
+--                        ALWAYS in v1. That is the contract working, not a bug.
+--   NO NEW THRESHOLDS  - every band below reuses a shipped constant or a shipped
+--                        display rule; this file invents none.
+-- =========================================================
+-- Author: TisonK
+-- =========================================================
+
+---@class SoilHandfulDialog
+SoilHandfulDialog = {}
+local SoilHandfulDialog_mt = Class(SoilHandfulDialog, ScreenElement)
+
+local SF_HANDFUL_MOD_NAME = g_currentModName
+local SF_HANDFUL_MOD_DIR  = g_currentModDirectory
+
+SoilHandfulDialog.INSTANCE = nil
+SoilHandfulDialog.xmlPath  = nil
+
+local DASH = "--"
+
+-- ── i18n helper (same shape as the sibling dialogs) ───────
+-- Carries an English fallback for every key. A key that resolves nowhere still
+-- renders readable text instead of the engine's "Missing '...'" string.
+local function tr(key, fallback)
+    local modEnv = g_modEnvironments and g_modEnvironments[SF_HANDFUL_MOD_NAME]
+    local i18n = (modEnv and modEnv.i18n) or g_i18n
+    if i18n then
+        local ok, text = pcall(function() return i18n:getText(key) end)
+        if ok and text and text ~= "" and text ~= ("$l10n_" .. key) then
+            local lower = text:lower()
+            if not lower:find("^missing%s") and not lower:find("^missing_") then
+                return text
+            end
+        end
+    end
+    return fallback or key
+end
+
+-- ── Bands (every cut point below is a SHIPPED value) ──────
+
+-- N/P/K arrive from the core already banded: getFieldInfo returns
+-- { value, status } with status in Poor/Fair/Good/Unknown. We localise the word
+-- and never re-derive it.
+local function bandNutrient(clause)
+    if type(clause) ~= "table" or type(clause.status) ~= "string" then return nil end
+    local s = clause.status:lower()
+    return tr("sf_handful_band_" .. s, clause.status)
+end
+
+-- pH: SoilConstants.REPORT_COLORS, the same cut points the report display uses.
+local function bandPh(ph)
+    if type(ph) ~= "number" then return nil end
+    local rc = SoilConstants and SoilConstants.REPORT_COLORS
+    if rc == nil then return nil end
+    if ph >= (rc.PH_GOOD_LOW or 6.0) and ph <= (rc.PH_GOOD_HIGH or 7.0) then
+        return tr("sf_handful_band_good", "Good")
+    elseif ph < (rc.PH_FAIR_LOW or 5.5) then
+        return tr("sf_handful_band_acidic", "Acidic")
+    elseif ph > (rc.PH_FAIR_HIGH or 7.5) then
+        return tr("sf_handful_band_alkaline", "Alkaline")
+    end
+    return tr("sf_handful_band_fair", "Fair")
+end
+
+-- Organic matter: SoilConstants.REPORT_COLORS OM_GOOD / OM_FAIR.
+local function bandOm(om)
+    if type(om) ~= "number" then return nil end
+    local rc = SoilConstants and SoilConstants.REPORT_COLORS
+    if rc == nil then return nil end
+    if om >= (rc.OM_GOOD or 4.0) then return tr("sf_handful_band_good", "Good") end
+    if om >= (rc.OM_FAIR or 2.5) then return tr("sf_handful_band_fair", "Fair") end
+    return tr("sf_handful_band_poor", "Poor")
+end
+
+-- Compaction: the cut points the shipped map layer already displays against
+-- (SoilMapOverlay layer 10: <25 no action, <60 subsoiling recommended, else
+-- urgent). Reused rather than re-invented so the two surfaces never disagree.
+local function bandCompaction(c)
+    if type(c) ~= "number" then return nil end
+    if c < 25 then return tr("sf_handful_band_low", "Low") end
+    if c < 60 then return tr("sf_handful_band_moderate", "Moderate") end
+    return tr("sf_handful_band_high", "High")
+end
+
+-- Pressure tiers: SoilConstants.DISEASE_PRESSURE LOW/MEDIUM/HIGH, the same
+-- ladder scoutField uses for its tier word.
+local function bandPressure(v)
+    if type(v) ~= "number" then return nil end
+    local dp = SoilConstants and SoilConstants.DISEASE_PRESSURE
+    if dp == nil then return nil end
+    if v < (dp.LOW or 20) then return tr("sf_scout_tier_none", "None") end
+    if v < (dp.MEDIUM or 50) then return tr("sf_scout_tier_mild", "Mild") end
+    if v < (dp.HIGH or 75) then return tr("sf_scout_tier_moderate", "Moderate") end
+    return tr("sf_scout_tier_severe", "Severe")
+end
+
+-- Material bands arrive from the layers as lowercase ids ("damp", "curing").
+-- The l10n key carries the display word; the FALLBACK has to capitalise, or a
+-- missing key degrades to a lowercase word sitting next to capitalised ones.
+local function bandMaterial(band)
+    if type(band) ~= "string" or band == "" then return nil end
+    local lower = band:lower()
+    return tr("sf_handful_band_" .. lower, lower:sub(1, 1):upper() .. lower:sub(2))
+end
+
+local function cropName(id)
+    if type(id) ~= "string" or id == "" then return nil end
+    local key = "sf_crop_" .. id:lower()
+    if g_i18n and g_i18n:hasText(key) then return g_i18n:getText(key) end
+    return (id:gsub("_", " "))
+end
+
+-- ── Constructor / registration ────────────────────────────
+
+function SoilHandfulDialog.new(target, customMt)
+    local self = ScreenElement.new(target, customMt or SoilHandfulDialog_mt)
+    self._payload = nil
+    return self
+end
+
+function SoilHandfulDialog.register(modDirectory)
+    if SoilHandfulDialog.INSTANCE ~= nil then return end
+
+    SF_HANDFUL_MOD_DIR = modDirectory
+    SoilHandfulDialog.xmlPath = modDirectory .. "xml/gui/SoilHandfulDialog.xml"
+    SoilHandfulDialog.INSTANCE = SoilHandfulDialog.new()
+    SoilLogger.info("SoilHandfulDialog: registering from %s", SoilHandfulDialog.xmlPath)
+
+    local ok, err = pcall(function()
+        g_gui:loadGui(SoilHandfulDialog.xmlPath, "SoilHandfulDialog", SoilHandfulDialog.INSTANCE)
+    end)
+    if not ok then
+        SoilLogger.error("SoilHandfulDialog: loadGui failed: %s", tostring(err))
+        SoilHandfulDialog.INSTANCE = nil
+    else
+        SoilLogger.info("SoilHandfulDialog: registered successfully")
+    end
+end
+
+--- Open the panel on an assembled payload. The caller (the kneel) owns the
+--- precondition ladder; by the time we are called the read has happened.
+---@param payload table|nil  HandfulRead.assemble result
+function SoilHandfulDialog.show(payload)
+    if SoilHandfulDialog.INSTANCE == nil then
+        SoilHandfulDialog.register(SF_HANDFUL_MOD_DIR)
+    end
+    local inst = SoilHandfulDialog.INSTANCE
+    if inst == nil then return end
+    inst._payload = payload
+    g_gui:showDialog("SoilHandfulDialog")
+end
+
+-- ── Lifecycle ─────────────────────────────────────────────
+
+function SoilHandfulDialog:onGuiSetupFinished()
+    SoilHandfulDialog:superClass().onGuiSetupFinished(self)
+    self.hfHeader      = self:getDescendantById("hfHeader")
+    self.hfNutrients   = self:getDescendantById("hfNutrients")
+    self.hfPhOm        = self:getDescendantById("hfPhOm")
+    self.hfGround      = self:getDescendantById("hfGround")
+    self.hfDisease     = self:getDescendantById("hfDisease")
+    self.hfPestWeed    = self:getDescendantById("hfPestWeed")
+    self.hfCrops       = self:getDescendantById("hfCrops")
+    self.hfRotation    = self:getDescendantById("hfRotation")
+    self.hfOrganic     = self:getDescendantById("hfOrganic")
+    self.hfSecMaterial = self:getDescendantById("hfSecMaterial")
+    self.hfMaterial    = self:getDescendantById("hfMaterial")
+    self.hfFooter      = self:getDescendantById("hfFooter")
+end
+
+function SoilHandfulDialog:onOpen()
+    SoilHandfulDialog:superClass().onOpen(self)
+    self:_populate()
+end
+
+function SoilHandfulDialog:onClose()
+    SoilHandfulDialog:superClass().onClose(self)
+    self._payload = nil
+end
+
+function SoilHandfulDialog:onClickClose()
+    g_gui:closeDialogByName("SoilHandfulDialog")
+end
+
+-- ── Rendering ─────────────────────────────────────────────
+
+local function setText(el, text) if el then el:setText(text or "") end end
+local function setVisible(el, v) if el and el.setVisible then el:setVisible(v) end end
+
+--- "Label: value" with the neutral dash when the clause is absent. This is the
+--- per-clause neutrality rule in one function: nil never becomes 0.
+local function pair(label, value)
+    return string.format("%s: %s", label, value or DASH)
+end
+
+function SoilHandfulDialog:_populate()
+    local p = self._payload
+    if p == nil then
+        setText(self.hfHeader, tr("sf_handful_no_read", "Nothing read"))
+        return
+    end
+
+    -- Header: which field, and whether the nutrient row was refined to the spot.
+    -- ONE shared refinement flag for N/P/K/pH/OM, labelled once, per the contract.
+    local grain = p.fromZoneCell
+        and tr("sf_handful_grain_spot", "spot")
+        or tr("sf_handful_grain_field", "field average")
+    setText(self.hfHeader, string.format("%s%s   ·   %s",
+        tr("sf_detail_field_label", "Field #"), tostring(p.fieldId or "?"), grain))
+
+    -- Nutrients (SPOT). Bands only: testKitActive is false until the kit ships.
+    setText(self.hfNutrients, string.format("%s    %s    %s",
+        pair(tr("sf_handful_n", "N"), bandNutrient(p.N)),
+        pair(tr("sf_handful_p", "P"), bandNutrient(p.P)),
+        pair(tr("sf_handful_k", "K"), bandNutrient(p.K))))
+    setText(self.hfPhOm, string.format("%s    %s",
+        pair(tr("sf_handful_ph", "pH"), bandPh(p.pH)),
+        pair(tr("sf_handful_om", "Organic matter"), bandOm(p.OM))))
+
+    -- Ground: compaction is SPOT, moisture is FIELD and UNGATED, so moisture
+    -- shows its real figure rather than a band it was never gated behind.
+    local moisture = type(p.moisture) == "number"
+        and string.format("%d%%", math.floor(p.moisture * 100 + 0.5)) or nil
+    setText(self.hfGround, string.format("%s    %s",
+        pair(tr("sf_handful_compaction", "Compaction"), bandCompaction(p.compaction)),
+        pair(tr("sf_handful_moisture", "Moisture"), moisture)))
+
+    -- Disease: knowledge-gated. shownDiseasePressure is nil while unscouted and
+    -- that is the honest answer, not a hole. The grain label says whether this
+    -- is the knelt cell or the whole field.
+    local disTxt
+    if p.diseasePressure == nil then
+        disTxt = tr("sf_handful_unscouted", "Unscouted")
+    else
+        disTxt = bandPressure(p.diseasePressure) or DASH
+    end
+    local disGrain = (p.diseaseGrain == "cell")
+        and tr("sf_handful_grain_cell", "this cell")
+        or tr("sf_handful_grain_field", "field average")
+    setText(self.hfDisease, string.format("%s   (%s)",
+        pair(tr("sf_handful_disease", "Disease pressure"), disTxt), disGrain))
+
+    -- Pests and weeds: FIELD grain, UNGATED at source, so no knowledge gate here.
+    setText(self.hfPestWeed, string.format("%s    %s",
+        pair(tr("sf_handful_pest", "Pests"), bandPressure(p.pestPressure)),
+        pair(tr("sf_handful_weed", "Weeds"), bandPressure(p.weedPressure))))
+
+    -- History (FIELD).
+    local crops = {}
+    for _, id in ipairs({ p.lastCrop, p.lastCrop2, p.lastCrop3 }) do
+        local n = cropName(id)
+        if n then crops[#crops + 1] = n end
+    end
+    setText(self.hfCrops, pair(tr("sf_handful_last_crops", "Last crops"),
+        #crops > 0 and table.concat(crops, "  >  ") or nil))
+
+    local rot = p.rotationStatus
+        and tr("sf_handful_rot_" .. tostring(p.rotationStatus):lower(), tostring(p.rotationStatus))
+        or nil
+    local rotLine = pair(tr("sf_handful_rotation", "Rotation"), rot)
+    if (p.rotationBonusDaysLeft or 0) > 0 then
+        rotLine = rotLine .. string.format("  (%s)", string.format(
+            tr("sf_handful_bonus_days", "%d bonus days left"), p.rotationBonusDaysLeft))
+    end
+    rotLine = rotLine .. string.format("    %s", pair(
+        tr("sf_handful_since_harvest", "Days since harvest"),
+        (p.daysSinceHarvest or 0) > 0 and tostring(p.daysSinceHarvest) or nil))
+    setText(self.hfRotation, rotLine)
+
+    local org = p.organicState
+    local orgTxt
+    if type(org) == "table" then
+        if org.certified then
+            orgTxt = tr("sf_handful_org_certified", "Certified organic")
+        elseif (org.transitionDaysNeeded or 0) > 0 and (org.daysAccrued or 0) > 0 then
+            orgTxt = string.format("%s %d/%d",
+                tr("sf_handful_org_transition", "In transition"),
+                org.daysAccrued or 0, org.transitionDaysNeeded or 0)
+        else
+            orgTxt = tr("sf_handful_org_conventional", "Conventional")
+        end
+        if (org.breaches or 0) > 0 then
+            orgTxt = orgTxt .. string.format("  (%s)", string.format(
+                tr("sf_handful_org_breaches", "%d breaches"), org.breaches))
+        end
+    end
+    setText(self.hfOrganic, pair(tr("sf_handful_organic", "Organic"), orgTxt))
+
+    -- Under the hand (SPOT). The whole section hides when nothing lies there:
+    -- an "unavailable" or "refusal" status is not a value to render.
+    local wet, down, verdict = p.materialWetness, p.materialDaysDown, p.materialVerdict
+    local hasMaterial = type(wet) == "table" and wet.band ~= nil
+    setVisible(self.hfSecMaterial, hasMaterial)
+    setVisible(self.hfMaterial, hasMaterial)
+    if hasMaterial then
+        local parts = {
+            pair(tr("sf_handful_mat_wetness", "Wetness"), bandMaterial(wet.band)),
+            pair(tr("sf_handful_mat_days", "Days down"),
+                (type(down) == "table" and down.days) and tostring(down.days) or nil),
+        }
+        if type(verdict) == "table" and verdict.status == "ok" then
+            parts[#parts + 1] = pair(tr("sf_handful_mat_verdict", "Verdict"),
+                verdict.spoiled and tr("sf_handful_mat_spoiled", "Spoiled")
+                or tr("sf_handful_mat_sound", "Sound"))
+        end
+        setText(self.hfMaterial, table.concat(parts, "    "))
+    end
+
+    -- Footer: the grain legend, and the kit state that explains why the numbers
+    -- above are words.
+    local kit = p.testKitActive
+        and tr("sf_handful_kit_yes", "Soil test kit in hand: exact figures")
+        or tr("sf_handful_kit_no", "No soil test kit: readings are by hand, so they are qualitative")
+    setText(self.hfFooter, kit)
+end

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,13 @@ SoilVersionDialog.INSTANCE = nil
 -- Max 11 lines are visible in the box; if more exist we stop on a bullet boundary and add a "full changelog on GitHub" note.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- READ THE DIRT can finally be read. Kneel down in a field and press the",
+    "    handful key (Shift+G by default) to get everything the mod knows about",
+    "    that exact spot: nutrients, pH, organic matter, compaction, moisture,",
+    "    pressure, crop history and whatever cut material lies under your hand.",
+    "    You have to actually be crouching, and readings are qualitative until",
+    "    a soil test kit exists. Part of Read the Dirt, so it needs Experimental",
+    "    Systems turned on under Settings > Experimental.",
     "- Release gate: disease resistance, hybrids, tank mixes, ground material,",
     "    spatial soil and Read the Dirt now ship LOCKED until you release them.",
     "    Turn them on under Settings > Experimental, at your own risk. A stable",

--- a/tools/test/lua/handful_panel_sf39_test.lua
+++ b/tools/test/lua/handful_panel_sf39_test.lua
@@ -1,0 +1,219 @@
+-- handful_panel_sf39_test.lua - THE HANDFUL PANEL (SF-39)
+--
+-- The reading surface for the kneel. It renders the FROZEN SF-38 payload and
+-- writes nothing, so the whole bench is: given a payload, what text appears.
+--
+-- The properties locked here are the SF-38 cert gates as they land on a screen:
+--   PER-CLAUSE NEUTRALITY - an absent clause renders a dash. NEVER a zero. This
+--     is the one that actually bites: nil-defaulted-to-zero is how a panel tells
+--     a player their nitrogen is empty when the truth is that nobody measured it.
+--   GRAIN HONESTY - the disease line says whether it is the knelt cell or the
+--     whole field, driven by the payload's own diseaseGrain label.
+--   BANDS NOT NUMBERS - readTestKit() is a hardcoded false until the kit member
+--     ships, so every gated clause renders a word. A raw figure leaking onto the
+--     panel would be the kit bypassing its own gate.
+--   NO PHANTOM FIELDS - every clause the panel draws is a name in
+--     HandfulRead.CLAUSES; the panel invents no read of its own.
+--   THE MATERIAL SECTION HIDES when nothing lies under the hand, rather than
+--     rendering an "unavailable" status as if it were a measurement.
+--
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/config/SoilBlends.lua, src/SpatialScouting.lua, src/HandfulRead.lua, src/ui/SoilHandfulDialog.lua
+
+-- Force tr() down its fallback path so assertions read as the English the player
+-- sees, not as key names. getText returning "" is exactly the "key absent" case.
+g_i18n = { getText = function(_self, _key) return "" end, hasText = function() return false end }
+
+local function el()
+  local e = { text = "", visible = true }
+  e.setText = function(_self, t) e.text = t or "" end
+  e.setVisible = function(_self, v) e.visible = v end
+  return e
+end
+
+local IDS = {
+  "hfHeader", "hfNutrients", "hfPhOm", "hfGround", "hfDisease", "hfPestWeed",
+  "hfCrops", "hfRotation", "hfOrganic", "hfSecMaterial", "hfMaterial", "hfFooter",
+}
+
+local function newPanel(payload)
+  local self = { _payload = payload }
+  for _, id in ipairs(IDS) do self[id] = el() end
+  return self
+end
+
+local function render(payload)
+  local p = newPanel(payload)
+  SoilHandfulDialog._populate(p)
+  return p
+end
+
+-- Sentinel for "override this clause to absent". A literal nil cannot do the job:
+-- assigning nil to a table key removes it, so pairs() never sees the override and
+-- the clause silently keeps its healthy value. That misfire is exactly how an
+-- absent-clause test passes while testing nothing.
+local NIL = {}
+
+-- A full, healthy payload in the exact shape HandfulRead.assemble returns.
+local function fullPayload(over)
+  local p = {
+    fieldId = 7,
+    fromZoneCell = true,
+    N = { value = 42, status = "Good" },
+    P = { value = 30, status = "Fair" },
+    K = { value = 12, status = "Poor" },
+    pH = 6.5,
+    OM = 4.2,
+    compaction = 18,
+    moisture = 0.47,
+    diseasePressure = 60,
+    diseaseGrain = "cell",
+    diseaseKnown = true,
+    pestPressure = 10,
+    weedPressure = 55,
+    lastCrop = "wheat", lastCrop2 = "barley", lastCrop3 = "canola",
+    rotationStatus = "Bonus",
+    rotationBonusDaysLeft = 5,
+    daysSinceHarvest = 12,
+    organicState = { state = 2, daysAccrued = 40, transitionDaysNeeded = 90, certified = false, breaches = 0 },
+    materialWetness = { pct = 30, band = "damp" },
+    materialDaysDown = { days = 3, band = "settling" },
+    materialVerdict = { status = "ok", spoiled = false },
+    testKitActive = false,
+    clauses = HandfulRead.CLAUSES,
+  }
+  for k, v in pairs(over or {}) do
+    if v == NIL then p[k] = nil else p[k] = v end
+  end
+  return p
+end
+
+local function has(s, sub) return type(s) == "string" and s:find(sub, 1, true) ~= nil end
+
+-- ── PER-CLAUSE NEUTRALITY: absent is a dash, never a zero ───────────────────
+do
+  -- Every optional clause stripped at once: one absent system must not take the
+  -- panel down with it, and must not become a confident zero.
+  local p = render({ fieldId = 3, clauses = HandfulRead.CLAUSES })
+
+  T.ok("an empty payload still renders a header", has(p.hfHeader.text, "3"))
+  T.ok("absent N renders a dash", has(p.hfNutrients.text, "--"))
+  T.ok("absent N never renders as zero", not has(p.hfNutrients.text, ": 0"))
+  T.ok("absent pH and OM render dashes", has(p.hfPhOm.text, "--"))
+  T.ok("absent compaction renders a dash", has(p.hfGround.text, "--"))
+  T.ok("absent moisture never renders 0%", not has(p.hfGround.text, "0%"))
+  T.ok("absent crop history renders a dash", has(p.hfCrops.text, "--"))
+  T.ok("absent organic state renders a dash", has(p.hfOrganic.text, "--"))
+end
+
+do
+  -- The narrow case the rule exists for: SCS absent blanks moisture ONLY, and
+  -- every neighbouring clause on the same row survives.
+  local p = render(fullPayload({ moisture = NIL }))
+  T.ok("SCS absent blanks moisture alone", has(p.hfGround.text, "--"))
+  T.ok("SCS absent leaves compaction intact", has(p.hfGround.text, "Low"))
+  T.ok("SCS absent leaves the nutrient row intact", has(p.hfNutrients.text, "Good"))
+end
+
+-- ── BANDS, NOT NUMBERS ──────────────────────────────────────────────────────
+do
+  local p = render(fullPayload())
+  T.ok("N renders its band word", has(p.hfNutrients.text, "Good"))
+  T.ok("P renders its band word", has(p.hfNutrients.text, "Fair"))
+  T.ok("K renders its band word", has(p.hfNutrients.text, "Poor"))
+  -- The kit is false, so the raw figure must not reach the screen.
+  T.ok("the raw N figure never leaks while the kit is absent", not has(p.hfNutrients.text, "42"))
+  T.ok("the footer explains why the readings are words", has(p.hfFooter.text, "No soil test kit"))
+end
+
+do
+  -- pH bands ride SoilConstants.REPORT_COLORS; no threshold is invented here.
+  local rc = SoilConstants.REPORT_COLORS
+  T.ok("pH inside the good band reads Good",
+    has(render(fullPayload({ pH = rc.PH_GOOD_LOW })).hfPhOm.text, "Good"))
+  T.ok("pH below the fair floor reads Acidic",
+    has(render(fullPayload({ pH = rc.PH_FAIR_LOW - 0.1 })).hfPhOm.text, "Acidic"))
+  T.ok("pH above the fair ceiling reads Alkaline",
+    has(render(fullPayload({ pH = rc.PH_FAIR_HIGH + 0.1 })).hfPhOm.text, "Alkaline"))
+  T.ok("OM under the fair floor reads Poor",
+    has(render(fullPayload({ OM = rc.OM_FAIR - 0.1 })).hfPhOm.text, "Poor"))
+end
+
+do
+  -- Compaction reuses the cut points the shipped map layer displays against.
+  T.ok("compaction under 25 reads Low",     has(render(fullPayload({ compaction = 24 })).hfGround.text, "Low"))
+  T.ok("compaction at 25 reads Moderate",   has(render(fullPayload({ compaction = 25 })).hfGround.text, "Moderate"))
+  T.ok("compaction at 60 reads High",       has(render(fullPayload({ compaction = 60 })).hfGround.text, "High"))
+end
+
+do
+  -- Pressure tiers ride SoilConstants.DISEASE_PRESSURE, the same ladder scoutField uses.
+  local dp = SoilConstants.DISEASE_PRESSURE
+  T.ok("pressure below LOW reads None",     has(render(fullPayload({ pestPressure = dp.LOW - 1 })).hfPestWeed.text, "None"))
+  T.ok("pressure at LOW reads Mild",        has(render(fullPayload({ pestPressure = dp.LOW })).hfPestWeed.text, "Mild"))
+  T.ok("pressure at MEDIUM reads Moderate", has(render(fullPayload({ pestPressure = dp.MEDIUM })).hfPestWeed.text, "Moderate"))
+  T.ok("pressure at HIGH reads Severe",     has(render(fullPayload({ pestPressure = dp.HIGH })).hfPestWeed.text, "Severe"))
+end
+
+-- ── GRAIN HONESTY ───────────────────────────────────────────────────────────
+do
+  T.ok("a knelt cell is labelled as this cell",
+    has(render(fullPayload({ diseaseGrain = "cell" })).hfDisease.text, "this cell"))
+  T.ok("field grain is labelled as the field average",
+    has(render(fullPayload({ diseaseGrain = "field" })).hfDisease.text, "field average"))
+  T.ok("a refined nutrient read is labelled spot",
+    has(render(fullPayload({ fromZoneCell = true })).hfHeader.text, "spot"))
+  T.ok("an unrefined nutrient read is labelled field average",
+    has(render(fullPayload({ fromZoneCell = false })).hfHeader.text, "field average"))
+end
+
+do
+  -- The knowledge gate: shownDiseasePressure is nil until scouted, and that is an
+  -- answer, not a hole. Rendering it as None would sell a clean bill of health
+  -- for a field nobody has looked at.
+  local p = render(fullPayload({ diseasePressure = NIL }))
+  T.ok("unscouted disease says so", has(p.hfDisease.text, "Unscouted"))
+  T.ok("unscouted disease never reads as None", not has(p.hfDisease.text, "None"))
+  T.ok("unscouted disease never reads as zero", not has(p.hfDisease.text, ": 0"))
+end
+
+-- ── THE MATERIAL SECTION HIDES WHEN THERE IS NOTHING UNDER THE HAND ─────────
+do
+  local shown = render(fullPayload())
+  T.ok("material section shows when material lies there", shown.hfSecMaterial.visible == true)
+  T.ok("material row renders its wetness band", has(shown.hfMaterial.text, "Damp"))
+  T.ok("material row renders days down", has(shown.hfMaterial.text, "3"))
+  T.ok("a sound verdict renders", has(shown.hfMaterial.text, "Sound"))
+
+  local bare = render(fullPayload({
+    materialWetness  = { status = "unavailable" },
+    materialDaysDown = { status = "unavailable" },
+    materialVerdict  = { status = "refusal", reason = "no material fill type supplied" },
+  }))
+  T.ok("material section hides on an absent-material payload", bare.hfSecMaterial.visible == false)
+  T.ok("material row hides too", bare.hfMaterial.visible == false)
+  T.ok("a refusal status is never rendered as a value", not has(bare.hfMaterial.text, "unavailable"))
+end
+
+-- ── NO PHANTOM FIELDS ───────────────────────────────────────────────────────
+do
+  -- Every clause the panel draws must be a name the frozen contract publishes.
+  local known = {}
+  for _, name in ipairs(HandfulRead.CLAUSES) do known[name] = true end
+  local drawn = {
+    "N", "P", "K", "pH", "OM", "compaction", "moisture", "diseasePressure",
+    "pestPressure", "weedPressure", "lastCrop", "lastCrop2", "lastCrop3",
+    "rotationStatus", "rotationBonusDaysLeft", "daysSinceHarvest", "organicState",
+    "materialWetness", "materialDaysDown", "materialVerdict", "testKitActive",
+  }
+  local missing = nil
+  for _, name in ipairs(drawn) do
+    if not known[name] then missing = name break end
+  end
+  T.ok("the panel draws only clauses the frozen contract publishes", missing == nil, missing)
+end
+
+-- ── A nil payload must not crash the surface ────────────────────────────────
+do
+  local p = render(nil)
+  T.ok("a nil payload renders a spoken refusal", has(p.hfHeader.text, "Nothing read"))
+end

--- a/tools/test/lua/handful_panel_sf39_test.lua
+++ b/tools/test/lua/handful_panel_sf39_test.lua
@@ -1,13 +1,16 @@
 -- handful_panel_sf39_test.lua - THE HANDFUL PANEL (SF-39)
 --
 -- The reading surface for the kneel. It renders the FROZEN SF-38 payload and
--- writes nothing, so the whole bench is: given a payload, what text appears.
+-- writes nothing, so the whole bench is: given a payload, what appears.
 --
 -- The properties locked here are the SF-38 cert gates as they land on a screen:
 --   PER-CLAUSE NEUTRALITY - an absent clause renders a dash. NEVER a zero. This
 --     is the one that actually bites: nil-defaulted-to-zero is how a panel tells
 --     a player their nitrogen is empty when the truth is that nobody measured it.
---   GRAIN HONESTY - the disease line says whether it is the knelt cell or the
+--   COLOUR IS A SECOND CHANNEL - the word always says the thing, and an absent
+--     or unknown reading takes the NEUTRAL grey. A clause nobody measured must
+--     never wear a severity colour, or absence reads as a verdict.
+--   GRAIN HONESTY - the disease tile says whether it is the knelt cell or the
 --     whole field, driven by the payload's own diseaseGrain label.
 --   BANDS NOT NUMBERS - readTestKit() is a hardcoded false until the kit member
 --     ships, so every gated clause renders a word. A raw figure leaking onto the
@@ -24,25 +27,27 @@
 g_i18n = { getText = function(_self, _key) return "" end, hasText = function() return false end }
 
 local function el()
-  local e = { text = "", visible = true }
+  local e = { text = "", visible = true, color = nil }
   e.setText = function(_self, t) e.text = t or "" end
   e.setVisible = function(_self, v) e.visible = v end
+  e.setTextColor = function(_self, r, g, b, a) e.color = { r, g, b, a } end
   return e
 end
 
 local IDS = {
-  "hfHeader", "hfNutrients", "hfPhOm", "hfGround", "hfDisease", "hfPestWeed",
-  "hfCrops", "hfRotation", "hfOrganic", "hfSecMaterial", "hfMaterial", "hfFooter",
+  "hfField", "hfGrain",
+  "hfLblN", "hfValN", "hfLblP", "hfValP", "hfLblK", "hfValK",
+  "hfLblPh", "hfValPh", "hfLblOm", "hfValOm",
+  "hfLblComp", "hfValComp", "hfLblMoist", "hfValMoist",
+  "hfLblDis", "hfValDis", "hfLblPest", "hfValPest", "hfLblWeed", "hfValWeed",
+  "hfDisGrain", "hfCrops", "hfRotation", "hfOrganic",
+  "hfSecMaterial", "hfLblWet", "hfValWet", "hfLblDown", "hfValDown",
+  "hfLblVerdict", "hfValVerdict", "hfFooter",
 }
 
-local function newPanel(payload)
-  local self = { _payload = payload }
-  for _, id in ipairs(IDS) do self[id] = el() end
-  return self
-end
-
 local function render(payload)
-  local p = newPanel(payload)
+  local p = { _payload = payload }
+  for _, id in ipairs(IDS) do p[id] = el() end
   SoilHandfulDialog._populate(p)
   return p
 end
@@ -88,6 +93,11 @@ local function fullPayload(over)
 end
 
 local function has(s, sub) return type(s) == "string" and s:find(sub, 1, true) ~= nil end
+local function sameColor(a, b)
+  if type(a) ~= "table" or type(b) ~= "table" then return false end
+  for i = 1, 4 do if a[i] ~= b[i] then return false end end
+  return true
+end
 
 -- ── PER-CLAUSE NEUTRALITY: absent is a dash, never a zero ───────────────────
 do
@@ -95,94 +105,127 @@ do
   -- panel down with it, and must not become a confident zero.
   local p = render({ fieldId = 3, clauses = HandfulRead.CLAUSES })
 
-  T.ok("an empty payload still renders a header", has(p.hfHeader.text, "3"))
-  T.ok("absent N renders a dash", has(p.hfNutrients.text, "--"))
-  T.ok("absent N never renders as zero", not has(p.hfNutrients.text, ": 0"))
-  T.ok("absent pH and OM render dashes", has(p.hfPhOm.text, "--"))
-  T.ok("absent compaction renders a dash", has(p.hfGround.text, "--"))
-  T.ok("absent moisture never renders 0%", not has(p.hfGround.text, "0%"))
+  T.ok("an empty payload still names the field", has(p.hfField.text, "3"))
+  T.eq("absent N renders a dash", p.hfValN.text, "--")
+  T.eq("absent pH renders a dash", p.hfValPh.text, "--")
+  T.eq("absent compaction renders a dash", p.hfValComp.text, "--")
+  T.eq("absent moisture renders a dash, not 0%", p.hfValMoist.text, "--")
   T.ok("absent crop history renders a dash", has(p.hfCrops.text, "--"))
   T.ok("absent organic state renders a dash", has(p.hfOrganic.text, "--"))
 end
 
 do
   -- The narrow case the rule exists for: SCS absent blanks moisture ONLY, and
-  -- every neighbouring clause on the same row survives.
+  -- every neighbouring clause survives.
   local p = render(fullPayload({ moisture = NIL }))
-  T.ok("SCS absent blanks moisture alone", has(p.hfGround.text, "--"))
-  T.ok("SCS absent leaves compaction intact", has(p.hfGround.text, "Low"))
-  T.ok("SCS absent leaves the nutrient row intact", has(p.hfNutrients.text, "Good"))
+  T.eq("SCS absent blanks moisture alone", p.hfValMoist.text, "--")
+  T.ok("SCS absent leaves compaction intact", has(p.hfValComp.text, "Low"))
+  T.ok("SCS absent leaves the nutrient tiles intact", has(p.hfValN.text, "Good"))
+end
+
+-- ── COLOUR IS A SECOND CHANNEL, AND ABSENCE IS NOT A VERDICT ────────────────
+do
+  local absent  = render({ fieldId = 1 })
+  local healthy = render(fullPayload())
+  T.ok("an absent clause takes a colour", absent.hfValN.color ~= nil)
+  T.ok("an absent clause does NOT wear the colour of a good reading",
+    not sameColor(absent.hfValN.color, healthy.hfValN.color))
+  T.ok("every absent clause shares one neutral colour",
+    sameColor(absent.hfValN.color, absent.hfValComp.color))
+end
+
+do
+  -- Good, fair and poor must be three visibly different colours, or the second
+  -- channel carries no information at all.
+  local p = render(fullPayload())
+  T.ok("good and fair differ in colour",  not sameColor(p.hfValN.color, p.hfValP.color))
+  T.ok("fair and poor differ in colour",  not sameColor(p.hfValP.color, p.hfValK.color))
+  T.ok("good and poor differ in colour",  not sameColor(p.hfValN.color, p.hfValK.color))
 end
 
 -- ── BANDS, NOT NUMBERS ──────────────────────────────────────────────────────
 do
   local p = render(fullPayload())
-  T.ok("N renders its band word", has(p.hfNutrients.text, "Good"))
-  T.ok("P renders its band word", has(p.hfNutrients.text, "Fair"))
-  T.ok("K renders its band word", has(p.hfNutrients.text, "Poor"))
-  -- The kit is false, so the raw figure must not reach the screen.
-  T.ok("the raw N figure never leaks while the kit is absent", not has(p.hfNutrients.text, "42"))
+  T.eq("N renders its band word", p.hfValN.text, "Good")
+  T.eq("P renders its band word", p.hfValP.text, "Fair")
+  T.eq("K renders its band word", p.hfValK.text, "Poor")
+  T.ok("the raw N figure never leaks while the kit is absent", not has(p.hfValN.text, "42"))
   T.ok("the footer explains why the readings are words", has(p.hfFooter.text, "No soil test kit"))
 end
 
 do
   -- pH bands ride SoilConstants.REPORT_COLORS; no threshold is invented here.
   local rc = SoilConstants.REPORT_COLORS
-  T.ok("pH inside the good band reads Good",
-    has(render(fullPayload({ pH = rc.PH_GOOD_LOW })).hfPhOm.text, "Good"))
-  T.ok("pH below the fair floor reads Acidic",
-    has(render(fullPayload({ pH = rc.PH_FAIR_LOW - 0.1 })).hfPhOm.text, "Acidic"))
-  T.ok("pH above the fair ceiling reads Alkaline",
-    has(render(fullPayload({ pH = rc.PH_FAIR_HIGH + 0.1 })).hfPhOm.text, "Alkaline"))
-  T.ok("OM under the fair floor reads Poor",
-    has(render(fullPayload({ OM = rc.OM_FAIR - 0.1 })).hfPhOm.text, "Poor"))
+  T.eq("pH inside the good band reads Good",
+    render(fullPayload({ pH = rc.PH_GOOD_LOW })).hfValPh.text, "Good")
+  T.eq("pH below the fair floor reads Acidic",
+    render(fullPayload({ pH = rc.PH_FAIR_LOW - 0.1 })).hfValPh.text, "Acidic")
+  T.eq("pH above the fair ceiling reads Alkaline",
+    render(fullPayload({ pH = rc.PH_FAIR_HIGH + 0.1 })).hfValPh.text, "Alkaline")
+  T.eq("OM under the fair floor reads Poor",
+    render(fullPayload({ OM = rc.OM_FAIR - 0.1 })).hfValOm.text, "Poor")
 end
 
 do
   -- Compaction reuses the cut points the shipped map layer displays against.
-  T.ok("compaction under 25 reads Low",     has(render(fullPayload({ compaction = 24 })).hfGround.text, "Low"))
-  T.ok("compaction at 25 reads Moderate",   has(render(fullPayload({ compaction = 25 })).hfGround.text, "Moderate"))
-  T.ok("compaction at 60 reads High",       has(render(fullPayload({ compaction = 60 })).hfGround.text, "High"))
+  -- Its polarity is inverted from the nutrients: LOW compaction is the GOOD one,
+  -- so the colour has to follow the meaning rather than the word.
+  local low  = render(fullPayload({ compaction = 24 }))
+  local high = render(fullPayload({ compaction = 60 }))
+  T.eq("compaction under 25 reads Low",   low.hfValComp.text, "Low")
+  T.eq("compaction at 25 reads Moderate", render(fullPayload({ compaction = 25 })).hfValComp.text, "Moderate")
+  T.eq("compaction at 60 reads High",     high.hfValComp.text, "High")
+  T.ok("LOW compaction is coloured as the good outcome",
+    sameColor(low.hfValComp.color, render(fullPayload()).hfValN.color))
+  T.ok("HIGH compaction is not coloured as good",
+    not sameColor(high.hfValComp.color, low.hfValComp.color))
 end
 
 do
   -- Pressure tiers ride SoilConstants.DISEASE_PRESSURE, the same ladder scoutField uses.
   local dp = SoilConstants.DISEASE_PRESSURE
-  T.ok("pressure below LOW reads None",     has(render(fullPayload({ pestPressure = dp.LOW - 1 })).hfPestWeed.text, "None"))
-  T.ok("pressure at LOW reads Mild",        has(render(fullPayload({ pestPressure = dp.LOW })).hfPestWeed.text, "Mild"))
-  T.ok("pressure at MEDIUM reads Moderate", has(render(fullPayload({ pestPressure = dp.MEDIUM })).hfPestWeed.text, "Moderate"))
-  T.ok("pressure at HIGH reads Severe",     has(render(fullPayload({ pestPressure = dp.HIGH })).hfPestWeed.text, "Severe"))
+  T.eq("pressure below LOW reads None",     render(fullPayload({ pestPressure = dp.LOW - 1 })).hfValPest.text, "None")
+  T.eq("pressure at LOW reads Mild",        render(fullPayload({ pestPressure = dp.LOW })).hfValPest.text, "Mild")
+  T.eq("pressure at MEDIUM reads Moderate", render(fullPayload({ pestPressure = dp.MEDIUM })).hfValPest.text, "Moderate")
+  T.eq("pressure at HIGH reads Severe",     render(fullPayload({ pestPressure = dp.HIGH })).hfValPest.text, "Severe")
 end
 
 -- ── GRAIN HONESTY ───────────────────────────────────────────────────────────
 do
   T.ok("a knelt cell is labelled as this cell",
-    has(render(fullPayload({ diseaseGrain = "cell" })).hfDisease.text, "this cell"))
+    has(render(fullPayload({ diseaseGrain = "cell" })).hfDisGrain.text, "this cell"))
   T.ok("field grain is labelled as the field average",
-    has(render(fullPayload({ diseaseGrain = "field" })).hfDisease.text, "field average"))
+    has(render(fullPayload({ diseaseGrain = "field" })).hfDisGrain.text, "field average"))
   T.ok("a refined nutrient read is labelled spot",
-    has(render(fullPayload({ fromZoneCell = true })).hfHeader.text, "spot"))
+    has(render(fullPayload({ fromZoneCell = true })).hfGrain.text, "spot"))
   T.ok("an unrefined nutrient read is labelled field average",
-    has(render(fullPayload({ fromZoneCell = false })).hfHeader.text, "field average"))
+    has(render(fullPayload({ fromZoneCell = false })).hfGrain.text, "field average"))
 end
 
 do
   -- The knowledge gate: shownDiseasePressure is nil until scouted, and that is an
   -- answer, not a hole. Rendering it as None would sell a clean bill of health
-  -- for a field nobody has looked at.
-  local p = render(fullPayload({ diseasePressure = NIL }))
-  T.ok("unscouted disease says so", has(p.hfDisease.text, "Unscouted"))
-  T.ok("unscouted disease never reads as None", not has(p.hfDisease.text, "None"))
-  T.ok("unscouted disease never reads as zero", not has(p.hfDisease.text, ": 0"))
+  -- for a field nobody has looked at - in the word AND in the colour.
+  local unscouted = render(fullPayload({ diseasePressure = NIL }))
+  local clean     = render(fullPayload({ diseasePressure = 0 }))
+  T.eq("unscouted disease says so", unscouted.hfValDis.text, "Unscouted")
+  T.eq("a genuinely clean field reads None", clean.hfValDis.text, "None")
+  T.ok("unscouted is NOT painted with the green of a clean field",
+    not sameColor(unscouted.hfValDis.color, clean.hfValDis.color))
 end
 
 -- ── THE MATERIAL SECTION HIDES WHEN THERE IS NOTHING UNDER THE HAND ─────────
 do
   local shown = render(fullPayload())
   T.ok("material section shows when material lies there", shown.hfSecMaterial.visible == true)
-  T.ok("material row renders its wetness band", has(shown.hfMaterial.text, "Damp"))
-  T.ok("material row renders days down", has(shown.hfMaterial.text, "3"))
-  T.ok("a sound verdict renders", has(shown.hfMaterial.text, "Sound"))
+  T.eq("material renders its wetness band", shown.hfValWet.text, "Damp")
+  T.eq("material renders days down", shown.hfValDown.text, "3")
+  T.eq("a sound verdict renders", shown.hfValVerdict.text, "Sound")
+
+  local spoiled = render(fullPayload({ materialVerdict = { status = "ok", spoiled = true } }))
+  T.eq("a spoiled verdict renders", spoiled.hfValVerdict.text, "Spoiled")
+  T.ok("spoiled and sound differ in colour",
+    not sameColor(spoiled.hfValVerdict.color, shown.hfValVerdict.color))
 
   local bare = render(fullPayload({
     materialWetness  = { status = "unavailable" },
@@ -190,8 +233,7 @@ do
     materialVerdict  = { status = "refusal", reason = "no material fill type supplied" },
   }))
   T.ok("material section hides on an absent-material payload", bare.hfSecMaterial.visible == false)
-  T.ok("material row hides too", bare.hfMaterial.visible == false)
-  T.ok("a refusal status is never rendered as a value", not has(bare.hfMaterial.text, "unavailable"))
+  T.ok("a refusal status is never rendered as a value", not has(bare.hfValWet.text, "unavailable"))
 end
 
 -- ── NO PHANTOM FIELDS ───────────────────────────────────────────────────────
@@ -215,5 +257,5 @@ end
 -- ── A nil payload must not crash the surface ────────────────────────────────
 do
   local p = render(nil)
-  T.ok("a nil payload renders a spoken refusal", has(p.hfHeader.text, "Nothing read"))
+  T.ok("a nil payload renders a spoken refusal", has(p.hfField.text, "Nothing read"))
 end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1383,6 +1383,60 @@
     <e k="wc_rf_pda_open_manager" v="Abrir gerenciador de trabalhadores" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planejador de rotação" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detalhe do campo" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1437,6 +1437,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -1357,5 +1357,59 @@
     <e k="wc_rf_pda_open_manager" v="Otevřít správce pracovníků" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Plánovač osevního postupu" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detail pole" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 </l10n>

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -1411,5 +1411,6 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1395,5 +1395,59 @@
     <e k="wc_rf_pda_open_manager" v="開啟工人管理員" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="輪作規劃" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="田地詳情" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1449,5 +1449,6 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1429,6 +1429,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1375,6 +1375,60 @@
     <e k="wc_rf_pda_open_manager" v="Otevřít správce pracovníků" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Plánovač osevního postupu" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detail pole" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1386,5 +1386,6 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 </l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1332,5 +1332,59 @@
     <e k="wc_rf_pda_open_manager" v="Åbn medarbejderstyring" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Rotationsplanlægger" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Markdetaljer" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1407,6 +1407,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1353,6 +1353,60 @@
     <e k="wc_rf_pda_open_manager" v="Arbeitermanager öffnen" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Fruchtfolgeplaner" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Felddetails" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1335,6 +1335,60 @@
     <e k="wc_rf_pda_open_manager" v="Abrir gestor de trabajadores" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planificador de rotación" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detalle del campo" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1389,6 +1389,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1401,5 +1401,59 @@
     <e k="wc_rf_pda_open_manager" v="Open Worker Manager" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Rotation Planner" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Field Detail" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1455,5 +1455,6 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1335,6 +1335,60 @@
     <e k="wc_rf_pda_open_manager" v="Abrir gestor de trabajadores" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planificador de rotación" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detalle del campo" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1389,6 +1389,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1395,5 +1395,59 @@
     <e k="wc_rf_pda_open_manager" v="Ouvrir le gestionnaire d'ouvriers" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planificateur de rotation" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Détail du champ" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 </l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1449,5 +1449,6 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1336,6 +1336,60 @@
     <e k="wc_rf_pda_open_manager" v="Avaa työntekijähallinta" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Viljelykiertosuunnittelija" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Pellon tiedot" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1390,6 +1390,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1389,5 +1389,6 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1335,5 +1335,59 @@
     <e k="wc_rf_pda_open_manager" v="Ouvrir le gestionnaire d'ouvriers" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planificateur de rotation" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Détail du champ" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1409,6 +1409,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1355,6 +1355,60 @@
     <e k="wc_rf_pda_open_manager" v="Dolgozókezelő megnyitása" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Vetésforgó-tervező" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Táblarészletek" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1436,6 +1436,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1382,6 +1382,60 @@
     <e k="wc_rf_pda_open_manager" v="Buka manajer pekerja" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Perencana rotasi" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detail lahan" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1436,6 +1436,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1382,6 +1382,60 @@
     <e k="wc_rf_pda_open_manager" v="Apri gestore operai" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Pianificatore rotazioni" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Dettaglio campo" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1416,6 +1416,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1362,6 +1362,60 @@
     <e k="wc_rf_pda_open_manager" v="作業員マネージャーを開く" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="輪作プランナー" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="畑の詳細" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1363,6 +1363,60 @@
     <e k="wc_rf_pda_open_manager" v="작업자 관리자 열기" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="윤작 계획기" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="밯 상세" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1417,6 +1417,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1366,6 +1366,60 @@
     <e k="wc_rf_pda_open_manager" v="Werkersbeheer openen" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Rotatieplanner" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Veldgegevens" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1420,6 +1420,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1418,6 +1418,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1364,6 +1364,60 @@
     <e k="wc_rf_pda_open_manager" v="Åpne arbeiderbehandler" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Rotasjonsplanlegger" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Feltdetaljer" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1418,6 +1418,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1364,6 +1364,60 @@
     <e k="wc_rf_pda_open_manager" v="Otwórz menedżera pracowników" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planer płodozmianu" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Szczegóły pola" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1437,6 +1437,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1383,6 +1383,60 @@
     <e k="wc_rf_pda_open_manager" v="Abrir gestor de trabalhadores" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planeador de rotação" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detalhe do campo" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1383,6 +1383,60 @@
     <e k="wc_rf_pda_open_manager" v="Deschide managerul de muncitori" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planificator de rotație" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detaliu câmp" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1437,6 +1437,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1378,6 +1378,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1324,6 +1324,60 @@
     <e k="wc_rf_pda_open_manager" v="Открыть менеджер работников" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Планировщик севооборота" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Сведения о поле" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1335,6 +1335,60 @@
     <e k="wc_rf_pda_open_manager" v="Öppna arbetshanteraren" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Växtföljdsplanerare" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Fältdetaljer" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1389,6 +1389,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1336,6 +1336,60 @@
     <e k="wc_rf_pda_open_manager" v="İşçi yöneticisini aç" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Ekim nöbeti planlayıcı" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Tarla detayı" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1390,6 +1390,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1335,6 +1335,60 @@
     <e k="wc_rf_pda_open_manager" v="Відкрити менеджер працівників" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Планувальник сівозміни" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Деталі поля" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1389,6 +1389,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1335,6 +1335,60 @@
     <e k="wc_rf_pda_open_manager" v="Mở trình quản lý công nhân" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Lập kế hoạch luân canh" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Chi tiết thửa ruộng" eh="03b5acd7" />
+    <e k="sf_handful_title" v="The Handful" />
+    <e k="sf_handful_sec_nutrients" v="NUTRIENTS" />
+    <e k="sf_handful_sec_ground" v="GROUND" />
+    <e k="sf_handful_sec_pressure" v="PRESSURE" />
+    <e k="sf_handful_sec_history" v="FIELD HISTORY" />
+    <e k="sf_handful_sec_material" v="UNDER THE HAND" />
+    <e k="sf_handful_need_kneel" v="Kneel down to read the soil" />
+    <e k="sf_handful_no_read" v="Nothing to read here" />
+    <e k="sf_handful_n" v="N" />
+    <e k="sf_handful_p" v="P" />
+    <e k="sf_handful_k" v="K" />
+    <e k="sf_handful_ph" v="pH" />
+    <e k="sf_handful_om" v="Organic matter" />
+    <e k="sf_handful_compaction" v="Compaction" />
+    <e k="sf_handful_moisture" v="Moisture" />
+    <e k="sf_handful_disease" v="Disease pressure" />
+    <e k="sf_handful_pest" v="Pests" />
+    <e k="sf_handful_weed" v="Weeds" />
+    <e k="sf_handful_last_crops" v="Last crops" />
+    <e k="sf_handful_rotation" v="Rotation" />
+    <e k="sf_handful_bonus_days" v="%d bonus days left" />
+    <e k="sf_handful_since_harvest" v="Days since harvest" />
+    <e k="sf_handful_organic" v="Organic" />
+    <e k="sf_handful_org_certified" v="Certified organic" />
+    <e k="sf_handful_org_transition" v="In transition" />
+    <e k="sf_handful_org_conventional" v="Conventional" />
+    <e k="sf_handful_org_breaches" v="%d breaches" />
+    <e k="sf_handful_mat_wetness" v="Wetness" />
+    <e k="sf_handful_mat_days" v="Days down" />
+    <e k="sf_handful_mat_verdict" v="Verdict" />
+    <e k="sf_handful_mat_spoiled" v="Spoiled" />
+    <e k="sf_handful_mat_sound" v="Sound" />
+    <e k="sf_handful_grain_spot" v="spot" />
+    <e k="sf_handful_grain_cell" v="this cell" />
+    <e k="sf_handful_grain_field" v="field average" />
+    <e k="sf_handful_unscouted" v="Unscouted" />
+    <e k="sf_handful_kit_yes" v="Soil test kit in hand: exact figures" />
+    <e k="sf_handful_kit_no" v="No soil test kit: readings are by hand, so they are qualitative" />
+    <e k="sf_handful_band_good" v="Good" />
+    <e k="sf_handful_band_fair" v="Fair" />
+    <e k="sf_handful_band_poor" v="Poor" />
+    <e k="sf_handful_band_unknown" v="Unknown" />
+    <e k="sf_handful_band_acidic" v="Acidic" />
+    <e k="sf_handful_band_alkaline" v="Alkaline" />
+    <e k="sf_handful_band_low" v="Low" />
+    <e k="sf_handful_band_moderate" v="Moderate" />
+    <e k="sf_handful_band_high" v="High" />
+    <e k="sf_handful_band_soaked" v="Soaked" />
+    <e k="sf_handful_band_damp" v="Damp" />
+    <e k="sf_handful_band_curing" v="Curing" />
+    <e k="sf_handful_band_fit" v="Fit" />
+    <e k="sf_handful_rot_bonus" v="Bonus" />
+    <e k="sf_handful_rot_ok" v="OK" />
+    <e k="sf_handful_rot_fatigue" v="Fatigue" />
 </elements>
 
 

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1389,6 +1389,7 @@
     <e k="sf_handful_rot_bonus" v="Bonus" />
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
+    <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
 </elements>
 
 

--- a/xml/gui/SoilHandfulDialog.xml
+++ b/xml/gui/SoilHandfulDialog.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<!--
+    THE HANDFUL PANEL (SF-39)
+    The reading surface for the kneel. Renders the frozen SF-38 payload.
+    Controller: SoilHandfulDialog (src/ui/SoilHandfulDialog.lua)
+
+    Five sections in payload order, each carrying its own grain tag in the
+    section header, because a FIELD clause must never read as a spot measurement.
+    The "Under the hand" section is hidden by the controller when no cut
+    material lies at the spot.
+-->
+<GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
+  <GuiElement profile="newLayer"/>
+  <Bitmap profile="dialogFullscreenBg" id="dialogBg"/>
+
+  <GuiElement profile="sfHandful_bg" id="dialogElement">
+
+    <ThreePartBitmap profile="fs25_dialogBgMiddle"/>
+    <ThreePartBitmap profile="fs25_dialogBgTop"/>
+    <ThreePartBitmap profile="fs25_dialogBgBottom"/>
+
+    <GuiElement profile="fs25_dialogContentContainer">
+
+      <!-- Title -->
+      <Text profile="fs25_dialogTitle" id="hfTitle"
+            text="$l10n_sf_handful_title" position="0px -26px"/>
+
+      <!-- Field + refinement grain for the nutrient row -->
+      <Text profile="sfHandful_header" id="hfHeader"
+            text="" position="0px -60px" size="660px 24px"/>
+
+      <!-- ── Nutrients (SPOT) ── -->
+      <Text profile="sfHandful_section" id="hfSecNutrients"
+            text="$l10n_sf_handful_sec_nutrients" position="0px -96px" size="660px 20px"/>
+      <Text profile="sfHandful_row" id="hfNutrients" text="" position="0px -120px" size="660px 24px"/>
+      <Text profile="sfHandful_row" id="hfPhOm"     text="" position="0px -146px" size="660px 24px"/>
+
+      <!-- ── Ground ── -->
+      <Text profile="sfHandful_section" id="hfSecGround"
+            text="$l10n_sf_handful_sec_ground" position="0px -182px" size="660px 20px"/>
+      <Text profile="sfHandful_row" id="hfGround" text="" position="0px -206px" size="660px 24px"/>
+
+      <!-- ── Pressure ── -->
+      <Text profile="sfHandful_section" id="hfSecPressure"
+            text="$l10n_sf_handful_sec_pressure" position="0px -242px" size="660px 20px"/>
+      <Text profile="sfHandful_row" id="hfDisease"  text="" position="0px -266px" size="660px 24px"/>
+      <Text profile="sfHandful_row" id="hfPestWeed" text="" position="0px -292px" size="660px 24px"/>
+
+      <!-- ── History (FIELD) ── -->
+      <Text profile="sfHandful_section" id="hfSecHistory"
+            text="$l10n_sf_handful_sec_history" position="0px -328px" size="660px 20px"/>
+      <Text profile="sfHandful_row" id="hfCrops"    text="" position="0px -352px" size="660px 24px"/>
+      <Text profile="sfHandful_row" id="hfRotation" text="" position="0px -378px" size="660px 24px"/>
+      <Text profile="sfHandful_row" id="hfOrganic"  text="" position="0px -404px" size="660px 24px"/>
+
+      <!-- ── Under the hand (SPOT) - hidden when no material lies there ── -->
+      <Text profile="sfHandful_section" id="hfSecMaterial"
+            text="$l10n_sf_handful_sec_material" position="0px -440px" size="660px 20px"/>
+      <Text profile="sfHandful_row" id="hfMaterial" text="" position="0px -464px" size="660px 24px"/>
+
+      <!-- Footer: why the readings are words and not numbers -->
+      <Text profile="sfHandful_footer" id="hfFooter"
+            text="" position="0px -502px" size="660px 40px" wrapText="true"/>
+
+    </GuiElement>
+
+    <BoxLayout profile="fs25_dialogButtonBox">
+      <Button profile="buttonBack" id="hfCloseBtn" text="$l10n_sf_detail_close" onClick="onClickClose"/>
+    </BoxLayout>
+
+  </GuiElement>
+
+  <GUIProfiles>
+
+    <Profile name="sfHandful_bg" extends="fs25_dialogBg">
+      <size value="720px 620px"/>
+    </Profile>
+
+    <Profile name="sfHandful_header" extends="fs25_textDefault" with="anchorTopCenter">
+      <textSize value="17px"/>
+      <textBold value="true"/>
+      <textColor value="0.35 0.85 0.40 1.0"/>
+      <textAlignment value="center"/>
+    </Profile>
+
+    <Profile name="sfHandful_section" extends="fs25_textDefault" with="anchorTopCenter">
+      <textSize value="13px"/>
+      <textBold value="true"/>
+      <textColor value="0.65 0.62 0.50 1.0"/>
+      <textAlignment value="center"/>
+    </Profile>
+
+    <Profile name="sfHandful_row" extends="fs25_textDefault" with="anchorTopCenter">
+      <textSize value="15px"/>
+      <textColor value="1 1 1 1"/>
+      <textAlignment value="center"/>
+    </Profile>
+
+    <Profile name="sfHandful_footer" extends="fs25_textDefault" with="anchorTopCenter">
+      <textSize value="12px"/>
+      <textColor value="0.65 0.65 0.65 1"/>
+      <textAlignment value="center"/>
+    </Profile>
+
+  </GUIProfiles>
+</GUI>

--- a/xml/gui/SoilHandfulDialog.xml
+++ b/xml/gui/SoilHandfulDialog.xml
@@ -4,10 +4,17 @@
     The reading surface for the kneel. Renders the frozen SF-38 payload.
     Controller: SoilHandfulDialog (src/ui/SoilHandfulDialog.lua)
 
-    Five sections in payload order, each carrying its own grain tag in the
-    section header, because a FIELD clause must never read as a spot measurement.
-    The "Under the hand" section is hidden by the controller when no cut
-    material lies at the spot.
+    Five sections in payload order. Each is a tinted panel with a lime accent
+    rail down its left edge and its GRAIN TAG in the header, because a FIELD
+    clause must never read as a spot measurement.
+
+    Banded clauses render as stat TILES (dim label over a coloured value); the
+    wordy history clauses stay as text rows. Value colour is set at runtime by
+    the controller via TextElement:setTextColor, so the profiles below only
+    carry size and weight, never a value colour.
+
+    The "Under the hand" section is a container the controller hides wholesale
+    when no cut material lies at the spot; hiding it hides its children.
 -->
 <GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
   <GuiElement profile="newLayer"/>
@@ -21,46 +28,85 @@
 
     <GuiElement profile="fs25_dialogContentContainer">
 
-      <!-- Title -->
+      <!-- ══ Header ══════════════════════════════════════════ -->
       <Text profile="fs25_dialogTitle" id="hfTitle"
-            text="$l10n_sf_handful_title" position="0px -26px"/>
+            text="$l10n_sf_handful_title" position="0px -22px"/>
+      <Text profile="sfHandful_field" id="hfField" text="" position="0px -58px" size="660px 26px"/>
+      <Text profile="sfHandful_grain" id="hfGrain" text="" position="0px -82px" size="660px 18px"/>
 
-      <!-- Field + refinement grain for the nutrient row -->
-      <Text profile="sfHandful_header" id="hfHeader"
-            text="" position="0px -60px" size="660px 24px"/>
+      <!-- ══ Nutrients (SPOT) ════════════════════════════════ -->
+      <GuiElement profile="sfHandful_section" position="0px -110px">
+        <Bitmap profile="sfHandful_sectionBg" size="680px 84px"/>
+        <Bitmap profile="sfHandful_rail"      size="3px 84px" position="0px 0px"/>
+        <Text profile="sfHandful_secHdr" text="$l10n_sf_handful_sec_nutrients" position="16px -8px"/>
 
-      <!-- ── Nutrients (SPOT) ── -->
-      <Text profile="sfHandful_section" id="hfSecNutrients"
-            text="$l10n_sf_handful_sec_nutrients" position="0px -96px" size="660px 20px"/>
-      <Text profile="sfHandful_row" id="hfNutrients" text="" position="0px -120px" size="660px 24px"/>
-      <Text profile="sfHandful_row" id="hfPhOm"     text="" position="0px -146px" size="660px 24px"/>
+        <Text profile="sfHandful_tileLbl" id="hfLblN"  text="" position="-260px -34px"/>
+        <Text profile="sfHandful_tileVal" id="hfValN"  text="" position="-260px -52px"/>
+        <Text profile="sfHandful_tileLbl" id="hfLblP"  text="" position="-130px -34px"/>
+        <Text profile="sfHandful_tileVal" id="hfValP"  text="" position="-130px -52px"/>
+        <Text profile="sfHandful_tileLbl" id="hfLblK"  text="" position="0px -34px"/>
+        <Text profile="sfHandful_tileVal" id="hfValK"  text="" position="0px -52px"/>
+        <Text profile="sfHandful_tileLbl" id="hfLblPh" text="" position="130px -34px"/>
+        <Text profile="sfHandful_tileVal" id="hfValPh" text="" position="130px -52px"/>
+        <Text profile="sfHandful_tileLbl" id="hfLblOm" text="" position="260px -34px"/>
+        <Text profile="sfHandful_tileVal" id="hfValOm" text="" position="260px -52px"/>
+      </GuiElement>
 
-      <!-- ── Ground ── -->
-      <Text profile="sfHandful_section" id="hfSecGround"
-            text="$l10n_sf_handful_sec_ground" position="0px -182px" size="660px 20px"/>
-      <Text profile="sfHandful_row" id="hfGround" text="" position="0px -206px" size="660px 24px"/>
+      <!-- ══ Ground ══════════════════════════════════════════ -->
+      <GuiElement profile="sfHandful_section" position="0px -204px">
+        <Bitmap profile="sfHandful_sectionBg" size="680px 84px"/>
+        <Bitmap profile="sfHandful_rail"      size="3px 84px" position="0px 0px"/>
+        <Text profile="sfHandful_secHdr" text="$l10n_sf_handful_sec_ground" position="16px -8px"/>
 
-      <!-- ── Pressure ── -->
-      <Text profile="sfHandful_section" id="hfSecPressure"
-            text="$l10n_sf_handful_sec_pressure" position="0px -242px" size="660px 20px"/>
-      <Text profile="sfHandful_row" id="hfDisease"  text="" position="0px -266px" size="660px 24px"/>
-      <Text profile="sfHandful_row" id="hfPestWeed" text="" position="0px -292px" size="660px 24px"/>
+        <Text profile="sfHandful_tileLbl" id="hfLblComp"  text="" position="-165px -34px"/>
+        <Text profile="sfHandful_tileVal" id="hfValComp"  text="" position="-165px -52px"/>
+        <Text profile="sfHandful_tileLbl" id="hfLblMoist" text="" position="165px -34px"/>
+        <Text profile="sfHandful_tileVal" id="hfValMoist" text="" position="165px -52px"/>
+      </GuiElement>
 
-      <!-- ── History (FIELD) ── -->
-      <Text profile="sfHandful_section" id="hfSecHistory"
-            text="$l10n_sf_handful_sec_history" position="0px -328px" size="660px 20px"/>
-      <Text profile="sfHandful_row" id="hfCrops"    text="" position="0px -352px" size="660px 24px"/>
-      <Text profile="sfHandful_row" id="hfRotation" text="" position="0px -378px" size="660px 24px"/>
-      <Text profile="sfHandful_row" id="hfOrganic"  text="" position="0px -404px" size="660px 24px"/>
+      <!-- ══ Pressure ════════════════════════════════════════ -->
+      <GuiElement profile="sfHandful_section" position="0px -298px">
+        <Bitmap profile="sfHandful_sectionBg" size="680px 98px"/>
+        <Bitmap profile="sfHandful_rail"      size="3px 98px" position="0px 0px"/>
+        <Text profile="sfHandful_secHdr" text="$l10n_sf_handful_sec_pressure" position="16px -8px"/>
 
-      <!-- ── Under the hand (SPOT) - hidden when no material lies there ── -->
-      <Text profile="sfHandful_section" id="hfSecMaterial"
-            text="$l10n_sf_handful_sec_material" position="0px -440px" size="660px 20px"/>
-      <Text profile="sfHandful_row" id="hfMaterial" text="" position="0px -464px" size="660px 24px"/>
+        <Text profile="sfHandful_tileLbl" id="hfLblDis"  text="" position="-220px -34px"/>
+        <Text profile="sfHandful_tileVal" id="hfValDis"  text="" position="-220px -52px"/>
+        <Text profile="sfHandful_tileGrain" id="hfDisGrain" text="" position="-220px -74px"/>
+        <Text profile="sfHandful_tileLbl" id="hfLblPest" text="" position="0px -34px"/>
+        <Text profile="sfHandful_tileVal" id="hfValPest" text="" position="0px -52px"/>
+        <Text profile="sfHandful_tileLbl" id="hfLblWeed" text="" position="220px -34px"/>
+        <Text profile="sfHandful_tileVal" id="hfValWeed" text="" position="220px -52px"/>
+      </GuiElement>
 
-      <!-- Footer: why the readings are words and not numbers -->
+      <!-- ══ Field history (FIELD) ═══════════════════════════ -->
+      <GuiElement profile="sfHandful_section" position="0px -406px">
+        <Bitmap profile="sfHandful_sectionBg" size="680px 104px"/>
+        <Bitmap profile="sfHandful_rail"      size="3px 104px" position="0px 0px"/>
+        <Text profile="sfHandful_secHdr" text="$l10n_sf_handful_sec_history" position="16px -8px"/>
+
+        <Text profile="sfHandful_row" id="hfCrops" text="" position="18px -32px"/>
+        <Text profile="sfHandful_row" id="hfRotation" text="" position="18px -54px"/>
+        <Text profile="sfHandful_row" id="hfOrganic"  text="" position="18px -76px"/>
+      </GuiElement>
+
+      <!-- ══ Under the hand (SPOT) - hidden when bare ════════ -->
+      <GuiElement profile="sfHandful_section" id="hfSecMaterial" position="0px -520px">
+        <Bitmap profile="sfHandful_sectionBg" size="680px 84px"/>
+        <Bitmap profile="sfHandful_rail"      size="3px 84px" position="0px 0px"/>
+        <Text profile="sfHandful_secHdr" text="$l10n_sf_handful_sec_material" position="16px -8px"/>
+
+        <Text profile="sfHandful_tileLbl" id="hfLblWet"     text="" position="-220px -34px"/>
+        <Text profile="sfHandful_tileVal" id="hfValWet"     text="" position="-220px -52px"/>
+        <Text profile="sfHandful_tileLbl" id="hfLblDown"    text="" position="0px -34px"/>
+        <Text profile="sfHandful_tileVal" id="hfValDown"    text="" position="0px -52px"/>
+        <Text profile="sfHandful_tileLbl" id="hfLblVerdict" text="" position="220px -34px"/>
+        <Text profile="sfHandful_tileVal" id="hfValVerdict" text="" position="220px -52px"/>
+      </GuiElement>
+
+      <!-- ══ Footer ══════════════════════════════════════════ -->
       <Text profile="sfHandful_footer" id="hfFooter"
-            text="" position="0px -502px" size="660px 40px" wrapText="true"/>
+            text="" position="0px -616px" size="660px 34px" wrapText="true"/>
 
     </GuiElement>
 
@@ -73,32 +119,73 @@
   <GUIProfiles>
 
     <Profile name="sfHandful_bg" extends="fs25_dialogBg">
-      <size value="720px 620px"/>
+      <size value="720px 764px"/>
     </Profile>
 
-    <Profile name="sfHandful_header" extends="fs25_textDefault" with="anchorTopCenter">
+    <!-- Section shell: a transparent anchor the panel, rail and tiles sit in. -->
+    <Profile name="sfHandful_section" extends="emptyPanel" with="anchorTopCenter">
+      <size value="680px 84px"/>
+    </Profile>
+    <Profile name="sfHandful_sectionBg" extends="baseReference" with="anchorTopCenter">
+      <imageColor value="0.08 0.09 0.07 0.72"/>
+    </Profile>
+    <!-- The lime rail is the one piece of brand colour per section. -->
+    <Profile name="sfHandful_rail" extends="baseReference" with="anchorTopLeft">
+      <imageColor value="0.659 0.878 0.290 0.85"/>
+    </Profile>
+
+    <Profile name="sfHandful_secHdr" extends="fs25_textDefault" with="anchorTopLeft">
+      <size value="400px 16px"/>
+      <textSize value="12px"/>
+      <textBold value="true"/>
+      <textColor value="0.659 0.878 0.290 0.80"/>
+      <textAlignment value="left"/>
+    </Profile>
+
+    <!-- Header block -->
+    <Profile name="sfHandful_field" extends="fs25_textDefault" with="anchorTopCenter">
+      <textSize value="22px"/>
+      <textBold value="true"/>
+      <textColor value="0.95 0.95 0.92 1.0"/>
+      <textAlignment value="center"/>
+    </Profile>
+    <Profile name="sfHandful_grain" extends="fs25_textDefault" with="anchorTopCenter">
+      <textSize value="12px"/>
+      <textColor value="0.60 0.60 0.55 1.0"/>
+      <textAlignment value="center"/>
+    </Profile>
+
+    <!-- Stat tile: dim label over a value the controller colours at runtime. -->
+    <Profile name="sfHandful_tileLbl" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="126px 16px"/>
+      <textSize value="12px"/>
+      <textColor value="0.58 0.58 0.54 1.0"/>
+      <textAlignment value="center"/>
+    </Profile>
+    <Profile name="sfHandful_tileVal" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="126px 22px"/>
       <textSize value="17px"/>
       <textBold value="true"/>
-      <textColor value="0.35 0.85 0.40 1.0"/>
-      <textAlignment value="center"/>
-    </Profile>
-
-    <Profile name="sfHandful_section" extends="fs25_textDefault" with="anchorTopCenter">
-      <textSize value="13px"/>
-      <textBold value="true"/>
-      <textColor value="0.65 0.62 0.50 1.0"/>
-      <textAlignment value="center"/>
-    </Profile>
-
-    <Profile name="sfHandful_row" extends="fs25_textDefault" with="anchorTopCenter">
-      <textSize value="15px"/>
       <textColor value="1 1 1 1"/>
       <textAlignment value="center"/>
+    </Profile>
+    <Profile name="sfHandful_tileGrain" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="200px 14px"/>
+      <textSize value="10px"/>
+      <textColor value="0.52 0.52 0.48 1.0"/>
+      <textAlignment value="center"/>
+    </Profile>
+
+    <Profile name="sfHandful_row" extends="fs25_textDefault" with="anchorTopLeft">
+      <size value="644px 20px"/>
+      <textSize value="14px"/>
+      <textColor value="0.88 0.88 0.85 1.0"/>
+      <textAlignment value="left"/>
     </Profile>
 
     <Profile name="sfHandful_footer" extends="fs25_textDefault" with="anchorTopCenter">
       <textSize value="12px"/>
-      <textColor value="0.65 0.65 0.65 1"/>
+      <textColor value="0.62 0.62 0.58 1"/>
       <textAlignment value="center"/>
     </Profile>
 


### PR DESCRIPTION
## SF-39: the handful panel

Read the Dirt's data side has shipped since 2026-07-31 with nothing to render it. This is the missing member: kneel in a field, press the key, and the frozen SF-38 payload is drawn.

Built against the brief added in `ecosystem-dev-tracking` (`SF-39-THE-HANDFUL-PANEL-BUILD-BRIEF.md`). The row correction on unified roadmap row 2 is flagged separately to Arissani; **nothing about the frozen payload contract changed here.**

### Commits (2)

| SHA | What |
|---|---|
| `7ec0348d` | the handful panel, the reading surface for the kneel |
| `ddc4549a` | name the keybinding, and restyle the panel |

### What it does

`SF_HANDFUL` (ONFOOT) opens an on-foot dialog built on the `SoilScoutDialog` pattern. The sequence is **reveal, then assemble, then show**, and that order is load bearing: SF-38 rule 5 requires `diseaseKnown` to reflect the just-knelt cell rather than a stale pre-reveal read. The panel itself performs zero writes.

**It opens only while crouched**, via `g_localPlayer.mover.isCrouching`. Verified at source rather than assumed: `PlayerStateCrouch:onStateEntered/onStateExited` flip it (`player/stateMachine/PlayerStateCrouch.lua:31,35`), the flag is a plain bool on `PlayerMover` (`player/PlayerMover.lua:45,168-169`), and `Player.mover` is assigned at `player/Player.lua:171`.

Two engine behaviours are documented rather than fought: crouch is a **hold**, not a toggle (`inputComponent.crouchValue > 0`), and a hand tool whose `canCrouch` is false blocks the crouch state outright, so a player holding the wrong tool cannot read. Every refusal in the ladder speaks through a blinking warning instead of failing silently.

### Two findings worth knowing

**No SF hotkey has ever had a default key.** All eleven actions are declared as bare `<actionBinding action="..."/>`, and the engine only reads a default from a nested `<binding device="..." input="..."/>` child (`InputBinding:loadBindingsFromXML` at `input/InputBinding.lua:1576-1589` into `Binding.createFromXML` at `input/Binding.lua:59-75`). Every "default Shift+K" in our own comments is stale; players have been binding by hand since release. SF-39 ships a real default (Shift+G). **Retro-fitting the other ten is a change to shipped behaviour and is deliberately not in this PR.**

**The first in-game pass showed the raw action name `SF_HANDFUL` in the controls menu.** FS25 labels a binding from an `input_<ACTION>` l10n key and the first commit shipped none. Fixed in the second.

### Rendering

Five tinted sections, each with an accent rail and its grain tag. Banded clauses render as stat tiles whose value colour is set at runtime by severity (`TextElement:setTextColor`, `gui/elements/TextElement.lua:626`); wordy history clauses stay text rows.

Colour is a **second** channel, never a replacement: the word always says the thing, so nothing is lost to a colour-blind player. Two polarity traps are handled explicitly and pinned by the bench, because both would have looked fine and been wrong:

- **LOW compaction is the GOOD outcome**, so it takes green rather than the red that "Low" implies by analogy with nutrients.
- **Absent and Unscouted take neutral grey, never the green of None.** A clause nobody measured must not wear a verdict colour, and an unlooked-at field has not earned a clean bill of health.

The inherited SF-38 cert gates all hold: grain honesty, per-clause neutrality (a nil clause is a dash, never a zero), no phantom fields, zero writes, and bands rather than numbers because `readTestKit()` is a hardcoded false until the kit member ships. **That last one is stated intent: a tester who kneels expecting "N: 42" and reads "N: Good" is seeing the contract work.**

### Release gate

`read_the_dirt` stays in `ReleaseGate.EXPERIMENTAL`. The panel is gated at the input callback, so with the gate locked the key refuses with the standard lock message and the dialog never opens. Whether this member is what finally releases the family is Arissani's call and is not assumed here.

### Verification

- Bench `handful_panel_sf39_test.lua`: 51 assertions on the render contract.
- Full suite **2823 passed, 0 failed across 66 files**; Lua 5.1 syntax and lint clean; the syntax gate was checked against a deliberately broken control file first.
- 54 `sf_handful_*` keys plus `input_SF_HANDFUL` in **all 27** translation files, with English fallbacks in code so a missing key still renders readable text.
- Built, deployed and **confirmed in-game by Tyson** at v2.5.0.62 (function) and v2.5.0.63 (binding label + restyle).

### Not covered

MP client behaviour. The panel adds no event; on a client, clauses whose source is server-only degrade to their neutral form under per-clause neutrality. If a client run shows too many neutral clauses to be useful, that is a follow-up request/response pair, not a change to this PR.
