### PR TITLE
fix(spray): boom-proportional area guard for headland slivers (#845)

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -4135,7 +4135,8 @@ function SoilFertilitySystem:paintBoomStrip(fieldId, boomPoints, _fillTypeName, 
         areaM2 = boomLen * (h * 2)
     end
 
-    if areaM2 and areaM2 > 0.001 then
+    local minArea = boomLen * 0.02
+    if areaM2 and areaM2 > minArea then
         local areaHa = areaM2 / 10000
         local scale = sd.area / areaHa
         local vm = self.valueMaps


### PR DESCRIPTION
## Summary
- Replaces the fixed `areaM2 > 0.001` guard in `paintBoomStrip` with `areaM2 > boomLen * 0.02`
- A 36 m boom now requires at least 0.72 m2 of perpendicular travel before painting, filtering out sub-0.2 m2 slivers produced during headland turns
- The old 0.001 m2 threshold let through nearly every turn sliver regardless of boom width

Closes #845