### PR TITLE
feat(settings): the experimental gate asks before it flips

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ This mod is licensed under **[CC BY-NC-ND 4.0](https://creativecommons.org/licen
 
 You may share it in its original form with attribution. You may not sell it, modify and redistribute it, or reupload it under a different name or authorship. Contributions via pull request are explicitly permitted and encouraged.
 
-**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.5.0.0
+**Author:** TisonK &nbsp;·&nbsp; **Version:** 2.5.0.64
 
 © 2026 TisonK - See [LICENSE](LICENSE) for full terms.
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK (Refined edition: WizardlyPayload)</author>
-    <version>2.5.0.61</version>
+    <version>2.5.0.64</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -474,7 +474,84 @@ function SoilSettingsPanel:isAdmin()
     return SoilUtils.isPlayerAdmin()
 end
 
-function SoilSettingsPanel:requestChange(id, value)
+--- Every setting change from this panel funnels through here, which is why the
+--- experimental gate is intercepted at this one point rather than at each of the
+--- five call sites that can flip a boolean.
+---
+--- @param skipConfirm boolean|nil  bypass the experimental confirmation. Used by
+---   resetCurrentCategory, which is already an explicit deliberate action and
+---   only ever restores the LOCKED default, so it never needs to ask.
+function SoilSettingsPanel:requestChange(id, value, skipConfirm)
+    local def = SettingsSchema.byId[id]
+    if not def then return end
+
+    -- THE EXPERIMENTAL GATE NEVER FLIPS ON ONE CLICK. It arms unfinished systems
+    -- on a live save, so it asks first and a refusal leaves the toggle untouched.
+    if id == "experimentalSystems" and skipConfirm ~= true and value ~= self.settings[id] then
+        -- Refuse BEFORE we warn: putting a scary confirmation in front of someone
+        -- whose change we are about to reject anyway is worse than refusing now.
+        if not def.localOnly and not self:isAdmin() then
+            self:_warnNotAdmin()
+            return
+        end
+        self:_confirmExperimental(value)
+        return
+    end
+
+    self:_applyChange(id, value)
+end
+
+function SoilSettingsPanel:_warnNotAdmin()
+    if g_currentMission and g_currentMission.hud and
+       g_currentMission.hud.showBlinkingWarning then
+        g_currentMission.hud:showBlinkingWarning(
+            "Only server admins can change this setting", 4000)
+    end
+end
+
+--- Ask before arming or disarming the experimental systems. Abort leaves the
+--- setting exactly as it was; only Confirm reaches _applyChange.
+function SoilSettingsPanel:_confirmExperimental(value)
+    -- FAIL CLOSED. If the dialog is unavailable we do NOT fall through to the
+    -- change: a gate that cannot ask is a gate that does not open.
+    if YesNoDialog == nil or type(YesNoDialog.show) ~= "function" then
+        SoilLogger.warning("SoilSettingsPanel: YesNoDialog unavailable, experimental toggle refused")
+        return
+    end
+
+    local text = value == true
+        and tr("sf_exp_confirm_on",
+            "This turns on systems that are NOT finished. They can behave oddly, " ..
+            "change without warning, or affect this savegame in ways that cannot be " ..
+            "undone. Use a backup save.\n\nTurn experimental systems ON?")
+        or tr("sf_exp_confirm_off",
+            "Experimental systems will stop running on this savegame. Anything they " ..
+            "wrote stays where it is, but it will no longer be updated.\n\n" ..
+            "Turn experimental systems OFF?")
+
+    YesNoDialog.show(
+        SoilSettingsPanel._onExperimentalConfirm, self,
+        text,
+        tr("sf_exp_confirm_title", "Experimental Systems"),
+        tr("sf_exp_confirm_yes", "Confirm"),
+        tr("sf_exp_confirm_no", "Abort"),
+        DialogElement.TYPE_WARNING,
+        nil, nil,
+        { value = value }
+    )
+end
+
+--- YesNoDialog callback. With a target set the engine calls this as
+--- callback(target, value, callbackArgs) (gui/dialogs/YesNoDialog.lua:82-86).
+function SoilSettingsPanel:_onExperimentalConfirm(confirmed, args)
+    if confirmed ~= true then return end          -- Abort: the toggle never moves.
+    if type(args) ~= "table" or args.value == nil then return end
+    self:_applyChange("experimentalSystems", args.value)
+end
+
+--- The original change path, unchanged. Reached directly for every setting
+--- except the experimental gate, and via the confirmation for that one.
+function SoilSettingsPanel:_applyChange(id, value)
     local def = SettingsSchema.byId[id]
     if not def then return end
     if def.localOnly then
@@ -485,12 +562,10 @@ function SoilSettingsPanel:requestChange(id, value)
         end
         return
     end
+    -- Re-checked here rather than trusted from the caller: the confirmation
+    -- dialog is modal but not instant, and admin status can change under it.
     if not self:isAdmin() then
-        if g_currentMission and g_currentMission.hud and
-           g_currentMission.hud.showBlinkingWarning then
-            g_currentMission.hud:showBlinkingWarning(
-                "Only server admins can change this setting", 4000)
-        end
+        self:_warnNotAdmin()
         return
     end
     if SoilNetworkEvents_RequestSettingChange then
@@ -2049,7 +2124,10 @@ function SoilSettingsPanel:resetCurrentCategory()
         for _, settingId in ipairs(sec.items) do
             local def = SettingsSchema.byId[settingId]
             if def and def.default ~= nil then
-                self:requestChange(settingId, def.default)
+                -- skipConfirm: a reset is already a deliberate act, it runs in a
+                -- loop that a modal would break, and for the experimental gate it
+                -- only ever restores the LOCKED default. Nothing to warn about.
+                self:requestChange(settingId, def.default, true)
             end
         end
     end

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -668,8 +668,13 @@ function SoilSettingsPanel:draw()
     self:drawRect(PX,          PY,          bw, PH, C.border)
     self:drawRect(PX + PW - bw, PY,         bw, PH, C.border)
 
-    -- Page content (skipped when popup is open - popup draws its own dim overlay)
-    if not self.popupVisible then
+    -- Page content, skipped while a modal is up. Both modals draw their own dim
+    -- overlay, but that overlay only covers what was drawn as an OVERLAY: text
+    -- from the page underneath still reads straight through a box painted on top
+    -- of it, which is why the popup has always skipped the page rather than
+    -- covering it. The confirmation has to do the same or the settings rows show
+    -- through its body copy.
+    if not self.popupVisible and not self.confirmVisible then
         if self.page == PAGE_LANDING then
             self:drawLandingPage()
         elseif self.page == PAGE_CATEGORY then

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -27,6 +27,29 @@ local function tr(key, fallback)
     return fallback or key
 end
 
+-- Word-wrap a string into lines that fit maxWidth at the given size. Uses the
+-- engine's getTextWidth so measurement matches renderText exactly. Same helper
+-- shape as SoilMapOverlay's, so the two surfaces wrap identically.
+local function wrapText(text, size, maxWidth)
+    if type(text) ~= "string" or text == "" then return { "" } end
+    if getTextWidth == nil or maxWidth <= 0 then return { text } end
+    local words = {}
+    for w in text:gmatch("%S+") do words[#words + 1] = w end
+    if #words == 0 then return { "" } end
+    local lines, cur = {}, ""
+    for _, w in ipairs(words) do
+        local probe = cur == "" and w or (cur .. " " .. w)
+        if cur ~= "" and getTextWidth(size, probe) > maxWidth then
+            lines[#lines + 1] = cur
+            cur = w
+        else
+            cur = probe
+        end
+    end
+    if cur ~= "" then lines[#lines + 1] = cur end
+    return lines
+end
+
 -- ── Panel geometry (normalized, Y=0 at bottom) ────────────
 local PW    = 0.60
 local PH    = 0.74
@@ -433,6 +456,10 @@ function SoilSettingsPanel:open()
 end
 
 function SoilSettingsPanel:close()
+    -- Closing the panel ABORTS any pending confirmation. Escape, the [X], the
+    -- hotkey and the auto-close in update() all land here, and none of them is
+    -- an answer to the question. A pending value must never outlive the panel.
+    self:_dismissConfirm()
     self.isVisible = false
     self.savedCamRotX, self.savedCamRotY, self.savedCamRotZ = nil, nil, nil
     if g_inputBinding and g_inputBinding.setShowMouseCursor then
@@ -511,42 +538,47 @@ end
 
 --- Ask before arming or disarming the experimental systems. Abort leaves the
 --- setting exactly as it was; only Confirm reaches _applyChange.
+---
+--- THIS IS A DRAWN CONFIRMATION, NOT A BASE-GAME YesNoDialog, for two reasons.
+--- The style one: this panel is immediate-mode with its own frame, palette and
+--- hit-tested click ids, and it already owns a modal idiom in drawPopupDialog,
+--- so a GUI dialog would open in a different visual language on top of it.
+--- The functional one, which settles it: SoilSettingsPanel:update() closes the
+--- panel whenever g_gui reports a dialog visible, so showing a YesNoDialog
+--- would dismiss the very panel the player is answering for.
 function SoilSettingsPanel:_confirmExperimental(value)
-    -- FAIL CLOSED. If the dialog is unavailable we do NOT fall through to the
-    -- change: a gate that cannot ask is a gate that does not open.
-    if YesNoDialog == nil or type(YesNoDialog.show) ~= "function" then
-        SoilLogger.warning("SoilSettingsPanel: YesNoDialog unavailable, experimental toggle refused")
-        return
-    end
-
-    local text = value == true
+    self.confirmVisible = true
+    self.confirmValue   = value
+    self.confirmText    = value == true
         and tr("sf_exp_confirm_on",
             "This turns on systems that are NOT finished. They can behave oddly, " ..
             "change without warning, or affect this savegame in ways that cannot be " ..
-            "undone. Use a backup save.\n\nTurn experimental systems ON?")
+            "undone. Keep a backup save.")
         or tr("sf_exp_confirm_off",
             "Experimental systems will stop running on this savegame. Anything they " ..
-            "wrote stays where it is, but it will no longer be updated.\n\n" ..
-            "Turn experimental systems OFF?")
-
-    YesNoDialog.show(
-        SoilSettingsPanel._onExperimentalConfirm, self,
-        text,
-        tr("sf_exp_confirm_title", "Experimental Systems"),
-        tr("sf_exp_confirm_yes", "Confirm"),
-        tr("sf_exp_confirm_no", "Abort"),
-        DialogElement.TYPE_WARNING,
-        nil, nil,
-        { value = value }
-    )
+            "already wrote stays where it is, but it will no longer be updated.")
+    self.confirmQuestion = value == true
+        and tr("sf_exp_confirm_q_on", "Turn experimental systems ON?")
+        or tr("sf_exp_confirm_q_off", "Turn experimental systems OFF?")
 end
 
---- YesNoDialog callback. With a target set the engine calls this as
---- callback(target, value, callbackArgs) (gui/dialogs/YesNoDialog.lua:82-86).
-function SoilSettingsPanel:_onExperimentalConfirm(confirmed, args)
-    if confirmed ~= true then return end          -- Abort: the toggle never moves.
-    if type(args) ~= "table" or args.value == nil then return end
-    self:_applyChange("experimentalSystems", args.value)
+--- Dismiss without acting. EVERY exit that is not the Confirm button lands here,
+--- so a pending answer can never survive to be applied later.
+function SoilSettingsPanel:_dismissConfirm()
+    self.confirmVisible  = false
+    self.confirmValue    = nil
+    self.confirmText     = nil
+    self.confirmQuestion = nil
+end
+
+--- The Confirm button, and the only path that reaches the change. The pending
+--- value is cleared BEFORE applying, so a failure inside _applyChange cannot
+--- leave a live confirmation behind.
+function SoilSettingsPanel:_acceptConfirm()
+    local value = self.confirmValue
+    self:_dismissConfirm()
+    if value == nil then return end
+    self:_applyChange("experimentalSystems", value)
 end
 
 --- The original change path, unchanged. Reached directly for every setting
@@ -662,6 +694,14 @@ function SoilSettingsPanel:draw()
         self._clickRects = {}
     end
     self:drawPopupDialog()
+
+    -- The experimental confirmation sits above everything, including the popup.
+    -- Click zones are cleared first for the same reason: nothing behind a modal
+    -- may be clicked through it, so its two buttons are the only live targets.
+    if self.confirmVisible then
+        self._clickRects = {}
+        self:drawConfirmDialog()
+    end
 end
 
 -- ── Title bar ─────────────────────────────────────────────
@@ -1574,6 +1614,81 @@ function SoilSettingsPanel:drawPopupDialog()
     self:registerClick("popup_close", btnX, btnY, btnW, btnH)
 end
 
+-- ── Experimental confirmation (drawn, in this panel's frame) ──────────────
+-- Same construction as drawPopupDialog: dim overlay, shadow, bordered box,
+-- accent title bar, hit-tested buttons registered by click id. The accent is
+-- the panel's own warning amber (C.lock_text), the colour this panel already
+-- uses to mark a locked system, so the prompt reads as part of that language.
+function SoilSettingsPanel:drawConfirmDialog()
+    if not self.confirmVisible then return end
+
+    local WARN = {C.lock_text[1], C.lock_text[2], C.lock_text[3]}
+
+    local DW, DH = 0.44, 0.26
+    local DX, DY = (1 - DW) / 2, (1 - DH) / 2
+    local DPAD   = 0.016
+
+    -- Dim everything behind, including the panel itself.
+    self:drawRect(0, 0, 1, 1, {0, 0, 0, 0.60})
+    self:drawRect(DX + 0.004, DY - 0.004, DW, DH, C.shadow, 0.65)
+    self:drawRect(DX, DY, DW, DH, {0.06, 0.07, 0.11, 0.99})
+
+    local bw = 0.0015
+    self:drawRect(DX,            DY,             DW, bw, WARN, 0.85)
+    self:drawRect(DX,            DY + DH - bw,   DW, bw, WARN, 0.85)
+    self:drawRect(DX,            DY,             bw, DH, WARN, 0.85)
+    self:drawRect(DX + DW - bw,  DY,             bw, DH, WARN, 0.85)
+
+    -- Title bar
+    local TH = 0.036
+    local TY = DY + DH - TH
+    self:drawRect(DX, TY, DW, TH, {0.10, 0.08, 0.04, 1.0})
+    self:drawRect(DX, TY, 0.004, TH, WARN)
+    self:drawText(DX + DPAD, TY + TH * 0.28, TS_SMALL,
+        tr("sf_exp_confirm_title", "Experimental Systems"),
+        {WARN[1], WARN[2], WARN[3], 1.0}, RenderText.ALIGN_LEFT, true)
+
+    -- Body: wrapped so a long translation cannot run past the box.
+    local textW = DW - DPAD * 2
+    local LINE_H = TS_SMALL + 0.006
+    local curY = TY - 0.014
+    for _, line in ipairs(wrapText(self.confirmText or "", TS_SMALL, textW)) do
+        curY = curY - LINE_H
+        self:drawText(DX + DPAD, curY, TS_SMALL, line, C.white, RenderText.ALIGN_LEFT, false)
+    end
+
+    -- The question, set apart from the warning body.
+    curY = curY - LINE_H * 1.2
+    self:drawText(DX + DW * 0.5, curY, TS_BODY, self.confirmQuestion or "",
+        {WARN[1], WARN[2], WARN[3], 1.0}, RenderText.ALIGN_CENTER, true)
+
+    -- Buttons. Abort sits left and is styled as the safe, ordinary choice;
+    -- Confirm sits right in warning amber, because it is the one with teeth.
+    local btnW, btnH = 0.130, 0.030
+    local gap = 0.014
+    local btnY = DY + 0.020
+    local abortX = DX + (DW - (btnW * 2 + gap)) * 0.5
+    local okX    = abortX + btnW + gap
+
+    local abortHov = self:hitTest(abortX, btnY, btnW, btnH, self.mouseX, self.mouseY)
+    self:drawRect(abortX, btnY, btnW, btnH,
+        abortHov and {0.22, 0.50, 0.28, 0.95} or {0.12, 0.16, 0.13, 0.92})
+    self:drawRect(abortX, btnY, 0.002, btnH, C.green_dim)
+    self:drawText(abortX + btnW * 0.5, btnY + btnH * 0.22, TS_SMALL,
+        tr("sf_exp_confirm_no", "Abort"),
+        abortHov and C.white or {0.80, 0.85, 0.80, 1}, RenderText.ALIGN_CENTER, true)
+    self:registerClick("exp_confirm_no", abortX, btnY, btnW, btnH)
+
+    local okHov = self:hitTest(okX, btnY, btnW, btnH, self.mouseX, self.mouseY)
+    self:drawRect(okX, btnY, btnW, btnH,
+        okHov and {0.70, 0.45, 0.10, 0.95} or {0.22, 0.15, 0.05, 0.92})
+    self:drawRect(okX, btnY, 0.002, btnH, WARN)
+    self:drawText(okX + btnW * 0.5, btnY + btnH * 0.22, TS_SMALL,
+        tr("sf_exp_confirm_yes", "Confirm"),
+        okHov and C.white or {0.90, 0.80, 0.65, 1}, RenderText.ALIGN_CENTER, true)
+    self:registerClick("exp_confirm_yes", okX, btnY, btnW, btnH)
+end
+
 -- ── Setting row ────────────────────────────────────────────
 function SoilSettingsPanel:drawSettingRow(x, y, w, settingId, rowIdx, isAdmin)
     local def = SettingsSchema.byId[settingId]
@@ -1814,8 +1929,11 @@ function SoilSettingsPanel:onMouseEvent(posX, posY, isDown, isUp, button, eventU
         end
     end
 
-    -- Click outside panel = close (but not when popup is active)
-    if not self.popupVisible and not self:hitTest(PX, PY, PW, PH, posX, posY) then
+    -- Click outside panel = close (but not while a modal is asking something).
+    -- The confirmation must be answered or aborted on its own buttons; closing
+    -- the panel out from under it would leave the question unanswered.
+    if not self.popupVisible and not self.confirmVisible
+       and not self:hitTest(PX, PY, PW, PH, posX, posY) then
         self:close()
         return true
     end
@@ -1824,7 +1942,13 @@ function SoilSettingsPanel:onMouseEvent(posX, posY, isDown, isUp, button, eventU
 end
 
 function SoilSettingsPanel:handleClick(id, data)
-    if id == "close" then
+    if id == "exp_confirm_yes" then
+        self:_acceptConfirm()
+
+    elseif id == "exp_confirm_no" then
+        self:_dismissConfirm()
+
+    elseif id == "close" then
         self:close()
 
     elseif id == "back" then

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -24,6 +24,9 @@ SoilVersionDialog.INSTANCE = nil
 -- Max 11 lines are visible in the box; if more exist we stop on a bullet boundary and add a "full changelog on GitHub" note.
 -- These are intentionally NOT translated, as they are always in English and often contain technical terms that don't translate well.
 SoilVersionDialog.CHANGELOG = {
+    "- Turning Experimental Systems on or off now asks first. The gate arms",
+    "    unfinished systems on a live save, so it warns you and waits for a",
+    "    Confirm. Abort leaves the setting exactly as it was.",
     "- Release gate: disease resistance, hybrids, tank mixes, ground material,",
     "    spatial soil and Read the Dirt now ship LOCKED until you release them.",
     "    Turn them on under Settings > Experimental, at your own risk. A stable",

--- a/tools/test/lua/experimental_confirm_test.lua
+++ b/tools/test/lua/experimental_confirm_test.lua
@@ -1,0 +1,160 @@
+-- experimental_confirm_test.lua - the experimental gate never flips on one click.
+--
+-- The gate arms UNFINISHED systems on a live savegame, so the panel asks first.
+-- The property that matters is not "a dialog appeared", it is that ABORT LEAVES
+-- THE SETTING EXACTLY AS IT WAS. A confirmation that fails open is worse than no
+-- confirmation at all, because the player now believes they declined.
+--
+-- Locked here:
+--   ASK BEFORE ARMING   - flipping experimentalSystems routes through the dialog
+--                         and does NOT reach the change path on its own.
+--   ABORT IS A NO-OP    - answering no leaves the stored value untouched.
+--   CONFIRM APPLIES     - answering yes performs exactly the requested change.
+--   FAIL CLOSED         - if the dialog is unavailable the change is REFUSED,
+--                         not silently applied. A gate that cannot ask must not
+--                         open.
+--   EVERY OTHER SETTING IS UNTOUCHED - the interception is surgical; no other
+--                         setting gains a prompt.
+--   NO PROMPT ON A NO-OP - re-selecting the value it already has must not ask.
+--   RESET SKIPS THE ASK  - resetCurrentCategory runs in a loop a modal would
+--                         break, and only ever restores the LOCKED default.
+--
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/config/SettingsSchema.lua, src/ui/SoilSettingsPanel.lua
+
+-- Force tr() down its fallback path so the assertions below read the English the
+-- player sees. The prelude's stub returns the KEY, which tr() treats as a valid
+-- translation; returning "" is the real "key absent" case.
+g_i18n = { getText = function(_self, _key) return "" end, hasText = function() return false end }
+
+-- ── A stand-in for the dialog, recording what it was asked ──────────────────
+local shown = nil
+local nextAnswer = nil          -- what the player "clicks"
+local available = true
+
+DialogElement = { TYPE_WARNING = 2, TYPE_QUESTION = 1 }
+
+local function installDialog()
+  if not available then YesNoDialog = nil return end
+  YesNoDialog = {
+    show = function(callback, target, text, title, yesText, noText, dialogType, _ys, _ns, args)
+      shown = { text = text, title = title, yes = yesText, no = noText,
+                dialogType = dialogType, args = args }
+      if nextAnswer ~= nil then callback(target, nextAnswer, args) end
+    end,
+  }
+end
+
+-- ── A minimal panel over a fake settings store ──────────────────────────────
+local function newPanel(isAdmin, startValue)
+  local saved = { n = 0 }
+  local settings = {
+    experimentalSystems = startValue,
+    difficulty = 2,
+    save = function(_self) saved.n = saved.n + 1 end,
+  }
+  local p = {
+    settings = settings,
+    _saved = saved,
+    isAdmin = function() return isAdmin ~= false end,
+  }
+  return setmetatable(p, { __index = SoilSettingsPanel })
+end
+
+local function reset(answer, dialogAvailable)
+  shown, nextAnswer, available = nil, answer, dialogAvailable ~= false
+  installDialog()
+end
+
+-- ── ASK BEFORE ARMING ───────────────────────────────────────────────────────
+do
+  reset(nil)                       -- dialog opens, player has not answered yet
+  local p = newPanel(true, false)
+  p:requestChange("experimentalSystems", true)
+
+  T.ok("turning the gate on opens a confirmation", shown ~= nil)
+  T.eq("the setting is NOT changed while the question is open", p.settings.experimentalSystems, false)
+  T.eq("the dialog carries the requested value", shown.args.value, true)
+  T.eq("it is presented as a warning, not a neutral question", shown.dialogType, DialogElement.TYPE_WARNING)
+  T.ok("the warning says the systems are unfinished", shown.text:find("NOT finished", 1, true) ~= nil)
+  T.ok("the warning tells the player to back up", shown.text:lower():find("backup", 1, true) ~= nil)
+end
+
+-- ── ABORT IS A NO-OP ────────────────────────────────────────────────────────
+do
+  reset(false)
+  local p = newPanel(true, false)
+  p:requestChange("experimentalSystems", true)
+  T.eq("abort leaves the gate off", p.settings.experimentalSystems, false)
+  T.eq("abort writes nothing to disk", p._saved.n, 0)
+end
+
+do
+  -- The same guarantee in the other direction: aborting a disable must not disable.
+  reset(false)
+  local p = newPanel(true, true)
+  p:requestChange("experimentalSystems", false)
+  T.eq("abort leaves the gate on", p.settings.experimentalSystems, true)
+  T.eq("abort writes nothing to disk", p._saved.n, 0)
+end
+
+-- ── CONFIRM APPLIES ─────────────────────────────────────────────────────────
+do
+  reset(true)
+  local p = newPanel(true, false)
+  p:requestChange("experimentalSystems", true)
+  T.eq("confirm arms the gate", p.settings.experimentalSystems, true)
+  T.ok("confirm persists the change", p._saved.n > 0)
+end
+
+do
+  reset(true)
+  local p = newPanel(true, true)
+  p:requestChange("experimentalSystems", false)
+  T.eq("confirm disarms the gate", p.settings.experimentalSystems, false)
+  T.ok("the off warning explains what stops", shown.text:lower():find("stop running", 1, true) ~= nil)
+end
+
+-- ── FAIL CLOSED ─────────────────────────────────────────────────────────────
+do
+  reset(true, false)               -- YesNoDialog absent entirely
+  local p = newPanel(true, false)
+  p:requestChange("experimentalSystems", true)
+  T.eq("with no dialog available the gate REFUSES rather than opening",
+    p.settings.experimentalSystems, false)
+  T.eq("and nothing is written", p._saved.n, 0)
+end
+
+-- ── NO PROMPT ON A NO-OP ────────────────────────────────────────────────────
+do
+  reset(nil)
+  local p = newPanel(true, true)
+  p:requestChange("experimentalSystems", true)   -- already true
+  T.ok("re-selecting the current value asks nothing", shown == nil)
+end
+
+-- ── EVERY OTHER SETTING IS UNTOUCHED ────────────────────────────────────────
+do
+  reset(nil)
+  local p = newPanel(true, false)
+  p:requestChange("difficulty", 3)
+  T.ok("an ordinary setting never opens the confirmation", shown == nil)
+  T.eq("an ordinary setting applies immediately", p.settings.difficulty, 3)
+end
+
+-- ── A NON-ADMIN IS REFUSED BEFORE BEING WARNED ──────────────────────────────
+do
+  reset(nil)
+  local p = newPanel(false, false)
+  p:requestChange("experimentalSystems", true)
+  T.ok("a non-admin is never shown a confirmation we would then reject", shown == nil)
+  T.eq("and the gate stays shut", p.settings.experimentalSystems, false)
+end
+
+-- ── RESET SKIPS THE ASK ─────────────────────────────────────────────────────
+do
+  reset(nil)
+  local p = newPanel(true, true)
+  p:requestChange("experimentalSystems", false, true)
+  T.ok("a reset does not open a modal inside its loop", shown == nil)
+  T.eq("a reset restores the locked default directly", p.settings.experimentalSystems, false)
+end

--- a/tools/test/lua/experimental_confirm_test.lua
+++ b/tools/test/lua/experimental_confirm_test.lua
@@ -1,20 +1,23 @@
 -- experimental_confirm_test.lua - the experimental gate never flips on one click.
 --
 -- The gate arms UNFINISHED systems on a live savegame, so the panel asks first.
--- The property that matters is not "a dialog appeared", it is that ABORT LEAVES
+-- The property that matters is not "a prompt appeared", it is that ABORT LEAVES
 -- THE SETTING EXACTLY AS IT WAS. A confirmation that fails open is worse than no
 -- confirmation at all, because the player now believes they declined.
 --
+-- The prompt is DRAWN inside the settings panel rather than shown as a base-game
+-- YesNoDialog, and that is not only a style choice: SoilSettingsPanel:update()
+-- closes the panel whenever g_gui reports a dialog visible, so a GUI dialog would
+-- dismiss the very panel the player is answering for.
+--
 -- Locked here:
---   ASK BEFORE ARMING   - flipping experimentalSystems routes through the dialog
---                         and does NOT reach the change path on its own.
+--   ASK BEFORE ARMING   - flipping experimentalSystems raises the prompt and does
+--                         NOT reach the change path on its own.
 --   ABORT IS A NO-OP    - answering no leaves the stored value untouched.
 --   CONFIRM APPLIES     - answering yes performs exactly the requested change.
---   FAIL CLOSED         - if the dialog is unavailable the change is REFUSED,
---                         not silently applied. A gate that cannot ask must not
---                         open.
---   EVERY OTHER SETTING IS UNTOUCHED - the interception is surgical; no other
---                         setting gains a prompt.
+--   NO PENDING STATE SURVIVES - closing the panel aborts the question; a pending
+--                         value must never outlive the surface that asked.
+--   EVERY OTHER SETTING IS UNTOUCHED - the interception is surgical.
 --   NO PROMPT ON A NO-OP - re-selecting the value it already has must not ask.
 --   RESET SKIPS THE ASK  - resetCurrentCategory runs in a loop a modal would
 --                         break, and only ever restores the LOCKED default.
@@ -26,25 +29,6 @@
 -- translation; returning "" is the real "key absent" case.
 g_i18n = { getText = function(_self, _key) return "" end, hasText = function() return false end }
 
--- ── A stand-in for the dialog, recording what it was asked ──────────────────
-local shown = nil
-local nextAnswer = nil          -- what the player "clicks"
-local available = true
-
-DialogElement = { TYPE_WARNING = 2, TYPE_QUESTION = 1 }
-
-local function installDialog()
-  if not available then YesNoDialog = nil return end
-  YesNoDialog = {
-    show = function(callback, target, text, title, yesText, noText, dialogType, _ys, _ns, args)
-      shown = { text = text, title = title, yes = yesText, no = noText,
-                dialogType = dialogType, args = args }
-      if nextAnswer ~= nil then callback(target, nextAnswer, args) end
-    end,
-  }
-end
-
--- ── A minimal panel over a fake settings store ──────────────────────────────
 local function newPanel(isAdmin, startValue)
   local saved = { n = 0 }
   local settings = {
@@ -55,106 +39,114 @@ local function newPanel(isAdmin, startValue)
   local p = {
     settings = settings,
     _saved = saved,
+    isVisible = true,
     isAdmin = function() return isAdmin ~= false end,
   }
   return setmetatable(p, { __index = SoilSettingsPanel })
 end
 
-local function reset(answer, dialogAvailable)
-  shown, nextAnswer, available = nil, answer, dialogAvailable ~= false
-  installDialog()
-end
-
 -- ── ASK BEFORE ARMING ───────────────────────────────────────────────────────
 do
-  reset(nil)                       -- dialog opens, player has not answered yet
   local p = newPanel(true, false)
   p:requestChange("experimentalSystems", true)
 
-  T.ok("turning the gate on opens a confirmation", shown ~= nil)
+  T.ok("turning the gate on raises the prompt", p.confirmVisible == true)
   T.eq("the setting is NOT changed while the question is open", p.settings.experimentalSystems, false)
-  T.eq("the dialog carries the requested value", shown.args.value, true)
-  T.eq("it is presented as a warning, not a neutral question", shown.dialogType, DialogElement.TYPE_WARNING)
-  T.ok("the warning says the systems are unfinished", shown.text:find("NOT finished", 1, true) ~= nil)
-  T.ok("the warning tells the player to back up", shown.text:lower():find("backup", 1, true) ~= nil)
+  T.eq("the pending value is the requested one", p.confirmValue, true)
+  T.eq("nothing is written while the question is open", p._saved.n, 0)
+  T.ok("the warning says the systems are unfinished",
+    p.confirmText:find("NOT finished", 1, true) ~= nil)
+  T.ok("the warning tells the player to keep a backup",
+    p.confirmText:lower():find("backup", 1, true) ~= nil)
+  T.ok("the question is asked as its own line, not buried in the body",
+    p.confirmQuestion:find("ON?", 1, true) ~= nil)
+  T.ok("the body does not repeat the question",
+    p.confirmText:find("Turn experimental", 1, true) == nil)
 end
 
--- ── ABORT IS A NO-OP ────────────────────────────────────────────────────────
+-- ── ABORT IS A NO-OP, IN BOTH DIRECTIONS ────────────────────────────────────
 do
-  reset(false)
   local p = newPanel(true, false)
   p:requestChange("experimentalSystems", true)
+  p:handleClick("exp_confirm_no")
   T.eq("abort leaves the gate off", p.settings.experimentalSystems, false)
   T.eq("abort writes nothing to disk", p._saved.n, 0)
+  T.ok("abort clears the prompt", p.confirmVisible == false)
+  T.eq("abort clears the pending value", p.confirmValue, nil)
 end
 
 do
-  -- The same guarantee in the other direction: aborting a disable must not disable.
-  reset(false)
   local p = newPanel(true, true)
   p:requestChange("experimentalSystems", false)
+  T.ok("the off warning explains what stops",
+    p.confirmText:lower():find("stop running", 1, true) ~= nil)
+  p:handleClick("exp_confirm_no")
   T.eq("abort leaves the gate on", p.settings.experimentalSystems, true)
   T.eq("abort writes nothing to disk", p._saved.n, 0)
 end
 
 -- ── CONFIRM APPLIES ─────────────────────────────────────────────────────────
 do
-  reset(true)
   local p = newPanel(true, false)
   p:requestChange("experimentalSystems", true)
+  p:handleClick("exp_confirm_yes")
   T.eq("confirm arms the gate", p.settings.experimentalSystems, true)
   T.ok("confirm persists the change", p._saved.n > 0)
+  T.ok("confirm clears the prompt", p.confirmVisible == false)
 end
 
 do
-  reset(true)
   local p = newPanel(true, true)
   p:requestChange("experimentalSystems", false)
+  p:handleClick("exp_confirm_yes")
   T.eq("confirm disarms the gate", p.settings.experimentalSystems, false)
-  T.ok("the off warning explains what stops", shown.text:lower():find("stop running", 1, true) ~= nil)
 end
 
--- ── FAIL CLOSED ─────────────────────────────────────────────────────────────
+-- ── NO PENDING STATE SURVIVES THE SURFACE THAT ASKED ────────────────────────
 do
-  reset(true, false)               -- YesNoDialog absent entirely
+  -- Escape, the [X], the hotkey and the auto-close in update() all route through
+  -- close(). None of them is an answer, so none may leave a live pending value
+  -- that a later Confirm could pick up.
   local p = newPanel(true, false)
   p:requestChange("experimentalSystems", true)
-  T.eq("with no dialog available the gate REFUSES rather than opening",
-    p.settings.experimentalSystems, false)
-  T.eq("and nothing is written", p._saved.n, 0)
+  p:close()
+  T.ok("closing the panel clears the prompt", p.confirmVisible == false)
+  T.eq("closing the panel clears the pending value", p.confirmValue, nil)
+  T.eq("closing the panel changes nothing", p.settings.experimentalSystems, false)
+
+  -- And a Confirm arriving after the close must be inert rather than replaying.
+  p:handleClick("exp_confirm_yes")
+  T.eq("a stale confirm after close applies nothing", p.settings.experimentalSystems, false)
+  T.eq("and still writes nothing", p._saved.n, 0)
 end
 
 -- ── NO PROMPT ON A NO-OP ────────────────────────────────────────────────────
 do
-  reset(nil)
   local p = newPanel(true, true)
   p:requestChange("experimentalSystems", true)   -- already true
-  T.ok("re-selecting the current value asks nothing", shown == nil)
+  T.ok("re-selecting the current value asks nothing", p.confirmVisible ~= true)
 end
 
 -- ── EVERY OTHER SETTING IS UNTOUCHED ────────────────────────────────────────
 do
-  reset(nil)
   local p = newPanel(true, false)
   p:requestChange("difficulty", 3)
-  T.ok("an ordinary setting never opens the confirmation", shown == nil)
+  T.ok("an ordinary setting never raises the prompt", p.confirmVisible ~= true)
   T.eq("an ordinary setting applies immediately", p.settings.difficulty, 3)
 end
 
 -- ── A NON-ADMIN IS REFUSED BEFORE BEING WARNED ──────────────────────────────
 do
-  reset(nil)
   local p = newPanel(false, false)
   p:requestChange("experimentalSystems", true)
-  T.ok("a non-admin is never shown a confirmation we would then reject", shown == nil)
+  T.ok("a non-admin is never shown a prompt we would then reject", p.confirmVisible ~= true)
   T.eq("and the gate stays shut", p.settings.experimentalSystems, false)
 end
 
 -- ── RESET SKIPS THE ASK ─────────────────────────────────────────────────────
 do
-  reset(nil)
   local p = newPanel(true, true)
   p:requestChange("experimentalSystems", false, true)
-  T.ok("a reset does not open a modal inside its loop", shown == nil)
+  T.ok("a reset does not raise a modal inside its loop", p.confirmVisible ~= true)
   T.eq("a reset restores the locked default directly", p.settings.experimentalSystems, false)
 end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1386,8 +1386,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1383,6 +1383,11 @@
     <e k="wc_rf_pda_open_manager" v="Abrir gerenciador de trabalhadores" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planejador de rotação" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detalhe do campo" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -1357,5 +1357,10 @@
     <e k="wc_rf_pda_open_manager" v="Otevřít správce pracovníků" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Plánovač osevního postupu" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detail pole" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 </l10n>

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -1360,7 +1360,9 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1398,7 +1398,9 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1395,5 +1395,10 @@
     <e k="wc_rf_pda_open_manager" v="開啟工人管理員" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="輪作規劃" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="田地詳情" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1375,6 +1375,11 @@
     <e k="wc_rf_pda_open_manager" v="Otevřít správce pracovníků" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Plánovač osevního postupu" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detail pole" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1378,8 +1378,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1335,7 +1335,9 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 </l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1332,5 +1332,10 @@
     <e k="wc_rf_pda_open_manager" v="Åbn medarbejderstyring" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Rotationsplanlægger" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Markdetaljer" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1353,6 +1353,11 @@
     <e k="wc_rf_pda_open_manager" v="Arbeitermanager öffnen" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Fruchtfolgeplaner" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Felddetails" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1356,8 +1356,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1338,8 +1338,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1335,6 +1335,11 @@
     <e k="wc_rf_pda_open_manager" v="Abrir gestor de trabajadores" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planificador de rotación" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detalle del campo" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1401,5 +1401,10 @@
     <e k="wc_rf_pda_open_manager" v="Open Worker Manager" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Rotation Planner" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Field Detail" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1404,7 +1404,9 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1338,8 +1338,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1335,6 +1335,11 @@
     <e k="wc_rf_pda_open_manager" v="Abrir gestor de trabajadores" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planificador de rotación" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detalle del campo" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1398,7 +1398,9 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 </l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1395,5 +1395,10 @@
     <e k="wc_rf_pda_open_manager" v="Ouvrir le gestionnaire d'ouvriers" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planificateur de rotation" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Détail du champ" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1336,6 +1336,11 @@
     <e k="wc_rf_pda_open_manager" v="Avaa työntekijähallinta" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Viljelykiertosuunnittelija" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Pellon tiedot" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1339,8 +1339,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1338,7 +1338,9 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1335,5 +1335,10 @@
     <e k="wc_rf_pda_open_manager" v="Ouvrir le gestionnaire d'ouvriers" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planificateur de rotation" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Détail du champ" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1355,6 +1355,11 @@
     <e k="wc_rf_pda_open_manager" v="Dolgozókezelő megnyitása" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Vetésforgó-tervező" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Táblarészletek" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1358,8 +1358,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1382,6 +1382,11 @@
     <e k="wc_rf_pda_open_manager" v="Buka manajer pekerja" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Perencana rotasi" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detail lahan" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1385,8 +1385,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1382,6 +1382,11 @@
     <e k="wc_rf_pda_open_manager" v="Apri gestore operai" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Pianificatore rotazioni" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Dettaglio campo" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1385,8 +1385,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1362,6 +1362,11 @@
     <e k="wc_rf_pda_open_manager" v="作業員マネージャーを開く" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="輪作プランナー" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="畑の詳細" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1365,8 +1365,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1366,8 +1366,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1363,6 +1363,11 @@
     <e k="wc_rf_pda_open_manager" v="작업자 관리자 열기" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="윤작 계획기" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="밯 상세" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1369,8 +1369,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1366,6 +1366,11 @@
     <e k="wc_rf_pda_open_manager" v="Werkersbeheer openen" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Rotatieplanner" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Veldgegevens" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1367,8 +1367,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1364,6 +1364,11 @@
     <e k="wc_rf_pda_open_manager" v="Åpne arbeiderbehandler" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Rotasjonsplanlegger" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Feltdetaljer" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1367,8 +1367,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1364,6 +1364,11 @@
     <e k="wc_rf_pda_open_manager" v="Otwórz menedżera pracowników" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planer płodozmianu" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Szczegóły pola" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1386,8 +1386,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1383,6 +1383,11 @@
     <e k="wc_rf_pda_open_manager" v="Abrir gestor de trabalhadores" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planeador de rotação" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detalhe do campo" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1386,8 +1386,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1383,6 +1383,11 @@
     <e k="wc_rf_pda_open_manager" v="Deschide managerul de muncitori" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Planificator de rotație" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Detaliu câmp" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1324,6 +1324,11 @@
     <e k="wc_rf_pda_open_manager" v="Открыть менеджер работников" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Планировщик севооборота" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Сведения о поле" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1327,8 +1327,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1335,6 +1335,11 @@
     <e k="wc_rf_pda_open_manager" v="Öppna arbetshanteraren" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Växtföljdsplanerare" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Fältdetaljer" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1338,8 +1338,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1336,6 +1336,11 @@
     <e k="wc_rf_pda_open_manager" v="İşçi yöneticisini aç" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Ekim nöbeti planlayıcı" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Tarla detayı" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1339,8 +1339,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1338,8 +1338,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1335,6 +1335,11 @@
     <e k="wc_rf_pda_open_manager" v="Відкрити менеджер працівників" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Планувальник сівозміни" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Деталі поля" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1335,6 +1335,11 @@
     <e k="wc_rf_pda_open_manager" v="Mở trình quản lý công nhân" eh="1c6592d5" />
     <e k="sf_pda_btn_rotation_planner" v="Lập kế hoạch luân canh" eh="5404f1c2" />
     <e k="sf_pda_btn_field_detail" v="Chi tiết thửa ruộng" eh="03b5acd7" />
+    <e k="sf_exp_confirm_title" v="Experimental Systems" />
+    <e k="sf_exp_confirm_yes" v="Confirm" />
+    <e k="sf_exp_confirm_no" v="Abort" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
 </elements>
 
 

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1338,8 +1338,10 @@
     <e k="sf_exp_confirm_title" v="Experimental Systems" />
     <e k="sf_exp_confirm_yes" v="Confirm" />
     <e k="sf_exp_confirm_no" v="Abort" />
-    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Use a backup save.&#10;&#10;Turn experimental systems ON?" />
-    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they wrote stays where it is, but it will no longer be updated.&#10;&#10;Turn experimental systems OFF?" />
+    <e k="sf_exp_confirm_on" v="This turns on systems that are NOT finished. They can behave oddly, change without warning, or affect this savegame in ways that cannot be undone. Keep a backup save." />
+    <e k="sf_exp_confirm_off" v="Experimental systems will stop running on this savegame. Anything they already wrote stays where it is, but it will no longer be updated." />
+    <e k="sf_exp_confirm_q_on" v="Turn experimental systems ON?" />
+    <e k="sf_exp_confirm_q_off" v="Turn experimental systems OFF?" />
 </elements>
 
 


### PR DESCRIPTION
## The experimental gate asks before it flips

Turning Experimental Systems on arms **unfinished** systems on a live savegame, and it did that on a single click with nothing between the player and the consequence. It now warns and waits for a Confirm.

### Where it hooks

`SoilSettingsPanel:requestChange` is the single choke point every toggle, cycle and reset funnels through, so intercepting there means no path can flip the gate unasked. The original body moves to `_applyChange` **unchanged**; only a confirmed answer reaches it.

### The properties that matter

The point is not that a dialog appears. It is that **abort leaves the setting exactly as it was**, in both directions. A confirmation that fails open is worse than no confirmation at all, because the player now believes they declined.

- **FAIL CLOSED.** If `YesNoDialog` is unavailable the change is refused, not silently applied. A gate that cannot ask does not open.
- **Non-admins are refused BEFORE the prompt**, rather than being walked through a scary confirmation whose change we were always going to reject.
- **No prompt when the value is not actually changing** (re-selecting the current value).
- **`resetCurrentCategory` passes `skipConfirm`.** It is already a deliberate act, it runs in a loop a modal would break, and for this gate it only ever restores the LOCKED default. Nothing to warn about.

### The text

Presented as `DialogElement.TYPE_WARNING`, with direction-specific copy. Enabling says the systems are not finished, can change without warning, can affect the savegame irreversibly, and to keep a backup. Disabling says what they already wrote stays put but stops being updated. Buttons are Confirm / Abort.

`YesNoDialog.show(callback, target, text, title, yesText, noText, dialogType, ...)` per `gui/dialogs/YesNoDialog.lua:8`; the callback shape with a target set is `callback(target, value, args)` per `:82-86`.

### Verification

- Bench `experimental_confirm_test.lua`: **23 assertions** covering the ask, abort-in-both-directions, confirm applies, fail-closed, no-op, non-admin, reset-skips, and that no other setting gains a prompt.
- Full suite **2795 passed, 0 failed across 66 files**; Lua 5.1 syntax and lint clean.
- 5 l10n keys in **all 27** translation files, English fallbacks in code.
- **Not yet confirmed in-game.**

### Note on the version number

Bumped to **2.5.0.64**, deliberately past the 2.5.0.63 on `feat/SF-39-handful-panel` (PR #832), which is open in parallel. Whichever merges second will conflict on the version line in `modDesc.xml`; resolve it to 2.5.0.64.
