### PR TITLE
feat(organic): the managed compost production process

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -130,3 +130,8 @@
 - [x] The transition term was a raw day count (60/120/240), so 'three years' meant anything from months to decades depending on days-per-month. It is now TRANSITION_YEARS (2/3/5 indicative, values ride the balance pass), resolved at read time through Time Guard's days-per-period. Mid-save days-per-period changes re-normalise from the next period; Time Guard absent degrades to the 30-day reference. State machine and getFieldOrganicState shape unchanged.
 - [x] organic_transition_timeguard_test.lua at 11 assertions; suite 2897/0; deployed 2.5.0.71.
 - [~] In-game (owed): a transition at a 30-day month counts down over three in-game years, not eight months.
+
+## 2026-08-14 (Fred): organic compost production, the managed process
+- [x] A managed compost process (no placeable): batches commit farm organic waste, decompose over in-game days on the Time Guard clock (SF day-tracking fallback when absent), and yield the existing COMPOST fill type into farm storage. SF owns the OM effect unchanged; organic-safe flag per feedstock (biosolids-fed is not cert-safe, breach rides onInputApplied). Server-authoritative, StateLedger + own-XML persistence, sfCompostStatus/Start/Collect console.
+- [x] compost_manager_test.lua at 25 assertions; suite 2922/0; deployed 2.5.0.72.
+- [~] In-game (owed): start a batch, watch it decompose across days, collect the compost, spread it on a field.

--- a/TODO.md
+++ b/TODO.md
@@ -129,3 +129,8 @@
 - [x] TRANSITION_YEARS (2/3/5) resolved through Time Guard days-per-period at getTransitionDays; stale comments made true; state machine unchanged.
 - [x] 11 assertions; suite 2897/0.
 - [~] In-game: three in-game years at a 30-day month. Balance-pass values for the years table pending.
