### PR TITLE
feat(drilling-window): the advisory line - good or risky window for putting seed in this ground

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,3 +135,8 @@
 - [x] A managed compost process (no placeable): batches commit farm organic waste, decompose over in-game days on the Time Guard clock (SF day-tracking fallback when absent), and yield the existing COMPOST fill type into farm storage. SF owns the OM effect unchanged; organic-safe flag per feedstock (biosolids-fed is not cert-safe, breach rides onInputApplied). Server-authoritative, StateLedger + own-XML persistence, sfCompostStatus/Start/Collect console.
 - [x] compost_manager_test.lua at 25 assertions; suite 2922/0; deployed 2.5.0.72.
 - [~] In-game (owed): start a batch, watch it decompose across days, collect the compost, spread it on a field.
+
+## 2026-08-14 (Fred): the drilling-window advisory
+- [x] The field-info line now says whether the coming days are a good or risky window for drilling, from the SCS rain outlook over the season-scaled establishment horizon and the ground moisture against the kill condition. Three hedged verdicts (good / risky / forecast-only), silent when SCS is absent, never gates or writes. Renders in SF's own field-info surface; FarmTablet mirrors the hub read.
+- [x] drilling_advisory_test.lua at 5 assertions; suite 2944/0; deployed 2.5.0.74.
+- [~] In-game (owed): a wet-leaning field under a cloudy sky reads risky; removing SCS silences the line.

--- a/TODO.md
+++ b/TODO.md
@@ -134,3 +134,8 @@
 - [x] CompostManager: batch lifecycle, Time Guard day accrual + fallback, storage deposit, organic-safe flag, persistence, console.
 - [x] 25 assertions; suite 2922/0.
 - [~] In-game batch flow; FarmTablet organic-app batch display (read-only) pending the app's own work.
+
+## Drilling-window advisory (2026-08-14)
+- [x] Advisory verdict from the SCS rain outlook + moisture vs kill condition; three hedged strings in 26 languages; SF field-info line; silent without SCS.
+- [x] 5 assertions; suite 2944/0.
+- [~] In-game; FarmTablet mirror (hub read of the same surface).

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK (Refined edition: WizardlyPayload)</author>
-    <version>2.5.0.73</version>
+    <version>2.5.0.74</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -972,6 +972,34 @@ end
 -- third return of getFieldDataAtWorldPosition), banded into the SEEDBED_WEIGHT
 -- table (plowed/seedbed resists, cultivated normal, stubble tillage eases).
 -- A nil read or an unknown band degrades to the neutral 1.0.
