### PR TITLE
fix(esc): Crop Stress table flush - reclaim the 0-height action bar, drop the region toward the cards

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK (Refined edition: WizardlyPayload)</author>
-    <version>2.5.0.77</version>
+    <version>2.5.0.78</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>
@@ -84,13 +84,13 @@
     </vehicleTypes>
 
     <actions>
-        <action name="SF_TOGGLE_HUD"  category="ONFOOT" />
+        <action name="SF_TOGGLE_HUD"  category="ONFOOT VEHICLE" />
         <action name="SF_RATE_UP"     category="VEHICLE" />
         <action name="SF_RATE_DOWN"   category="VEHICLE" />
         <action name="SF_TOGGLE_AUTO" category="VEHICLE" />
-        <action name="SF_CYCLE_MAP_LAYER"   category="ONFOOT" />
-        <action name="SF_OPEN_SETTINGS"     category="ONFOOT" />
-        <action name="SF_HUD_DRAG"          category="ONFOOT" />
+        <action name="SF_CYCLE_MAP_LAYER"   category="ONFOOT VEHICLE" />
+        <action name="SF_OPEN_SETTINGS"     category="ONFOOT VEHICLE" />
+        <action name="SF_HUD_DRAG"          category="ONFOOT VEHICLE" />
         <action name="SF_VARIABLE_RATE"     category="VEHICLE" />
         <action name="SF_MINIMAP_ZOOM"      category="ONFOOT" />
         <action name="SF_SCOUT"             category="ONFOOT" />
@@ -101,14 +101,30 @@
     <l10n filenamePrefix="translations/translation" />
 
     <inputBinding>
-        <actionBinding action="SF_TOGGLE_HUD" />
-        <actionBinding action="SF_RATE_UP" />
-        <actionBinding action="SF_RATE_DOWN" />
-        <actionBinding action="SF_TOGGLE_AUTO" />
-        <actionBinding action="SF_CYCLE_MAP_LAYER" />
-        <actionBinding action="SF_OPEN_SETTINGS" />
-        <actionBinding action="SF_HUD_DRAG" />
-        <actionBinding action="SF_VARIABLE_RATE" />
+        <actionBinding action="SF_TOGGLE_HUD">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_j" />
+        </actionBinding>
+        <actionBinding action="SF_RATE_UP">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rightbracket" />
+        </actionBinding>
+        <actionBinding action="SF_RATE_DOWN">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_leftbracket" />
+        </actionBinding>
+        <actionBinding action="SF_TOGGLE_AUTO">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_l" />
+        </actionBinding>
+        <actionBinding action="SF_CYCLE_MAP_LAYER">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_m" />
+        </actionBinding>
+        <actionBinding action="SF_OPEN_SETTINGS">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_o" />
+        </actionBinding>
+        <actionBinding action="SF_HUD_DRAG">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lshift KEY_h" />
+        </actionBinding>
+        <actionBinding action="SF_VARIABLE_RATE">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_lalt KEY_7" />
+        </actionBinding>
         <actionBinding action="SF_MINIMAP_ZOOM" />
         <actionBinding action="SF_SCOUT" />
         <actionBinding action="SF_TREATMENT" />

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -400,6 +400,21 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
         -- registerActionEvent's built-in dedup handles multiple calls per session gracefully.
         if self.soilHUD and InputBinding and InputBinding.endActionEventsModification then
             local _soilVehicleHookActive = false
+            -- BUILD 21:38: put an event on the in-cab F1 strip. The engine lists an action
+            -- only when it is active, has a binding, and has its text visible. modDesc supplies
+            -- the bindings; this supplies the last two. GS_PRIO_HIGH is not decoration: the
+            -- strip's normal tier is a handful of slots and the cab set is cut without it.
+            local function sfShowOnCabStrip(binding, id)
+                if binding == nil or id == nil then
+                    return
+                end
+                if type(binding.setActionEventTextVisibility) == "function" then
+                    binding:setActionEventTextVisibility(id, true)
+                end
+                if GS_PRIO_HIGH ~= nil and type(binding.setActionEventTextPriority) == "function" then
+                    binding:setActionEventTextPriority(id, GS_PRIO_HIGH)
+                end
+            end
             local originalEndMod = InputBinding.endActionEventsModification
             self._vehicleInputHookOriginal = originalEndMod
             InputBinding.endActionEventsModification = function(binding, ignoreCheck)
