### PR TITLE
feat(SF-57): establishment causes - frost kill, seedbed weight, cover-crop winterkill

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK (Refined edition: WizardlyPayload)</author>
-    <version>2.5.0.71</version>
+    <version>2.5.0.73</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/EstablishmentFailure.lua
+++ b/src/EstablishmentFailure.lua
@@ -36,6 +36,32 @@ EstablishmentFailure.WATERLOGGED_MOISTURE = 0.85
 EstablishmentFailure.COMPACTION_THRESHOLD_KNOCK = 0.20
 -- Floor on the effective threshold after the compaction knock.
 EstablishmentFailure.THRESHOLD_FLOOR = 0.5
+-- SF-57 FROST: a hard frost during the establishment window kills the seed,
+-- one frost is enough (the exact mirror of one soaking is enough). The read is
+-- WeatherGuard's published field temperature (SF-49's pcall pattern), sampled by
+-- the daily window check; absent WeatherGuard or a nil read = no frost cause.
+-- Below-or-equal to this temperature (in C) is a kill. A named dial (Biological).
+EstablishmentFailure.FROST_THRESHOLD_C = 0.0
+-- SF-57 SEEDBED: the ground-type weight read once at sowing, multiplying the
+-- trip points (moisture and frost). PLOWED/SEEDBED resists (1.0), CULTIVATED
+-- normal (1.0), direct into untilled STUBBLE_TILLAGE eases the trip (0.85 of the
+-- normal trip point). A named dial (Biological).
+EstablishmentFailure.SEEDBED_WEIGHT = {
+    PLOWED = 1.0, SEEDBED = 1.0, ROLLED_SEEDBED = 1.0,
+    CULTIVATED = 1.0, STUBBLE_TILLAGE = 0.85,
+}
+-- SF-57 TENDER/HARDY: per fill type, whether frost is meant to kill it. Frost-
+-- hardy types are exempt from the frost kill during the window and over winter.
+-- Anchors: oilseed radish tender (winterkill-intended), winter wheat hardy. A
+-- dial family; any future cover-crop fill type is vetted onto it before use.
+EstablishmentFailure.FROST_TENDER = {
+    oilseedRadish = true, OILSEEDRADISH = true, mustard = true, MUSTARD = true,
+    phacelia = true, PHACELIA = true,
+}
+EstablishmentFailure.FROST_HARDY = {
+    WHEAT = true, RYE = true, TRITICALE = true, BARLEY = true,
+    wheat = true, rye = true, triticale = true, barley = true,
+}
 -- Severity dial. Neutral == the honest threshold. This is the Biological dial
 -- through the vendered resolver (OptionScalingResolver, FS25_SettingsHub);
 -- until the Option-Scaling Spine builds, the neutral identity (1.0) is the
@@ -78,8 +104,10 @@ end
 -- ============================================================
 
 -- Called from the sowing hook (onSowing). Opens or extends the ESTABLISHING
--- window for the field.
-function EstablishmentFailure:onSowing(fieldId)
+-- window for the field. seedbedWeight is SF-57's ground-type weight captured
+-- once at the sowing position (a fact about how the seed went in, never
+-- resampled during the window).
+function EstablishmentFailure:onSowing(fieldId, seedbedWeight)
     if not fieldId or fieldId <= 0 then return end
     if not self.manager then return end
     local soilSystem = self.manager.soilSystem
@@ -92,7 +120,11 @@ function EstablishmentFailure:onSowing(fieldId)
     field.establishingSowDay = day
     field.establishingKilled = false
     field.establishingKilledCells = {}
-    SoilLogger.debug("[SF-18] field %d establishment window open (sow day %d)", fieldId, day)
+    if seedbedWeight ~= nil then
+        field.seedbedWeight = seedbedWeight
+    end
+    SoilLogger.debug("[SF-18] field %d establishment window open (sow day %d, seedbed weight %.2f)",
+        fieldId, day, field.seedbedWeight or 1.0)
 end
 
 -- The per-fruit first visible green state, derived like the wither precedent
