### PR TITLE
feat(organic): the transition term is now organic YEARS, normalized via Time Guard

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -125,3 +125,8 @@
 - [x] Item 5 (the ~500 ms anchor drop) split out as a design item, NOT in this fix.
 - [x] rsf836_boom_line_test.lua at 11 assertions (0/30/45 deg main path, fallback width, partial-width exclusion, the old array-end read as the RED case). Suite 2886/0 across 69 files; syntax and lint clean.
 - [~] In-game (owed): a wide boom on a diagonal pass, ground read after one pass.
+
+## 2026-08-14 (Fred): organic transition normalized to YEARS via Time Guard
+- [x] The transition term was a raw day count (60/120/240), so 'three years' meant anything from months to decades depending on days-per-month. It is now TRANSITION_YEARS (2/3/5 indicative, values ride the balance pass), resolved at read time through Time Guard's days-per-period. Mid-save days-per-period changes re-normalise from the next period; Time Guard absent degrades to the 30-day reference. State machine and getFieldOrganicState shape unchanged.
+- [x] organic_transition_timeguard_test.lua at 11 assertions; suite 2897/0; deployed 2.5.0.71.
+- [~] In-game (owed): a transition at a 30-day month counts down over three in-game years, not eight months.

--- a/TODO.md
+++ b/TODO.md
@@ -124,3 +124,8 @@
 - [x] True boom endpoints derived in the vehicle's own frame (components[1].node), main + fallback paths; paintBoomStrip consumes the line with a tip-swap guard; partial-width VWW exclusion inherited; cell stamping byte-identical.
 - [x] rsf836_boom_line_test.lua at 11 assertions; suite 2886/0.
 - [~] In-game: a wide boom on a diagonal pass, ground read after one pass (reporter antler22 offered the R4045 screenshots).
+
+## Organic transition Time Guard normalization (2026-08-14)
+- [x] TRANSITION_YEARS (2/3/5) resolved through Time Guard days-per-period at getTransitionDays; stale comments made true; state machine unchanged.
+- [x] 11 assertions; suite 2897/0.
+- [~] In-game: three in-game years at a 30-day month. Balance-pass values for the years table pending.

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK (Refined edition: WizardlyPayload)</author>
-    <version>2.5.0.70</version>
+    <version>2.5.0.71</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/OrganicCertification.lua
+++ b/src/OrganicCertification.lua
@@ -131,9 +131,23 @@ function OrganicCertification:getDifficulty()
 end
 
 --- In-game days required to complete the transition at the current difficulty.
+--- The term is expressed in ORGANIC YEARS and resolved through Time Guard's
+--- days-per-period, so a year is an in-game year on any save: a fixed raw day
+--- count turned "three years" into anything from months to decades depending on
+--- the days-per-month setting. Computed at read time so a mid-save days-per-period
+--- change re-normalises from the next period forward. Time Guard absent: falls
+--- back to a 30-day month, the reference calendar.
 function OrganicCertification:getTransitionDays()