@@ -465,6 +480,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                 )
                 if vHudOk and vHudId then
                     g_SoilFertilityManager.vehicleHUDEventId = vHudId
+                    sfShowOnCabStrip(binding, vHudId)
                     SoilLogger.debug("HUD toggle (J) registered in VEHICLE context")
                 end
 
@@ -476,6 +492,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                 )
                 if upOk and upId then
                     g_SoilFertilityManager.rateUpEventId = upId
+                    sfShowOnCabStrip(binding, upId)
                     SoilLogger.debug("Rate UP (]) registered in VEHICLE context")
                 end
 
@@ -487,6 +504,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                 )
                 if downOk and downId then
                     g_SoilFertilityManager.rateDownEventId = downId
+                    sfShowOnCabStrip(binding, downId)
                     SoilLogger.debug("Rate DOWN ([) registered in VEHICLE context")
                 end
 
@@ -498,6 +516,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                 )
                 if autoOk and autoId then
                     g_SoilFertilityManager.toggleAutoEventId = autoId
+                    sfShowOnCabStrip(binding, autoId)
                     SoilLogger.debug("Auto toggle (Shift+L) registered in VEHICLE context")
                 end
 
@@ -505,7 +524,10 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                 local vrOk, vrId = binding:registerActionEvent(
                     InputAction.SF_VARIABLE_RATE, g_SoilFertilityManager,
                     g_SoilFertilityManager.onVariableRateInput, false, true, false, true)
-                if vrOk and vrId then g_SoilFertilityManager.variableRateEventId = vrId end
+                if vrOk and vrId then
+                    g_SoilFertilityManager.variableRateEventId = vrId
+                    sfShowOnCabStrip(binding, vrId)
+                end
 
                 -- Settings panel (Shift+O) in VEHICLE context
                 if g_SoilFertilityManager.settingsPanel then
@@ -516,7 +538,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     )
                     if vSpOk and vSpId then
                         g_SoilFertilityManager.vehicleSettingsPanelEventId = vSpId
-                        binding:setActionEventTextVisibility(vSpId, false)
+                        sfShowOnCabStrip(binding, vSpId)
                         SoilLogger.debug("Settings panel (Shift+O) registered in VEHICLE context")
                     end
                 end
@@ -530,7 +552,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     )
                     if vDragOk and vDragId then
                         g_SoilFertilityManager.vehicleHudDragEventId = vDragId
-                        binding:setActionEventTextVisibility(vDragId, false)
+                        sfShowOnCabStrip(binding, vDragId)
                         SoilLogger.debug("HUD drag (Shift+H) registered in VEHICLE context")
                     end
                 end
@@ -558,7 +580,7 @@ function SoilFertilityManager.new(mission, modDirectory, modName, disableGUI)
                     )
                     if vMapOk and vMapId then
                         g_SoilFertilityManager.vehicleCycleMapLayerEventId = vMapId
-                        binding:setActionEventTextVisibility(vMapId, false)
+                        sfShowOnCabStrip(binding, vMapId)
                         SoilLogger.debug("Map layer cycle registered in VEHICLE context")
                     end
                 end
@@ -1843,7 +1865,18 @@ function SoilFertilityManager:_checkVehicleCompaction()
     -- Keep the moisture term current even when no heavy vehicle is around.
     self:_updateSoilWetness()
 
-    local vList = TrafficDrag.resolveVehicleList()
+    -- BUILD 21:59: a zip that carried this manager without src/TrafficDrag.lua indexed nil
+    -- here once per update tick. It falls back rather than returning: compaction is the older
+    -- shipped feature and should keep working when the newer module is absent, and the drag
+    -- write already stands down on its own guards.
+    local vList
+    if TrafficDrag ~= nil and type(TrafficDrag.resolveVehicleList) == "function" then
+        vList = TrafficDrag.resolveVehicleList()
+    else
+        vList = (g_currentMission ~= nil and g_currentMission.vehicleSystem
+                 and g_currentMission.vehicleSystem.vehicles)
+                or (g_currentMission ~= nil and g_currentMission.vehicles) or {}
+    end
     local checked = 0
     for _, vehicle in pairs(vList) do
         if self:_checkOneVehicleCompaction(vehicle) then checked = checked + 1 end

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -535,7 +535,7 @@
 
                     <!-- CS table: top-flush with 404 bottom reserve so the last rows clear the
                          FIELD DETAIL band title (CS FieldDetail fix, applied in the HOST page). -->