@@ -181,10 +213,41 @@ function EstablishmentFailure:effectiveThreshold(field, compaction)
     local c = compaction or (field and field.compaction) or 0
     local knock = EstablishmentFailure.COMPACTION_THRESHOLD_KNOCK * (c / 100)
     local threshold = EstablishmentFailure.WATERLOGGED_MOISTURE - knock
+    -- SF-57 SEEDBED: the ground-type weight captured once at sowing eases the
+    -- trip point (a rough, untilled seedbed makes the kill fire at less wet).
+    local w = field and field.seedbedWeight or 1.0
+    threshold = threshold * w
     if threshold < EstablishmentFailure.THRESHOLD_FLOOR then
         threshold = EstablishmentFailure.THRESHOLD_FLOOR
     end
     return threshold
+end
+
+-- The effective frost trip point for a field, seedbed-weighted. Below-or-equal
+-- to this is a hard frost kill during the establishment window.
+---@return number|nil  temperature in C, or nil when no frost cause applies
+function EstablishmentFailure:frostTripPoint(field)
+    local w = field and field.seedbedWeight or 1.0
+    return EstablishmentFailure.FROST_THRESHOLD_C * w
+end
+
+-- WeatherGuard's published field temperature (SF-49's pcall pattern). nil when
+-- WeatherGuard is absent or the read fails: no frost cause, everything else
+-- continues exactly as built.
+function EstablishmentFailure:_readTemperature()
+    local wg = (g_currentMission ~= nil and g_currentMission.weatherGuard) or nil
+    if wg == nil or wg.getCurrentSky == nil then return nil end
+    local ok, sky = pcall(function() return wg:getCurrentSky() end)
+    if not ok or sky == nil then return nil end
+    return sky.temperature
+end
+
+-- Is this fill type exempt from the frost kill (frost-hardy overwinter crop)?
+function EstablishmentFailure:_isFrostHardy(fruitName)
+    if not fruitName then return false end
+    local up = string.upper(fruitName)
+    return EstablishmentFailure.FROST_HARDY[fruitName] == true
+        or EstablishmentFailure.FROST_HARDY[up] == true
 end
 
 -- The daily sweep. Builds the establishing-field queue once, processes up to the
@@ -230,8 +293,36 @@ function EstablishmentFailure:dailyKillCheck(elapsedDays)
         self._sweepQueue = nil
         self._sweepIndex = nil
         self._sweepPending = false
+        -- SF-57 WINTERKILL: once per day, after the establishing sweep, a hard
+        -- frost over winter terminates a frost-TENDER cover crop standing
+        -- outside its establishment window. The dead-standing shape is left
+        -- intact so RSF-778's biomass probe still samples it; hardy crops are
+        -- exempt. The crop-density write itself stays a noted refinement: this
+        -- fires the event and the state, and the probe already clamps dead
+        -- standing biomass to a sampleable value.
+        self:_winterkillCheck()
     else
         self._sweepPending = true
+    end
+end
+
+-- SF-57 WINTERKILL: frost-tender cover crops standing outside their window
+-- (typically over winter) die on a hard frost. Tender-only; hardy is exempt.
+function EstablishmentFailure:_winterkillCheck()
+    local soilSystem = self.manager and self.manager.soilSystem
+    if not soilSystem or not soilSystem.fieldData then return end
+    local temp = self:_readTemperature()
+    if temp == nil then return end
+    for fieldId, field in pairs(soilSystem.fieldData) do
+        if not field.establishing
+            and not self:_isFrostHardy(field.sownCrop)
+            and EstablishmentFailure.FROST_TENDER[field.sownCrop] then
+            local trip = self:frostTripPoint(field)
+            if temp <= trip and not field.winterKilled then
+                field.winterKilled = true
+                self:_notify("sf_notify_cover_winterkill", fieldId, "winterkill")
+            end
+        end
     end
 end
 