+
+-- The drilling-window advisory (the field-info line): whether the coming days
+-- are a good or risky window for putting seed in this ground. It speaks from the
+-- SCS sky-reading (clouds now, rain now, the season's habits) and the ground
+-- moisture against the establishment kill condition. Advice never gates or
+-- writes; it is silent when SCS is absent (never guessing), and the weaker
+-- forecast-only form is used when the moisture read is unavailable. The verdict
+-- is a stable l10n key.
+function SoilFertilitySystem:_drillingAdvisory(fieldId)
+    local cs = g_currentMission ~= nil and g_currentMission.cropStressManager
+    if cs == nil or cs.getRainOutlook == nil then return nil end
+    local d = SoilConstants.DRILLING
+    local horizon = SoilDuration.seasonScaled(d.ESTABLISHMENT_HORIZON_DAYS)
+    local ok, out = pcall(function() return cs:getRainOutlook(horizon) end)
+    if not ok or out == nil or type(out.likelihood) ~= "number" then return nil end
+    local moist, hasMoisture = 0.5, false
+    if cs.getMoisture ~= nil then
+        local ok2, m = pcall(function() return cs:getMoisture(fieldId) end)
+        if ok2 and type(m) == "number" then moist, hasMoisture = m, true end
+    end
+    if out.likelihood < d.RISKY_LIKELIHOOD then
+        return "sf_notify_drill_good"
+    end
+    if hasMoisture and moist >= d.WET_GROUND_MOISTURE then
+        return "sf_notify_drill_risky"
+    end
+    return "sf_notify_drill_forecast_only"
+end
 function SoilFertilitySystem:_seedbedWeightAtLastSow()
     local x = self._lastTillageX
     local z = self._lastTillageZ

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -36,6 +36,16 @@ SoilConstants.TIMING = {
 -- TRANSITION_YEARS (year-normalised via Time Guard at its own read site,
 -- OrganicCertification:getTransitionDays) and the fallow threshold (multiplied
 -- by daysPerMonth at its read site).
+-- The drilling-window advisory: how far ahead the outlook reads (in days,
+-- season-scaled via SoilDuration), the rain-likelihood at which a window turns
+-- risky, and the ground-moisture below which the risky form is softened. These
+-- are honest defaults, not derived agronomy; a balance-pass number.
+SoilConstants.DRILLING = {
+    ESTABLISHMENT_HORIZON_DAYS = 7,
+    RISKY_LIKELIHOOD           = 0.4,
+    WET_GROUND_MOISTURE        = 0.5,
+}
+
 SoilConstants.DURATION = {
     REFERENCE_DPP = 3,   -- days-per-month the chemical durations were tuned at
 }

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -917,6 +917,24 @@ function SoilHUD:buildFieldInfoLines(info)
         table.insert(lines, { group = "late", label = g_i18n:getText("sf_fieldinfo_burn_risk") or "Amend. burn risk", value = "Yes" })
     end
 
+    -- The drilling-window advisory (SF-55-wave2 brief): whether the coming days
+    -- are a good or risky window for putting seed in this ground. Silent when
+    -- SCS is absent; the verdict is an l10n key. Never gates or writes.
+    if info.fieldId ~= nil and g_SoilFertilityManager ~= nil
+        and g_SoilFertilityManager.soilSystem ~= nil then
+        local ss = g_SoilFertilityManager.soilSystem
+        if ss._drillingAdvisory ~= nil then
+            local verdictKey = ss:_drillingAdvisory(info.fieldId)
+            if verdictKey ~= nil then
+                table.insert(lines, {
+                    group = "late",
+                    label = g_i18n:getText("sf_fieldinfo_drilling") or "Drilling",
+                    value = g_i18n:getText(verdictKey) or verdictKey,
+                })
+            end
+        end
+    end
+
     return lines
 end
 

--- a/tools/test/lua/drilling_advisory_test.lua
+++ b/tools/test/lua/drilling_advisory_test.lua
@@ -1,0 +1,65 @@
+-- drilling_advisory_test.lua
+-- The drilling-window advisory: a hedged line on whether the coming days are a
+-- good or risky window for putting seed in this ground. Speaks from the SCS
+-- sky-reading and the ground moisture against the establishment kill condition.
+-- Advice never gates or writes; silent when SCS is absent (never guessing); the
+-- weaker forecast-only form when the moisture read is unavailable.
+--
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/config/SoilBlends.lua, src/ReleaseGate.lua, src/ResistanceBands.lua, src/HybridStrains.lua, src/utils/DurationScaling.lua, src/SoilFertilitySystem.lua
+
+g_currentMission = { _isServer = true, environment = { currentMonotonicDay = 10 } }
+function g_currentMission:getIsServer() return self._isServer end
+
+local function soilSys(cs)
+  local s = setmetatable({}, { __index = SoilFertilitySystem })
+  g_currentMission.cropStressManager = cs
+  return s
+end
+
+-- 1. SILENT WHEN SCS IS ABSENT (never guessing).
+do
+  local s = soilSys(nil)
+  T.eq('silent.noSCS', s:_drillingAdvisory(1), nil)
+end
+
+-- 2. GOOD WHEN THE OUTLOOK IS CLEAR.
+do
+  local cs = {
+    getRainOutlook = function() return { likelihood = 0.2, approximate = true } end,
+    getMoisture = function() return 0.3 end,
+  }
+  local s = soilSys(cs)
+  T.eq('good.clearAhead', s:_drillingAdvisory(1), "sf_notify_drill_good")
+end
+
+-- 3. RISKY WHEN RAIN IS LIKELY AND THE GROUND IS WET.
+do
+  local cs = {
+    getRainOutlook = function() return { likelihood = 0.7, approximate = true } end,
+    getMoisture = function() return 0.7 end,
+  }
+  local s = soilSys(cs)
+  T.eq('risky.wetAndLikely', s:_drillingAdvisory(1), "sf_notify_drill_risky")
+end
+
+-- 4. THE WEAKER FORM WHEN RAIN IS LIKELY BUT MOISTURE IS UNREADABLE.
+do
+  local cs = {
+    getRainOutlook = function() return { likelihood = 0.7, approximate = true } end,
+    getMoisture = function() return nil end,
+  }
+  local s = soilSys(cs)
+  T.eq('weaker.forecastOnly', s:_drillingAdvisory(1), "sf_notify_drill_forecast_only")
+end
+
+-- 5. THE OUTLOOK GETTER FAILING IS ALSO SILENT.
+do
+  local cs = {
+    getRainOutlook = function() error("no sky") end,
+    getMoisture = function() return 0.5 end,
+  }
+  local s = soilSys(cs)
+  T.eq('silent.outlookError', s:_drillingAdvisory(1), nil)
+end
+
+T.summary()

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1446,7 +1446,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -1420,5 +1420,8 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1458,5 +1458,8 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1438,7 +1438,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1395,5 +1395,8 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1416,7 +1416,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1398,7 +1398,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1464,5 +1464,8 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1398,7 +1398,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1458,5 +1458,8 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1399,7 +1399,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1398,5 +1398,8 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1418,7 +1418,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1445,7 +1445,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1445,7 +1445,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1425,7 +1425,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1426,7 +1426,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1429,7 +1429,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1427,7 +1427,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1427,7 +1427,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1446,7 +1446,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1446,7 +1446,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1387,7 +1387,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1398,7 +1398,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1399,7 +1399,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1398,7 +1398,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1398,7 +1398,10 @@
     <e k="sf_handful_rot_fatigue" v="Fatigue" />
     <e k="input_SF_HANDFUL" v="Read the Dirt (kneel down)" />
     <e k="sf_notify_establishment_frost" v="Establishment failed: frost" />
-    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" /></elements>
+    <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
+    <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
+    <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
 
 
 </l10n>


### PR DESCRIPTION
The drilling-window advisory: SF's own field-info surface now says whether the coming days are a good or risky window for putting seed in this ground.

It speaks from the SCS rain outlook (the getRainOutlook sky-reading, clouds now + rain now + the season's habits, always approximate by law) over the establishment horizon, season-scaled through the delivered SoilDuration mechanism, and the ground moisture against the establishment kill condition. Three hedged verdicts, never a promise: good window, risky with the reason, and the weaker forecast-only form when the moisture read is unavailable. The line renders in SF's own per-field field-info surface, so it stands alone with no tablet; the FarmTablet mirrors the hub's read of the same surface.

Advice never gates or writes, and it is silent when SCS is absent, never guessing. The three strings ship in all 26 languages. This is the SF surface half of the drilling-window brief; the SCS getRainOutlook getter it reads is already merged.

Verified: 5 new assertions (drilling_advisory_test.lua): silent without SCS, good on a clear outlook, risky on wet ground with rain likely, the forecast-only degrade, and the silent outlook-error path. Full suite 2944/0, syntax and lint clean. Built and deployed as 2.5.0.74. Not yet observed in a running game.