-                    <GuiElement profile="emptyPanel" id="csActionBar" position="0px 0px" size="1140px 44px">
+                    <GuiElement profile="emptyPanel" id="csActionBar" position="0px 0px" size="1140px 0px">
                         <!-- BUILD 18:48: this button owned the table-hiding consultant swap, which
                              is now a hard engine VETO. Hidden rather than deleted so any stale
                              binding still resolves; its job belongs to the Fields|Pivot subnav. -->
@@ -546,8 +546,8 @@
                     <!-- Inline Alex Chen consultant readout. Exclusive with rfHostTableRegion:
                          csBtnConsultant toggles which of the two is visible. Fixed Texts only -
                          George NO-GO on TextElement.new rebuild, dialog XML nest, or SmoothList. -->
-                    <GuiElement profile="RF_TableRegionShell" id="csConsultPanel" position="0px -44px"
-                                absoluteSizeOffset="0px 584px" visible="false">
+                    <GuiElement profile="RF_TableRegionShell" id="csConsultPanel" position="0px 0px"
+                                absoluteSizeOffset="0px 514px" visible="false">
                         <Text profile="RF_SectionTitle"   id="csConsTitle"    position="16px -12px"  size="700px 26px"  text=""/>
                         <Text profile="RF_TreatTargetLine" id="csConsRelation" position="16px -36px"  size="1140px 20px" visible="false" text=""/>
                         <Text profile="RF_ColHeader" id="csConsColField"    position="16px -64px"  size="280px 22px" text=""/>
@@ -582,8 +582,8 @@
                               textMaxNumLines="2" visible="false" text=""/>
                     </GuiElement>
 
-                    <GuiElement profile="RF_TableRegionShell" id="rfHostTableRegion" position="0px -44px"
-                                absoluteSizeOffset="0px 584px">
+                    <GuiElement profile="RF_TableRegionShell" id="rfHostTableRegion" position="0px 0px"
+                                absoluteSizeOffset="0px 514px">
                         <Text profile="RF_ColHeader" id="csColField" text="" position="16px -8px" size="100px 24px"/>
                         <Text profile="RF_ColHeader" id="csColCrop" text="" position="140px -8px" size="200px 24px"/>
                         <Text profile="RF_ColHeader" id="csColMoisture" text="" position="360px -8px" size="160px 24px"/>


### PR DESCRIPTION
csActionBar has held nothing but a hidden button since the table-hiding consultant swap
became an engine veto, so its 44px reserved space for nothing and started the Crop Stress
table 44px lower than it needed to. Height goes to 0 and the node stays, so any stale
csBtnConsultant binding still resolves.

rfHostTableRegion and its hidden twin csConsultPanel move to 0,0 and take
absoluteSizeOffset 514 instead of 584. RF_TableRegionShell stretches in Y, so the offset is
subtracted from the stretched height and a smaller offset is a taller region: 70px taller.
44 of those were already spent reclaiming the top, so 26px land at the bottom as new travel
toward the FIELD DETAIL and AGRONOMIST cards. Family rhythm, not a kiss.

FIELD DETAIL, AGRONOMIST and PIVOT are unmoved, and RF_CsDetailStrip is not grown.

The same page bytes go to all nine Esc doors on purpose. RfEscBootstrap.ensureDoor returns
early once the page exists, and whichever mod loads first builds it from its own copy, so a
change in one door alone is simply overwritten by whoever wins that race.

Two Soil-only additions that development does not have yet, both verified absent before
being applied:

modDesc: the eight advertised chords now ship nested <binding> defaults, and four actions
become dual ONFOOT VEHICLE. The engine lists an action on the F1 help strip only when it is
active, has a binding, and has visible text; every SF action except Handful shipped without
a binding, so none of them could ever be listed however visible the text was. Key names were
verified against the installed mod corpus rather than guessed (KEY_rightbracket and
KEY_leftbracket are both real; the KEY_] form is not).

SoilFertilityManager: sfShowOnCabStrip makes the cab five and the three openers visible with
GS_PRIO_HIGH so the strip's small normal tier does not cut them, and the one unguarded
TrafficDrag.resolveVehicleList call now falls back to resolving the same list itself. A zip
that carried this manager without src/TrafficDrag.lua indexed nil there once per update tick.
Compaction is the older shipped feature and should survive that module being absent.

Applied onto development's own content rather than copied from the local tree, so the SF-14
zone-yield wiring from #847 is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)