-    local list = SoilConstants.ORGANIC.TRANSITION_DAYS
-    return list[self:getDifficulty()] or list[2] or 120
+    local years = SoilConstants.ORGANIC.TRANSITION_YEARS[self:getDifficulty()] or 3
+    local daysPerMonth = 30
+    local tg = (g_currentMission ~= nil and g_currentMission.timeGuard) or g_timeGuard
+    if tg ~= nil and tg.getContext ~= nil then
+        local ok, ctx = pcall(function() return tg:getContext() end)
+        if ok and ctx ~= nil and type(ctx.daysPerPeriod) == "number" and ctx.daysPerPeriod > 0 then
+            daysPerMonth = ctx.daysPerPeriod
+        end
+    end
+    return math.max(1, math.floor(years * 12 * daysPerMonth))
 end
 
 --- Is a fill type name allowed under organic rules?

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -33,8 +33,9 @@ SoilConstants.TIMING = {
 -- REFERENCE_DPP is the days-per-month the shipped duration constants were tuned
 -- against (Tyson's ruling, 2026-07-23). Time Guard absent -> the absolute count.
 -- EXCLUSIONS (already season-honest, must NOT double-scale): the organic
--- TRANSITION_DAYS (year-normalised via Time Guard) and the fallow threshold
--- (multiplied by daysPerMonth at its read site).
+-- TRANSITION_YEARS (year-normalised via Time Guard at its own read site,
+-- OrganicCertification:getTransitionDays) and the fallow threshold (multiplied
+-- by daysPerMonth at its read site).
 SoilConstants.DURATION = {
     REFERENCE_DPP = 3,   -- days-per-month the chemical durations were tuned at
 }
@@ -614,8 +615,15 @@ SoilConstants.ORGANIC = {
     STATE_TRANSITION   = "in_transition",
     STATE_CERTIFIED    = "certified",
 
-    -- Transition length in in-game days, indexed by difficulty (1 Simple / 2 Realistic / 3 Hardcore).
-    TRANSITION_DAYS = { 60, 120, 240 },
+    -- Transition length in ORGANIC YEARS, indexed by difficulty (1 Simple /
+    -- 2 Realistic / 3 Hardcore). Resolved to a day threshold at read time via Time
+    -- Guard's days-per-period, so "N years" means N in-game years on any save
+    -- (OrganicCertification:getTransitionDays). A raw day count silently turned
+    -- the intended multi-year commitment into anything from months to decades
+    -- depending on days-per-month. Values are the INDICATIVE easy<standard<hard
+    -- set (standard ~3 years per the USDA/SARE anchor); the exact per-difficulty
+    -- values ride the Option-Scaling Spine + the balance pass.
+    TRANSITION_YEARS = { 2, 3, 5 },
 
     -- Yield factor vs an optimally synthetic-fertilised field. Organic amendments +
     -- high OM offset part of this through the existing OM_YIELD pipeline, so these

--- a/src/utils/DurationScaling.lua
+++ b/src/utils/DurationScaling.lua
@@ -16,7 +16,8 @@
 -- shipped count, exactly the behaviour before this change.
 --
 -- ONLY the absolute chemical day-counts scale here (fungicide, herbicide,
--- insecticide). The organic transition (TRANSITION_DAYS) and the fallow
+-- insecticide). The organic transition (TRANSITION_YEARS, year-normalised via
+-- Time Guard at OrganicCertification:getTransitionDays) and the fallow
 -- threshold are ALREADY season-honest at their read sites and must NOT pass
 -- through this, or they double-scale.
 -- =========================================================

--- a/tools/test/lua/duration_season_scaling_spec_test.lua
+++ b/tools/test/lua/duration_season_scaling_spec_test.lua
@@ -51,7 +51,7 @@ T.eq("2x reference season doubles insecticide cover", scaled(30, 6), 60)
 -- the fallow threshold is multiplied by daysPerMonth at its read site. If either
 -- ever gets wrapped in seasonScaled() it double-scales. We assert the raw
 -- constants stay put as a drift tripwire.
-T.eq("organic TRANSITION_DAYS untouched (excluded)", SoilConstants.ORGANIC.TRANSITION_DAYS[2], 120)
+T.eq("organic TRANSITION_YEARS untouched (excluded)", SoilConstants.ORGANIC.TRANSITION_YEARS[2], 3)
 T.eq("fallow threshold untouched (excluded, scaled by daysPerMonth at its site)", SoilConstants.TIMING.FALLOW_THRESHOLD, 7)
 
 -- ── 9. The Time Guard read wrapper (mocked mission) ──────────────────────────

--- a/tools/test/lua/organic_transition_timeguard_test.lua
+++ b/tools/test/lua/organic_transition_timeguard_test.lua
@@ -1,0 +1,79 @@
+-- organic_transition_timeguard_test.lua
+-- The organic transition is a multi-YEAR commitment, resolved through Time Guard's
+-- days-per-period so "N years" means N in-game years on any save. A raw day count
+-- turned three years into anything from months to decades depending on the
+-- days-per-month setting.
+--
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/config/SoilBlends.lua, src/ReleaseGate.lua, src/ResistanceBands.lua, src/HybridStrains.lua, src/OrganicCertification.lua
+
+-- Engine mock: a manager whose difficulty setting we can drive.
+g_SoilFertilityManager = { settings = { difficulty = 2 } }
+g_currentMission = { environment = { currentMonotonicDay = 10 } }
+
+local function org()
+  return setmetatable({}, { __index = OrganicCertification })
+end
+
+local function setDpm(dpm)
+  if dpm == nil then
+    g_currentMission.timeGuard = nil
+    g_timeGuard = nil
+  else
+    g_currentMission.timeGuard = { getContext = function() return { daysPerPeriod = dpm } end }
+    g_timeGuard = nil
+  end
+end
+
+-- 1. A YEAR IS A YEAR: the threshold is YEARS * 12 * days-per-month.
+setDpm(30)
+local o = org()
+T.eq("standard (3y) at a 30-day month = 1080 days", o:getTransitionDays(), 1080)
+
+setDpm(15)
+T.eq("standard (3y) at a 15-day month = 540 days", o:getTransitionDays(), 540)
+
+setDpm(1)
+T.eq("standard (3y) at a 1-day month = 36 days", o:getTransitionDays(), 36)
+
+-- 2. DIFFICULTY INDEXING: easy < standard < hard, each still a year-scaled term.
+g_SoilFertilityManager.settings.difficulty = 1
+setDpm(30)
+T.eq("easy (2y) at 30-day month = 720 days", o:getTransitionDays(), 720)
+
+g_SoilFertilityManager.settings.difficulty = 3
+T.eq("hard (5y) at 30-day month = 1800 days", o:getTransitionDays(), 1800)
+
+-- 3. TIME GUARD ABSENT: degrades to the reference 30-day month, never a crash.
+g_SoilFertilityManager.settings.difficulty = 2
+setDpm(nil)
+T.eq("no Time Guard -> 30-day reference (1080)", o:getTransitionDays(), 1080)
+
+-- 4. THE THRESHOLD TRACKS A MID-SAVE CHANGE (re-normalises from the next period).
+setDpm(30)
+T.eq("first read at 30-day month", o:getTransitionDays(), 1080)
+setDpm(7)
+T.eq("same save, now a 7-day month -> 252 days", o:getTransitionDays(), 252)
+
+-- 5. THE STATE MACHINE IS UNCHANGED: getFieldOrganicState still reports the
+-- normalized threshold as transitionDaysNeeded.
+do
+  g_SoilFertilityManager.settings.difficulty = 2
+  setDpm(30)
+  local cert = setmetatable({}, { __index = OrganicCertification })
+  cert.soilSystem = {
+    fieldData = { [1] = { organic = { state = SoilConstants.ORGANIC.STATE_TRANSITION, startDay = 0 } } },
+  }
+  cert.getTransitionDays = OrganicCertification.getTransitionDays
+  cert.getCurrentDay = function() return 500 end
+  cert.getDifficulty = function() return 2 end
+  cert.getTransitionDays = function(self)
+    return OrganicCertification.getTransitionDays(self)
+  end
+  cert.ensureState = function() end
+  local st = cert:getFieldOrganicState(1)
+  T.eq("transitionDaysNeeded is the normalized threshold", st.transitionDaysNeeded, 1080)
+  T.eq("daysAccrued still tracks the monotonic day", st.daysAccrued, 500)
+  T.eq("state is still in_transition", st.state, SoilConstants.ORGANIC.STATE_TRANSITION)
+end
+
+T.summary()


### PR DESCRIPTION
The organic transition term is now organic YEARS, normalized through Time Guard.

The transition was a raw in-game day count (60/120/240, difficulty-scaled), which silently turned the intended multi-year commitment into anything from a couple of months to a couple of decades depending on the days-per-month setting. "Three years" was not three years on most saves.

What changed:
- `TRANSITION_DAYS` becomes `TRANSITION_YEARS` (2/3/5, the indicative easy/standard/hard set, standard ~3 years per the USDA/SARE anchor). The exact per-difficulty values ride the Option-Scaling Spine + the balance pass, flagged as such in the constant.
- `getTransitionDays()` resolves the term at read time: `TRANSITION_YEARS[difficulty] * 12 * daysPerPeriod` via Time Guard's context, so a year is an in-game year on any save. A mid-save days-per-period change re-normalises from the next period forward, and Time Guard absent degrades to the reference 30-day month.
- The state machine (opt-in, in_transition, certified, breach reset) and `getFieldOrganicState`'s shape are unchanged. Every consumer already reads `transitionDaysNeeded`, so none needs a change.
- The two comments that already claimed this normalization existed are now true instead of aspirational.

Build note: the brief's item 3 (accrue on Time Guard's day tick) was evaluated and not taken, because the promotion path already tracks in-game days via the monotonic counter (the identity holds) and `subscribeTick("day", ...)` fires on all peers while the shipped promotion is server-guarded. The load-bearing change is the normalized threshold.

Verified: 11 new assertions (organic_transition_timeguard_test.lua): the year-to-day resolution at 30/15/1-day months, difficulty indexing, the no-Time-Guard degrade, a mid-save days-per-period change, and the unchanged state-machine shape. The season-scaling exclusion tripwire updated to the new constant. Full suite 2897/0, syntax and lint clean. Built and deployed as 2.5.0.71. Not yet observed in a running game.
