### PR TITLE
fix(mp): drip-feed value map sync on dedicated servers

### DIFF
--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -2230,16 +2230,13 @@ function SoilNetworkEvents_SendValueMaps(connection, onlyLayerIdx)
         return checksums
     end
 
-    if g_dedicatedServer ~= nil or g_currentMission == nil
-       or g_currentMission.addUpdateable == nil then
-        -- Synchronous path (connection lifetime guaranteed - see issue #228)
+    if g_currentMission == nil or g_currentMission.addUpdateable == nil then
         for i, item in ipairs(work) do
             connection:sendEvent(buildChunk(item, i == #work))
         end
         connection:sendEvent(SoilValueMapChecksumEvent.new(buildChecksums()))
         SoilLogger.info("Server: value maps sent synchronously (%d chunks)", #work)
     else
-        -- Listen server: drip-feed chunks across frames
         local dispatcher = {
             index      = 1,
             timer      = 0,
@@ -2248,6 +2245,10 @@ function SoilNetworkEvents_SendValueMaps(connection, onlyLayerIdx)
             connection = connection,
             update = function(dsp, dt)
                 if not dsp.connection or dsp.index > #dsp.work then
+                    g_currentMission:removeUpdateable(dsp)
+                    return
+                end
+                if dsp.connection.isConnected == false then
                     g_currentMission:removeUpdateable(dsp)
                     return
                 end


### PR DESCRIPTION
## Summary
- Dedicated servers were sending ALL value map chunks synchronously in one frame, causing 5000ms frame spikes on clients receiving the burst
- Now all servers use the drip-feed dispatcher (40ms between chunks), spreading the load across frames on both server and client
- Added `connection.isConnected` guard to the dispatcher so it stops cleanly if the client disconnects mid-sync (the original reason the synchronous path existed per issue #228)

## Test plan
- [ ] Join a dedicated server - verify value map sync completes without frame drops
- [ ] Verify soil overlay data matches server after sync
- [ ] Disconnect mid-sync and verify no server errors
- [ ] Verify checksum drift detection still works after sync