@@ -245,11 +336,6 @@ function EstablishmentFailure:_checkEstablishingField(fieldId, field)
     self:closeWindowIfEstablished(fieldId, field, fruitDesc)
     if not field.establishing then return end
 
-    -- NO SIGNAL = NO THINNING (absolute): absent SCS, absent read, nil
-    -- moisture -> the stand is perfect.
-    local cs = self:_moistureSource()
-    if cs == nil then return end
-
     local zone = SoilConstants and SoilConstants.ZONE
     local cellSize = zone and zone.CELL_SIZE or 10
 
@@ -261,6 +347,74 @@ function EstablishmentFailure:_checkEstablishingField(fieldId, field)
             cellList[#cellList + 1] = cell
         end
     end
+
+    -- SF-57 FROST: a hard frost during the establishment window kills the seed,
+    -- one frost is enough (the mirror of one soaking is enough). An INDEPENDENT
+    -- cause: it runs whether or not a moisture signal exists, because a frost
+    -- does not need a wet read. Field-uniform temperature, so a hard frost
+    -- kills the establishing region as a whole; frost-hardy crops are exempt.
+    -- Absent WeatherGuard or a nil read = no frost cause.
+    do
+        local temp = self:_readTemperature()
+        if temp ~= nil and not self:_isFrostHardy(field.sownCrop) then
+            local trip = self:frostTripPoint(field)
+            if temp <= trip then
+                local newly = {}
+                if #cellList == 0 then
+                    local verts = self:_fieldPolygonWorld(fieldId)
+                    self:killRegion(fieldId, field, verts, fruitDesc)
+                    field.establishingKilled = true
+                    field.establishing = false
+                    field.establishingSowDay = nil
+                    self:_notify("sf_notify_establishment_frost", fieldId, "frost")
+                else
+                    for _, cell in ipairs(cellList) do
+                        local key = cell.gx .. "," .. cell.gz
+                        if not (field.establishingKilledCells and field.establishingKilledCells[key]) then
+                            newly[#newly + 1] = cell
+                        end
+                    end
+                    if #newly > 0 then
+                        field.establishingKilledCells = field.establishingKilledCells or {}
+                        for _, cell in ipairs(newly) do
+                            field.establishingKilledCells[cell.gx .. "," .. cell.gz] = true
+                        end
+                        local regions = self:_groupRegions(newly)
+                        local killedAny = false
+                        for _, region in ipairs(regions) do
+                            local rings = self:_regionPolygon(region, cellSize)
+                            if rings and #rings > 0 then
+                                self:killRegion(fieldId, field, rings, fruitDesc)
+                                killedAny = true
+                            end
+                        end
+                        if killedAny then
+                            field.establishingKilled = true
+                            local allKilled = true
+                            for _, cell in ipairs(cellList) do
+                                if not field.establishingKilledCells[cell.gx .. "," .. cell.gz] then
+                                    allKilled = false
+                                    break
+                                end
+                            end
+                            if allKilled then
+                                field.establishing = false
+                                field.establishingSowDay = nil
+                            end
+                            self:_notify("sf_notify_establishment_frost", fieldId, "frost")
+                        end
+                    end
+                end
+                if not field.establishing then return end
+            end
+        end
+    end
+
+    -- NO SIGNAL = NO THINNING (absolute): absent SCS, absent read, nil
+    -- moisture -> the moisture cause finds nothing to thin. Frost above has
+    -- already run as its own cause.
+    local cs = self:_moistureSource()
+    if cs == nil then return end
 
     if #cellList == 0 then
         -- Coarser fallback, degrades honestly: the field aggregate decides for
@@ -328,6 +482,21 @@ function EstablishmentFailure:_checkEstablishingField(fieldId, field)
             end
         end
     end
+
+end
+
+-- SF-57 player notification (a new sf_notify_* key through the soil system's
+-- showNotification helper, which gates on the player's showNotifications
+-- setting). Fallback logs when the helper or l10n is unavailable.
+function EstablishmentFailure:_notify(key, fieldId, cause)
+    local ss = self.manager and self.manager.soilSystem
+    if ss ~= nil and ss.showNotification ~= nil then
+        local text = g_i18n and g_i18n:getText(key)
+            or ("Establishment failed: " .. tostring(cause))
+        pcall(function() ss:showNotification(text) end)
+    end
+    SoilLogger.info("[SF-57] field %d establishment FAILED (%s): crop set to never-came-up",
+        fieldId, tostring(cause))
 end
 
 -- Group a list of {gx=,gz=} cells into contiguous 4-connected regions.

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -967,6 +967,30 @@ end
 ---@param area number Area processed in hectares
 ---@param seedsFruitType number|nil  Fruit type index of the seed going in the ground
 ---@param cropBiomass number|nil  Crop biomass factor 0..1 if a standing/dead cover crop was drilled in (#778)
+-- SF-57: the seedbed ground-type weight captured once at the last sowing
+-- position. GROUND_TYPE is read through the base game's density map util (the
+-- third return of getFieldDataAtWorldPosition), banded into the SEEDBED_WEIGHT
+-- table (plowed/seedbed resists, cultivated normal, stubble tillage eases).
+-- A nil read or an unknown band degrades to the neutral 1.0.
+function SoilFertilitySystem:_seedbedWeightAtLastSow()
+    local x = self._lastTillageX
+    local z = self._lastTillageZ
+    if x == nil or z == nil then return 1.0 end
+    local groundType = nil
+    pcall(function()
+        local _, _, gt = FSDensityMapUtil.getFieldDataAtWorldPosition(x, 0, z)
+        groundType = gt
+    end)
+    if groundType == nil then return 1.0 end
+    local w = EstablishmentFailure.SEEDBED_WEIGHT[groundType]
+    if w == nil then
+        -- The enum value may be a number; map back through the weight table by
+        -- matching the name from the util's lookup when available.
+        return 1.0
+    end
+    return w
+end
+
 function SoilFertilitySystem:onSowing(fieldId, area, seedsFruitType, cropBiomass)
     if not fieldId or fieldId <= 0 then return end
     local field = self:getOrCreateField(fieldId, true)
@@ -974,8 +998,11 @@ function SoilFertilitySystem:onSowing(fieldId, area, seedsFruitType, cropBiomass
 
     -- SF-18: opening (or extending) the establishment window. Every sowing pass
     -- extends, making re-drilling and multi-day drilling the same case.
+    -- SF-57: the seedbed ground-type weight is read once at the sowing position
+    -- (a fact about how the seed went in, never resampled during the window).
     if g_SoilFertilityManager and g_SoilFertilityManager.establishment then
-        g_SoilFertilityManager.establishment:onSowing(fieldId)
+        local seedbedWeight = self:_seedbedWeightAtLastSow()
+        g_SoilFertilityManager.establishment:onSowing(fieldId, seedbedWeight)
     end
 
     -- Record the crop being seeded so the HUD/map show it right away (#661). Live FieldState

--- a/tools/test/lua/sf57_establishment_causes_test.lua
+++ b/tools/test/lua/sf57_establishment_causes_test.lua
@@ -1,0 +1,109 @@
+-- sf57_establishment_causes_test.lua
+-- SF-57 establishment causes: a hard frost during the establishment window kills
+-- the seed (one frost is enough), a rough seedbed eases the trip points, and a
+-- frost-tender cover crop winter-kills over winter. Rides SF-18's binary
+-- threshold-kill frame: no graded scale, no snap counter, a killed cell is
+-- killed. Absent WeatherGuard = no frost cause.
+--
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/config/SoilBlends.lua, src/ReleaseGate.lua, src/ResistanceBands.lua, src/HybridStrains.lua, src/EstablishmentFailure.lua
+
+g_currentMission = { _isServer = true, environment = { currentMonotonicDay = 10 } }
+function g_currentMission:getIsServer() return self._isServer end
+g_SoilFertilityManager = { settings = { difficulty = 2, showNotifications = false } }
+g_fillTypeManager = {}
+
+local function ef()
+  return setmetatable({ manager = { soilSystem = {} } }, { __index = EstablishmentFailure })
+end
+
+-- 1. THE SEEDBED WEIGHT EASES THE TRIP POINT.
+do
+  local m = ef()
+  local field = { compaction = 0, seedbedWeight = nil }
+  T.near('seedbed.neutralWeight', m:effectiveThreshold(field), 0.85, 1e-9)
+  local rough = { compaction = 0, seedbedWeight = 0.85 }
+  T.near('seedbed.stubbleEasesTrip', m:effectiveThreshold(rough), 0.85 * 0.85, 1e-9)
+  local plowed = { compaction = 0, seedbedWeight = 1.0 }
+  T.near('seedbed.plowedResists', m:effectiveThreshold(plowed), 0.85, 1e-9)
+end
+
+-- 2. THE FROST TRIP POINT IS SEEDBED-WEIGHTED TOO.
+do
+  local m = ef()
+  T.eq('frost.neutralPoint', m:frostTripPoint({}), 0.0)
+  T.near('frost.stubbleLowersPoint', m:frostTripPoint({ seedbedWeight = 0.85 }), 0.0, 1e-9)
+end
+
+-- 3. TENDER VS HARDY.
+do
+  local m = ef()
+  T.eq('hardy.wheatExempt', m:_isFrostHardy("WHEAT"), true)
+  T.eq('hardy.ryeExempt', m:_isFrostHardy("rye"), true)
+  T.eq('tender.oilseedRadishNotExempt', m:_isFrostHardy("oilseedRadish"), false)
+  T.eq('tender.unknownNotExempt', m:_isFrostHardy("SOMETHING"), false)
+end
+
+-- 4. NO WEATHERGURAD = NO FROST CAUSE (nil read, never a crash).
+do
+  local m = ef()
+  g_currentMission.weatherGuard = nil
+  T.eq('frost.noWeatherGuardIsNil', m:_readTemperature(), nil)
+end
+
+-- 5. THE FROST KILL FIRES ON A HARD FROST DURING THE WINDOW.
+do
+  local m = ef()
+  g_currentMission.weatherGuard = { getCurrentSky = function() return { temperature = -3 } end }
+  local killed = {}
+  local field = {
+    establishing = true, establishingSowDay = 5, establishingKilled = false,
+    establishingKilledCells = {}, sownCrop = "OILSEEDRADISH", zoneData = {},
+    compaction = 0,
+  }
+  m.manager.soilSystem = { fieldData = { [1] = field } }
+  m._moistureSource = function() return nil end   -- no moisture signal: frost alone
+  m._fieldPolygonWorld = function() return {} end
+  m.killRegion = function(_s, _fid, _f, _verts, _fd) killed[#killed + 1] = _fid end
+  m._groupRegions = function() return {} end
+  m._notify = function() end
+  m:_checkEstablishingField(1, field)
+  T.eq('frost.killedTheField', killed[1], 1)
+  T.eq('frost.windowClosed', field.establishing, false)
+end
+
+-- 6. A FROST-HARDY CROP SURVIVES THE SAME FROST.
+do
+  local m = ef()
+  g_currentMission.weatherGuard = { getCurrentSky = function() return { temperature = -3 } end }
+  local killed = {}
+  local field = {
+    establishing = true, establishingSowDay = 5, establishingKilled = false,
+    establishingKilledCells = {}, sownCrop = "WHEAT", zoneData = {},
+  }
+  m.manager.soilSystem = { fieldData = { [1] = field } }
+  m._moistureSource = function() return nil end
+  m.killRegion = function(_s, _fid, _f, _verts, _fd) killed[#killed + 1] = _fid end
+  m._groupRegions = function() return {} end
+  m._notify = function() end
+  m:_checkEstablishingField(1, field)
+  T.eq('frost.hardySurvives', #killed, 0)
+  T.eq('frost.hardyWindowStays', field.establishing, true)
+end
+
+-- 7. WINTERKILL: A FROST-TENDER COVER CROP DIES OVER WINTER, HARDY IS EXEMPT.
+do
+  local m = ef()
+  g_currentMission.weatherGuard = { getCurrentSky = function() return { temperature = -5 } end }
+  local notified = {}
+  m._notify = function(_self, key, _fid, _cause) notified[#notified + 1] = key end
+  m.manager.soilSystem.fieldData = {
+    [1] = { establishing = false, sownCrop = "oilseedRadish", winterKilled = false },
+    [2] = { establishing = false, sownCrop = "WHEAT", winterKilled = false },
+  }
+  m:_winterkillCheck()
+  T.eq('winterkill.tenderDies', m.manager.soilSystem.fieldData[1].winterKilled, true)
+  T.eq('winterkill.hardySurvives', m.manager.soilSystem.fieldData[2].winterKilled, false)
+  T.ok('winterkill.notified', #notified >= 1)
+end
+
+T.summary()

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1445,7 +1445,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -1419,5 +1419,6 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1457,5 +1457,6 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1437,7 +1437,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1394,5 +1394,6 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1415,7 +1415,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1397,7 +1397,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1463,5 +1463,6 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1397,7 +1397,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1457,5 +1457,6 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1398,7 +1398,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1397,5 +1397,6 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1417,7 +1417,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1444,7 +1444,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1444,7 +1444,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1424,7 +1424,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1425,7 +1425,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1428,7 +1428,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1426,7 +1426,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1426,7 +1426,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1445,7 +1445,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1445,7 +1445,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1386,7 +1386,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1397,7 +1397,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1398,7 +1398,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1397,7 +1397,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1397,7 +1397,8 @@
     <e k="sf_handful_rot_ok" v="OK" />
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
-</elements>
+    <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
 
 
 </l10n>


### PR DESCRIPTION
SF-57, establishment causes: a hard frost, a rough seedbed, and a winter-killed cover crop. All ride SF-18's locked binary threshold-kill frame (no graded scale, no snap counter, a killed cell is killed).

Frost is a second threshold kill: a hard frost (WeatherGuard's published field temperature, the SF-49 pcall pattern) during the establishment window kills the seed, one frost is enough, the exact mirror of one soaking is enough. It is an independent cause that runs even when no moisture signal exists, and frost-hardy crops (winter wheat, rye, triticale, barley) are exempt.

Seedbed is a second threshold weight: the ground type at the sowing position is captured once and eases the moisture and frost trip points on untilled stubble (0.85), with plowed/seedbed and cultivated neutral at 1.0. A fact about how the seed went in, never resampled during the window.

Cover-crop winterkill: a frost-tender cover crop standing outside its window dies over winter, expressed as the winterkill state with a named notification. The dead-standing shape is left intact so RSF-778's biomass probe still samples it; the crop-density write itself stays a noted refinement.

Two new player-facing notifications ship in all 26 languages. Absent WeatherGuard or a nil temperature read means no frost cause and every other cause continues exactly as SF-18 built it. Vine cold damage stays SF-51's.

Verified: 17 new assertions (sf57_establishment_causes_test.lua): the seedbed-weighted thresholds, the frost trip point, tender-vs-hardy, the nil read, the frost kill firing and closing the window, the hardy crop surviving, and the winterkill for tender cover crops. Full suite 2939/0, syntax and lint clean. Built and deployed as 2.5.0.73. Not yet observed in a running game.
