### PR TITLE
fix: recognize herbicides by spray-type category (#839)

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -305,6 +305,11 @@ function SoilFertilitySystem:initialize()
         self:warning("FieldManager not available - will try delayed initialization")
     end
 
+    -- Populate HERBICIDE_TYPES from the engine's spray-type registry so map-added
+    -- herbicides (Roundup, atrazine, etc.) are recognized without a manual table entry.
+    -- Explicit entries in HERBICIDE_TYPES take precedence (custom effectiveness values).
+    self:populateHerbicideTypesFromSprayCategory()
+
     -- Install hooks via HookManager
     self.hookManager:installAll(self)
 
@@ -317,6 +322,28 @@ function SoilFertilitySystem:initialize()
     -- Log multifruit compatibility status
     self:logCropProfileStatus()
 
+end
+
+function SoilFertilitySystem:populateHerbicideTypesFromSprayCategory()
+    if not g_sprayTypeManager then return end
+    local wp = SoilConstants.WEED_PRESSURE
+    if not wp then return end
+    if not wp.HERBICIDE_TYPES then wp.HERBICIDE_TYPES = {} end
+
+    local added = 0
+    for _, sprayType in ipairs(g_sprayTypeManager:getSprayTypes()) do
+        if sprayType.isHerbicide and sprayType.fillType then
+            local name = sprayType.fillType.name
+            if name and wp.HERBICIDE_TYPES[name] == nil then
+                wp.HERBICIDE_TYPES[name] = 1.0
+                added = added + 1
+                self:info("Herbicide '%s' recognized by spray-type category", name)
+            end
+        end
+    end
+    if added > 0 then
+        self:info("Added %d herbicide(s) from spray-type categories", added)
+    end
 end
 
 -- Log which registered fruit types have explicit extraction profiles


### PR DESCRIPTION
## Summary

- Map-added herbicides (Roundup, atrazine, etc.) register as spray type `HERBICIDE` in the engine's `SprayTypeManager` but were not in the one-entry `HERBICIDE_TYPES` table, so they sprayed, drained the tank, cost the money and did nothing to weed pressure
- At init, `populateHerbicideTypesFromSprayCategory()` scans `g_sprayTypeManager:getSprayTypes()` for all spray types with `isHerbicide == true` and populates `HERBICIDE_TYPES` with any not already explicitly listed
- Explicit entries take precedence (custom effectiveness values); category-matched entries default to 1.0
- No existing lookup sites change; the table is populated before `installAll`, so every hook and system reads the complete set

Design answer: Claude(A) ledger 2026-08-21, Arissani ruling -- recognize by fill-type category matching first, existing table as override and fallback.

Flip condition (from the ruling): if category data proves unreliable on third-party fill types at source, the wider-table shape takes over.

## Test plan

- [x] 3033 suite assertions pass (76 test files, 0 failures)
- [x] Build succeeds (`py build.py --deploy`)
- [ ] Verify in-game with a map that adds custom herbicide fill types (e.g. Illschwang with Roundup)
- [ ] Confirm log shows "Herbicide 'X' recognized by spray-type category" for each map-added herbicide
- [ ] Confirm weed pressure drops when spraying with a map-added herbicide
- [ ] Confirm See & Spray recognizes map-added herbicides