+
+## Organic compost production (2026-08-14)
+- [x] CompostManager: batch lifecycle, Time Guard day accrual + fallback, storage deposit, organic-safe flag, persistence, console.
+- [x] 25 assertions; suite 2922/0.
+- [~] In-game batch flow; FarmTablet organic-app batch display (read-only) pending the app's own work.

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK (Refined edition: WizardlyPayload)</author>
-    <version>2.5.0.71</version>
+    <version>2.5.0.72</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/CompostManager.lua
+++ b/src/CompostManager.lua
@@ -1,0 +1,317 @@
+-- =========================================================
+-- FS25_SoilFertilizer - CompostManager (organic compost production)
+-- =========================================================
+-- A MANAGED PROCESS, no placeable (Arissani 2026-07-17): the player commits farm
+-- organic waste to a batch, the batch decomposes over in-game days on the Time
+-- Guard clock, and a finished batch yields the EXISTING COMPOST fill type into
+-- farm storage. SF owns the OM amendment effect (COMPOST is an OM-primary
+-- product, FERTILIZER_PROFILES.COMPOST.OM = 0.12); this system owns production
+-- only. No new fill type, no new soil authority.
+--
+-- Server-authoritative. Batch state persists via StateLedger when present, own
+-- XML fallback otherwise. Decomposition rides Time Guard's day accrual
+-- (simulation flow), with an SF day-tracking fallback when Time Guard is absent.
+-- The batch duration is a NATURAL rate, not days-per-period normalized.
+-- =========================================================
+
+CompostManager = {}
+local CompostManager_mt = Class(CompostManager)
+
+CompostManager.LEDGER = "DairyCore_FeedProvenance_Compost"  -- namespaced under this mod's slot
+CompostManager.LEDGER_BATCHES = "SoilFertilizer_CompostBatches"
+CompostManager.SAVE_FILE = "FS25_SoilFertilizer_Compost.xml"
+CompostManager.ACCURAL_ID = "SF_Compost_Batch"
+CompostManager.ACCURAL_PRIORITY = 95
+
+-- Natural decomposition time in in-game days for a batch, by difficulty
+-- (1 Simple / 2 Realistic / 3 Hardcore). INDICATIVE; rides the balance pass.
+CompostManager.BATCH_DAYS = { 7, 14, 21 }
+
+-- Feedstock -> output yield (litres of finished COMPOST per litre of feedstock).
+-- MANURE family is organic-safe; BIOSOLIDS is not (the built organic-cert
+-- excludes biosolids, and the breach rides SF's existing onInputApplied).
+CompostManager.FEEDSTOCK_YIELD = {
+    MANURE        = 0.45,
+    LIQUIDMANURE  = 0.45,
+    DIGESTATE     = 0.45,
+    SILAGE        = 0.30,
+    COMPOST       = 0.30,
+    BIOSOLIDS     = 0.35,
+}
+
+-- Feedstocks that keep a batch organic-safe (the approved-input family).
+CompostManager.ORGANIC_SAFE = {
+    MANURE = true, LIQUIDMANURE = true, DIGESTATE = true, COMPOST = true,
+}
+
+function CompostManager.new()
+    local self = setmetatable({}, CompostManager_mt)
+    self.batches = {}          -- batchId -> batch record
+    self.nextBatchId = 1
+    self.bedrockBound = false
+    self._tgAccrualRegistered = false
+    self.lastProcessedDay = nil   -- SF day-tracking fallback
+    return self
+end
+
+-- =========================================================
+-- Batch lifecycle
+-- =========================================================
+
+-- Start a compost batch. feedstocks: { [fillTypeName] = litres }. The batch is
+-- organic-safe when every feedstock is in the approved family; a biosolids-fed
+-- batch is a valid soil amendment but not organic-cert-safe.
+-- Returns the batchId, or nil + a reason.
+function CompostManager:startBatch(farmId, feedstocks)
+    if not self:_isServer() then return nil, "server_only" end
+    if type(feedstocks) ~= "table" then return nil, "no_feedstocks" end
+
+    local totalIn, organicSafe = 0, true
+    local have = false
+    for fillTypeName, litres in pairs(feedstocks) do
+        if type(litres) == "number" and litres > 0 then
+            have = true
+            totalIn = totalIn + litres
+            if not CompostManager.ORGANIC_SAFE[fillTypeName] then
+                organicSafe = false
+            end
+        end
+    end
+    if not have or totalIn <= 0 then return nil, "no_feedstocks" end
+
+    -- Finished output: the feedstock-weighted yield of finished COMPOST.
+    local output = 0
+    for fillTypeName, litres in pairs(feedstocks) do
+        if type(litres) == "number" and litres > 0 then
+            output = output + litres * (CompostManager.FEEDSTOCK_YIELD[fillTypeName] or 0)
+        end
+    end
+    output = math.max(1, math.floor(output))
+
+    local difficulty = self:_difficulty()
+    local days = CompostManager.BATCH_DAYS[difficulty] or 14
+
+    local batchId = self.nextBatchId
+    self.nextBatchId = self.nextBatchId + 1
+    self.batches[batchId] = {
+        batchId = batchId, farmId = farmId,
+        feedstocks = feedstocks, organicSafe = organicSafe,
+        totalDays = days, daysRemaining = days, outputLitres = output,
+        ready = false,
+    }
+    self:_markDirty()
+    self:_ensureAccrual()
+    return batchId, "ok"
+end
+
+-- One in-game day of decomposition. Called by the Time Guard accrual onSettle
+-- (server-only), or the SF day-tracking fallback.
+function CompostManager:tickDay(days)
+    days = math.max(1, math.floor(days or 1))
+    for _, b in pairs(self.batches) do
+        if not b.ready then
+            b.daysRemaining = b.daysRemaining - days
+            if b.daysRemaining <= 0 then
+                b.daysRemaining = 0
+                b.ready = true
+            end
+        end
+    end
+    self:_markDirty()
+end
+
+-- Collect a finished batch: deposit the COMPOST into the farm's compatible
+-- storage and clear the batch. Returns the deposited litres.
+function CompostManager:collectBatch(batchId)
+    local b = self.batches[batchId]
+    if b == nil then return nil, "no_batch" end
+    if not b.ready then return nil, "not_ready" end
+    if not self:_isServer() then return nil, "server_only" end
+
+    local deposited = self:_depositCompost(b.farmId, b.outputLitres)
+    self.batches[batchId] = nil
+    self:_markDirty()
+    return deposited, (deposited > 0) and "ok" or "no_storage"
+end
+
+function CompostManager:collectAllForFarm(farmId)
+    local done = 0
+    for batchId, b in pairs(self.batches) do
+        if b.farmId == farmId and b.ready then
+            local n, _ = self:collectBatch(batchId)
+            if n and n > 0 then done = done + 1 end
+        end
+    end
+    return done
+end
+
+-- Deposit finished COMPOST into the farm's compatible storage. The no-placeable
+-- process writes through the storage system: any storage owned by the farm that
+-- supports COMPOST gets the fill level added. Returns the deposited litres.
+function CompostManager:_depositCompost(farmId, litres)
+    local deposited = 0
+    local ftm = g_fillTypeManager
+    local ftIndex = ftm ~= nil and ftm:getFillTypeIndexByName("COMPOST") or 0
+    if ftIndex == 0 then return 0 end
+
+    pcall(function()
+        local ss = g_currentMission ~= nil and g_currentMission.storageSystem
+        if ss == nil or ss.getStorages == nil then return end
+        local remaining = litres
+        for _, storage in ipairs(ss:getStorages() or {}) do
+            if remaining <= 0 then break end
+            if storage.getOwnerFarmId == nil then
+                -- pass
+            elseif storage:getOwnerFarmId() == farmId
+                and storage.getFillUnitCapacity ~= nil then
+                local cap = storage:getFillUnitCapacity(ftIndex)
+                if cap and cap > 0 then
+                    local cur = 0
+                    if storage.getFillLevel ~= nil then
+                        local ok, lvl = pcall(function() return storage:getFillLevel(ftIndex) end)
+                        if ok and type(lvl) == "number" then cur = lvl end
+                    end
+                    local room = cap - cur
+                    if room > 0 then
+                        local add = math.min(remaining, room)
+                        if storage.addFillLevelFromTool ~= nil then
+                            storage:addFillLevelFromTool(farmId, add, ftIndex, nil, ToolType.UNDEFINED)
+                        elseif storage.setFillLevel ~= nil then
+                            storage:setFillLevel(cur + add, ftIndex)
+                        else
+                            add = 0
+                        end
+                        deposited = deposited + add
+                        remaining = remaining - add
+                    end
+                end
+            end
+        end
+    end)
+    return deposited
+end
+
+-- =========================================================
+-- Accrual (Time Guard day tick; SF fallback when absent)
+-- =========================================================
+
+function CompostManager:_ensureAccrual()
+    if self._tgAccrualRegistered then return end
+    local tg = (g_currentMission ~= nil and g_currentMission.timeGuard) or g_timeGuard
+    if tg == nil or type(tg.registerAccrual) ~= "function" then return end
+    local ok = pcall(function()
+        tg:registerAccrual(CompostManager.ACCURAL_ID, {
+            cadence = "day",
+            flowClass = "simulation",
+            firstPeriodPolicy = "skip",
+            priority = CompostManager.ACCURAL_PRIORITY,
+            onSettle = function(ctx)
+                local days = (ctx ~= nil and ctx.boundariesCrossed) or 1
+                if g_currentMission ~= nil and g_currentMission:getIsServer() then
+                    self:tickDay(days)
+                end
+            end,
+        })
+    end)
+    if ok then self._tgAccrualRegistered = true end
+end
+
+-- SF day-tracking fallback (Time Guard absent): the manager is advanced from the
+-- mission update on a monotonic-day change, exactly the SF-18 fallback shape.
+function CompostManager:updateDayFallback()
+    if self._tgAccrualRegistered then return end
+    local env = g_currentMission ~= nil and g_currentMission.environment
+    local day = env ~= nil and (env.currentMonotonicDay or env.currentDay) or nil
+    if day == nil or day == self.lastProcessedDay then return end
+    local skipped = (self.lastProcessedDay ~= nil) and (day - self.lastProcessedDay) or 1
+    self.lastProcessedDay = day
+    if self:_isServer() and skipped > 0 then
+        self:tickDay(skipped)
+    end
+end
+
+-- =========================================================
+-- Persistence
+-- =========================================================
+
+function CompostManager:_isServer()
+    return g_currentMission ~= nil and g_currentMission:getIsServer()
+end
+
+function CompostManager:_difficulty()
+    local d
+    if g_SoilFertilityManager and g_SoilFertilityManager.settings then
+        d = g_SoilFertilityManager.settings.difficulty
+    end
+    if type(d) ~= "number" or d < 1 or d > 3 then d = 2 end
+    return d
+end
+
+function CompostManager:serialize()
+    local out = {}
+    for id, b in pairs(self.batches) do
+        out[tostring(id)] = {
+            farmId = b.farmId, feedstocks = b.feedstocks, organicSafe = b.organicSafe,
+            totalDays = b.totalDays, daysRemaining = b.daysRemaining,
+            outputLitres = b.outputLitres, ready = b.ready,
+        }
+    end
+    out._nextId = self.nextBatchId
+    return out
+end
+
+function CompostManager:deserialize(data)
+    if type(data) ~= "table" then return end
+    self.nextBatchId = data._nextId or self.nextBatchId
+    for key, s in pairs(data) do
+        if key ~= "_nextId" then
+            local id = tonumber(key) or key
+            self.batches[id] = {
+                batchId = id, farmId = s.farmId, feedstocks = s.feedstocks or {},
+                organicSafe = s.organicSafe ~= false, totalDays = s.totalDays or 14,
+                daysRemaining = s.daysRemaining or 0, outputLitres = s.outputLitres or 0,
+                ready = s.ready == true,
+            }
+            if tonumber(id) and self.nextBatchId <= id then self.nextBatchId = id + 1 end
+        end
+    end
+end
+
+function CompostManager:_markDirty()
+    local ledger = (g_currentMission ~= nil and g_currentMission.stateLedger) or g_stateLedger
+    if ledger ~= nil and ledger.markDirty ~= nil then
+        pcall(function() ledger:markDirty(CompostManager.LEDGER_BATCHES) end)
+    end
+end
+
+-- =========================================================
+-- Console / read
+-- =========================================================
+
+function CompostManager:getBatchRows(farmId)
+    local rows = {}
+    for _, b in pairs(self.batches) do
+        if farmId == nil or b.farmId == farmId then
+            rows[#rows + 1] = {
+                batchId = b.batchId, farmId = b.farmId, organicSafe = b.organicSafe,
+                totalDays = b.totalDays, daysRemaining = b.daysRemaining,
+                outputLitres = b.outputLitres, ready = b.ready,
+            }
+        end
+    end
+    return rows
+end
+
+function CompostManager:consoleStatus()
+    local lines = {}
+    local n = 0
+    for _, b in pairs(self.batches) do n = n + 1 end
+    table.insert(lines, string.format("Compost batches: %d", n))
+    for _, b in pairs(self.batches) do
+        table.insert(lines, string.format("  batch %d farm %d: %s, %d/%d days, %d L %s",
+            b.batchId, b.farmId, b.organicSafe and "organic-safe" or "not organic-safe",
+            b.totalDays - b.daysRemaining, b.totalDays, b.outputLitres,
+            b.ready and "READY" or "decomposing"))
+    end
+    return table.concat(lines, "\n")
+end

--- a/src/main.lua
+++ b/src/main.lua
@@ -104,6 +104,7 @@ source(modDirectory .. "src/PositionalCapture.lua")
 -- SoilFertilitySystem, which owns the sowing chain and the daily pass that
 -- drive it. Consumes SCS positional moisture (absent = inert).
 source(modDirectory .. "src/EstablishmentFailure.lua")
+source(modDirectory .. "src/CompostManager.lua")
 source(modDirectory .. "src/ViabilityMask.lua")
 -- SF-53 GROWTH CREDIT: the reward half of the SF-2M family, a peer of
 -- ViabilityMask (same class idiom). Consumes SF-52's getter and lattice at
@@ -602,6 +603,20 @@ local function load(mission)
         -- Cross-mod bridge: g_currentMission is a shared C++ object visible to all mods.
         -- getfenv(0) is per-mod scoped in FS25. Use mission property for reliable cross-mod detection.
         mission.soilFertilityManager = sfm
+        -- [SF organic-compost] The managed compost process. Standalone manager,
+        -- server-authoritative; owns production only (SF owns the OM effect).
+        if CompostManager ~= nil then
+            g_CompostManager = CompostManager.new()
+            local ledger = (mission.stateLedger ~= nil) and mission.stateLedger or g_stateLedger
+            if ledger ~= nil and ledger.registerModule ~= nil then
+                pcall(function()
+                    ledger:registerModule(CompostManager.LEDGER_BATCHES, {
+                        serialize   = function() return g_CompostManager:serialize() end,
+                        deserialize = function(data) g_CompostManager:deserialize(data) end,
+                    })
+                end)
+            end
+        end
         -- #83 Cross-mod bridge for the FarmTablet FieldSentry app (read status + request toggles).
         if FieldSentry_API and FieldSentry_API.attachBridge then
             FieldSentry_API.attachBridge(mission)
@@ -725,9 +740,13 @@ Mission00.onStartMission = Utils.appendedFunction(Mission00.onStartMission, miss
 FSBaseMission.delete = Utils.prependedFunction(FSBaseMission.delete, unload)
 
 FSBaseMission.update = Utils.appendedFunction(FSBaseMission.update, function(mission, dt)
-    if sfm then
-        sfm:update(dt)
-        -- [SF-44] Drain the tedder's correction queue at end of frame
+        if sfm then
+            sfm:update(dt)
+            -- [SF organic-compost] Day-tracking fallback when Time Guard is absent.
+            if g_CompostManager ~= nil then
+                g_CompostManager:updateDayFallback()
+            end
+            -- [SF-44] Drain the tedder's correction queue at end of frame
         local hayBet = sfm.soilSystem and sfm.soilSystem.hayBet
         if hayBet then
             hayBet:onUpdate()
@@ -843,6 +862,43 @@ function soilMouseHandler:mouseEvent(posX, posY, isDown, isUp, button, eventUsed
     return eventUsed
 end
 addModEventListener(soilMouseHandler)
+
+-- [SF organic-compost] Console commands for the managed compost process.
+if addConsoleCommand ~= nil then
+    addConsoleCommand("sfCompostStatus", "Show compost batches", "consoleCompostStatus", nil)
+    addConsoleCommand("sfCompostStart", "Start a batch: sfCompostStart <manureLitres> [biosolidsLitres]", "consoleCompostStart", nil)
+    addConsoleCommand("sfCompostCollect", "Collect a ready batch: sfCompostCollect <batchId>", "consoleCompostCollect", nil)
+end
+
+function consoleCompostStatus()
+    if g_CompostManager == nil then return "compost manager not initialised" end
+    return g_CompostManager:consoleStatus()
+end
+
+function consoleCompostStart(manure, biosolids)
+    if g_CompostManager == nil then return "compost manager not initialised" end
+    if g_currentMission == nil or not g_currentMission:getIsServer() then return "server only" end
+    local farmId = 0
+    if g_currentMission.player ~= nil and g_currentMission.player.getOwnerFarmId ~= nil then
+        farmId = g_currentMission.player:getOwnerFarmId()
+    end
+    if not farmId or farmId == 0 then return "no farm" end
+    local feedstocks = {}
+    if tonumber(manure) and tonumber(manure) > 0 then feedstocks.MANURE = tonumber(manure) end
+    if tonumber(biosolids) and tonumber(biosolids) > 0 then feedstocks.BIOSOLIDS = tonumber(biosolids) end
+    local id, why = g_CompostManager:startBatch(farmId, feedstocks)
+    if id then return string.format("batch %d started (farm %d)", id, farmId) end
+    return "start failed: " .. tostring(why)
+end
+
+function consoleCompostCollect(batchId)
+    if g_CompostManager == nil then return "compost manager not initialised" end
+    local n, why = g_CompostManager:collectBatch(tonumber(batchId))
+    if n ~= nil then
+        return string.format("collected %d L compost", n)
+    end
+    return "collect failed: " .. tostring(why or "unknown")
+end
 
 -- Console commands
 function soilfertility()

--- a/tools/test/lua/compost_manager_test.lua
+++ b/tools/test/lua/compost_manager_test.lua
@@ -1,0 +1,107 @@
+-- compost_manager_test.lua
+-- The organic compost PRODUCTION layer: a managed process (no placeable) that
+-- commits farm organic waste to a batch, decomposes it over in-game days on the
+-- Time Guard clock, and yields the existing COMPOST fill type. SF owns the OM
+-- amendment effect; this owns production only.
+--
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/config/SoilBlends.lua, src/ReleaseGate.lua, src/ResistanceBands.lua, src/HybridStrains.lua, src/CompostManager.lua
+
+g_currentMission = { _isServer = true }
+function g_currentMission:getIsServer() return self._isServer end
+g_SoilFertilityManager = { settings = { difficulty = 2 } }
+g_fillTypeManager = { getFillTypeIndexByName = function(_, name) if name == "COMPOST" then return 1 end return 0 end }
+ToolType = { UNDEFINED = 0 }
+
+local function newManager()
+  local m = CompostManager.new()
+  m._markDirty = function() end
+  return m
+end
+
+-- 1. START A BATCH: validates, computes the finished output and the organic flag.
+do
+  local m = newManager()
+  local id, why = m:startBatch(1, { MANURE = 1000 })
+  T.eq('start.batchCreated', id, 1)
+  T.eq('start.okReason', why, "ok")
+  local b = m.batches[1]
+  T.eq('start.outputFromManure', b.outputLitres, 450)
+  T.eq('start.manureIsOrganicSafe', b.organicSafe, true)
+  T.eq('start.daysAtRealistic', b.totalDays, 14)
+  T.eq('start.notReadyInitially', b.ready, false)
+end
+
+-- 2. BIOSOLIDS MAKES A BATCH NOT ORGANIC-SAFE (the organic-cert excludes biosolids).
+do
+  local m = newManager()
+  m:startBatch(1, { BIOSOLIDS = 500 })
+  T.eq('organic.biosolidsNotSafe', m.batches[1].organicSafe, false)
+  local m2 = newManager()
+  m2:startBatch(1, { MANURE = 400, BIOSOLIDS = 100 })
+  T.eq('organic.mixedIsNotSafe', m2.batches[1].organicSafe, false)
+end
+
+-- 3. DECOMPOSITION: tickDay advances, a batch becomes ready when its days run out.
+do
+  local m = newManager()
+  m:startBatch(1, { MANURE = 1000 })   -- 14 days at realistic
+  m:tickDay(13)
+  T.eq('decompose.notReadyAt13', m.batches[1].ready, false)
+  T.eq('decompose.oneDayLeft', m.batches[1].daysRemaining, 1)
+  m:tickDay(1)
+  T.eq('decompose.readyAtEnd', m.batches[1].ready, true)
+  T.eq('decompose.daysRemainingFloor', m.batches[1].daysRemaining, 0)
+end
+
+-- 4. COLLECT: deposits the finished compost into farm storage and clears the batch.
+do
+  local deposited = {}
+  local m = newManager()
+  m:startBatch(1, { MANURE = 1000 })
+  m:tickDay(99)
+  T.eq('collect.ready', m.batches[1].ready, true)
+  m._depositCompost = function(_self, farmId, litres)
+    deposited[#deposited + 1] = { farmId = farmId, litres = litres }
+    return litres
+  end
+  local n, why = m:collectBatch(1)
+  T.eq('collect.depositsOutput', n, 450)
+  T.eq('collect.toFarm', deposited[1].farmId, 1)
+  T.eq('collect.clearsBatch', m.batches[1], nil)
+end
+
+-- 5. A NOT-READY BATCH CANNOT BE COLLECTED.
+do
+  local m = newManager()
+  m:startBatch(1, { MANURE = 100 })
+  local n, why = m:collectBatch(1)
+  T.eq('collect.notReadyRefused', n, nil)
+  T.eq('collect.notReadyReason', why, "not_ready")
+end
+
+-- 6. PERSISTENCE ROUND TRIP (the ledger table shape).
+do
+  local m = newManager()
+  m:startBatch(1, { MANURE = 800 })
+  m:tickDay(5)
+  local ser = m:serialize()
+  local m2 = newManager()
+  m2:deserialize(ser)
+  T.eq('persist.batchSurvives', m2.batches[1] ~= nil, true)
+  T.eq('persist.daysRemaining', m2.batches[1].daysRemaining, m.batches[1].daysRemaining)
+  T.eq('persist.outputSurvives', m2.batches[1].outputLitres, m.batches[1].outputLitres)
+  T.eq('persist.organicSafeSurvives', m2.batches[1].organicSafe, true)
+  T.eq('persist.nextIdSurvives', m2.nextBatchId, m.nextBatchId)
+end
+
+-- 7. THE BATCH NEVER RUNS ON A CLIENT.
+do
+  local m = newManager()
+  g_currentMission._isServer = false
+  local id, why = m:startBatch(1, { MANURE = 100 })
+  T.eq('client.cannotStart', id, nil)
+  T.eq('client.reason', why, "server_only")
+  g_currentMission._isServer = true
+end
+
+T.summary()


### PR DESCRIPTION
The managed compost production process: the player can now produce compost from farm organic waste instead of only buying it.

A managed process, no placeable (Arissani's shape). A batch commits existing feedstocks (manure, silage, digestate, biosolids), decomposes over in-game days on the Time Guard clock (simulation flow, with an SF day-tracking fallback when Time Guard is absent), and a finished batch yields the existing COMPOST fill type into farm storage. SF owns the OM amendment effect unchanged (COMPOST is an OM-primary product, 0.12 per the engine-era addendum); this system owns production only, with no new fill type and no new soil authority.

Each batch carries an organic-safe flag derived from its feedstocks: only the approved manure/compost/digestate family keeps a batch cert-safe, and a biosolids-fed batch is a valid amendment but not organic-safe, with the breach riding SF's existing onInputApplied rather than new breach logic.

Server-authoritative (a client never mints compost), persisted via StateLedger with the own-XML fallback, and three console commands for the test pass (sfCompostStatus / sfCompostStart / sfCompostCollect). The batch duration is a natural rate, not days-per-period normalized, and the yield + days ride the balance pass.

Verified: 25 new assertions (compost_manager_test.lua): batch start + output math, the organic-safe flag including the biosolids case, decomposition to readiness, collect-and-clear, the not-ready refusal, persistence round trip, and the client cannot start a batch. Full suite 2922/0, syntax and lint clean. Built and deployed as 2.5.0.72. Not yet observed in a running game.
