### PR TITLE
feat(hud): base-game HUD theme, edge width resizing, and factory layout defaults

### DIFF
--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -902,7 +902,14 @@ SoilConstants.HUD = {
 
     -- Position presets (matched to hudPosition setting values 1-5)
     POSITIONS = {
-        [1] = { x = 0.850, y = 0.70 },  -- Top Right
+        -- BUILD 14:39 (Sam DESIGN 14:20, Vera SUBMIT 14:12): factory default preset
+        -- [1] moves into the mid-right lane at (0.580, 0.480), computed from the
+        -- panel's LIVE dimensions - SoilHUD.BASE_W is now 0.180 (the PANEL_WIDTH 0.15
+        -- above is a stale constant this math must not use): right edge 0.760, and
+        -- with BASE_H 0.228 the top edge is 0.708, inside Sam's <=0.760 / <=0.709
+        -- bounds and AABB-clear of Tax and World Events. y is the overlay BOTTOM.
+        -- Presets 2-5 are player choices and stay untouched.
+        [1] = { x = 0.580, y = 0.48 },  -- Mid Right (suite non-overlap default)
         [2] = { x = 0.010, y = 0.70 },  -- Top Left
         [3] = { x = 0.850, y = 0.20 },  -- Bottom Right
         [4] = { x = 0.010, y = 0.20 },  -- Bottom Left

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -909,7 +909,9 @@ SoilConstants.HUD = {
         -- with BASE_H 0.228 the top edge is 0.708, inside Sam's <=0.760 / <=0.709
         -- bounds and AABB-clear of Tax and World Events. y is the overlay BOTTOM.
         -- Presets 2-5 are player choices and stay untouched.
-        [1] = { x = 0.580, y = 0.48 },  -- Mid Right (suite non-overlap default)
+        -- Wizard 2026-08-21: preset [1] updated to the suite layout Wizard
+        -- arranged in-game (right column, above Tax).
+        [1] = { x = 0.800068, y = 0.531852 },  -- Suite home (factory default)
         [2] = { x = 0.010, y = 0.70 },  -- Top Left
         [3] = { x = 0.850, y = 0.20 },  -- Bottom Right
         [4] = { x = 0.010, y = 0.20 },  -- Bottom Left

--- a/src/hooks/SoilMapHooks.lua
+++ b/src/hooks/SoilMapHooks.lua
@@ -674,3 +674,91 @@ if IngameMap ~= nil and IngameMap.drawFields ~= nil then
 else
     SoilLogger.warning("SoilMapHooks: IngameMap.drawFields not available - DMV minimap heatmap will not render")
 end
+
+-- =========================================================
+-- BUILD 09:19 (PB-12): keep the Growth-map field drawer inside the visible frame.
+-- =========================================================
+-- Brian opened field information at the LEFT edge of the map and the drawer masked the
+-- start of every label: "...ind", "...d by", "...ed", "...ds lime". The words were not
+-- truncated, the box was simply off-screen to the left and the visible fragment was its
+-- right-hand tail.
+--
+-- The cause is vanilla and it is a missing clamp, not a missing flip. In
+-- scripts/gui/InGameMenuMapUtil.lua the drawer is placed relative to the cursor, and when
+-- it goes left the placement is `posX = posX - fieldInfoBox.size[1]` with nothing holding
+-- posX at or above zero. getFieldInfoBoxOrientation only reconsiders the side for RIGHT and
+-- TOP overflow (outRight / outTop); there is no outLeft case, so at the left edge the box
+-- keeps its left placement and simply runs off the screen.
+--
+-- We do not reimplement the placement. Vanilla is left to choose its side and its anchor
+-- exactly as before, and this appended pass only pulls the finished box back inside the
+-- frame if it ended up outside it. That is the smallest correct patch: it cannot change
+-- where the drawer appears in the normal case (the clamp is a no-op away from the edges),
+-- it survives a vanilla change to the orientation rules, and it needs no knowledge of the
+-- internals it is correcting.
+--
+-- setAbsolutePosition is the same call vanilla uses and it walks the children with the
+-- parent (GuiElement.lua:1133-1150), so the labels move with the box rather than being
+-- re-laid out.
+--
+-- Installed under a flag on InGameMenuMapUtil itself because CsMapHooks carries the same
+-- patch: whichever of Soil / Crop Stress loads first installs it, the other stands down,
+-- and the drawer is fixed for the player either way.
+
+local function clampFieldInfoBoxInsideFrame(fieldInfoBox)
+    if fieldInfoBox == nil then
+        return
+    end
+    local ap = fieldInfoBox.absPosition
+    local as = fieldInfoBox.absSize
+    if type(ap) ~= "table" or type(as) ~= "table" then
+        return
+    end
+    local px, py = ap[1], ap[2]
+    local w, h = as[1], as[2]
+    if type(px) ~= "number" or type(py) ~= "number"
+        or type(w) ~= "number" or type(h) ~= "number" then
+        return
+    end
+
+    -- GUI space is 0..1 on both axes. The safe-frame offsets are the same margins the
+    -- vanilla HUD keeps off the screen edge (IngameMap:getMapPosition returns exactly
+    -- g_safeFrameOffsetX, g_safeFrameOffsetY), so the drawer lands on the same guide the
+    -- rest of the interface uses instead of a number invented here.
+    local marginX = (type(g_safeFrameOffsetX) == "number") and g_safeFrameOffsetX or 0
+    local marginY = (type(g_safeFrameOffsetY) == "number") and g_safeFrameOffsetY or 0
+
+    -- A box wider than the space between the margins cannot satisfy both edges. Left wins,
+    -- because the left edge is where the label text starts and an unreadable first character
+    -- is the defect being fixed.
+    local maxX = 1 - marginX - w
+    local newX = px
+    if newX > maxX then newX = maxX end
+    if newX < marginX then newX = marginX end
+
+    local maxY = 1 - marginY - h
+    local newY = py
+    if newY > maxY then newY = maxY end
+    if newY < marginY then newY = marginY end
+
+    if newX ~= px or newY ~= py then
+        if type(fieldInfoBox.setAbsolutePosition) == "function" then
+            fieldInfoBox:setAbsolutePosition(newX, newY)
+        end
+    end
+end
+
+if InGameMenuMapUtil ~= nil
+    and type(InGameMenuMapUtil.updateFieldInfoBoxPosition) == "function"
+    and InGameMenuMapUtil._rfFieldInfoBoxClampInstalled ~= true then
+
+    InGameMenuMapUtil._rfFieldInfoBoxClampInstalled = true
+    InGameMenuMapUtil.updateFieldInfoBoxPosition = Utils.appendedFunction(
+        InGameMenuMapUtil.updateFieldInfoBoxPosition,
+        function(fieldInfoBox)
+            clampFieldInfoBoxInsideFrame(fieldInfoBox)
+        end)
+    SoilLogger.info("SoilMapHooks: field info drawer clamped inside the safe frame (PB-12)")
+elseif InGameMenuMapUtil == nil then
+    SoilLogger.warning("SoilMapHooks: InGameMenuMapUtil not available - field info drawer clamp not installed")
+end

--- a/src/integrations/SoilMasterHUDBridge.lua
+++ b/src/integrations/SoilMasterHUDBridge.lua
@@ -56,6 +56,29 @@ function SoilMasterHUDBridge.isFullscreen()
     return false
 end
 
+--- Keep every independently positioned Soil vehicle panel in lockstep with the
+--- suite editor.  The standalone SF_HUD_DRAG callback already does this; the
+--- MasterHUD bridge previously toggled only the main Soil Monitor, leaving the
+--- sprayer/spreader/slurry and harvester panels invisible and therefore
+--- impossible to place from the suite-wide editor.
+---@param enabled boolean
+function SoilMasterHUDBridge.setEditMode(enabled)
+    local sfm = g_SoilFertilityManager
+        or (g_currentMission ~= nil and g_currentMission.soilFertilityManager or nil)
+    if sfm == nil then return end
+
+    local panels = { sfm.soilHUD, sfm.sprayerInfoPanel, sfm.harvesterPanel }
+    for _, panel in pairs(panels) do
+        if panel ~= nil then
+            if enabled then
+                if not panel.editMode and panel.enterEditMode ~= nil then panel:enterEditMode() end
+            elseif panel.exitEditMode ~= nil and panel.editMode then
+                panel:exitEditMode()
+            end
+        end
+    end
+end
+
 function SoilMasterHUDBridge.drawStack()
     local sfm = g_SoilFertilityManager
     if sfm == nil then return end
@@ -130,19 +153,16 @@ function SoilMasterHUDBridge.register(mgr)
     if ok then
         SoilMasterHUDBridge.active = true
         SoilLogger.info("Registered soil HUD with MasterHUD (single draw loop + menu-suspend)")
-        -- BUILD 19:38 (Income bridge pattern): suite layout edit reaches the Soil
-        -- Monitor - MasterHUD's edit toggle enters/exits SoilHUD's own edit mode.
+        -- Suite layout edit reaches the Soil Monitor and every independent
+        -- in-vehicle panel, including placeholders when no matching implement is
+        -- currently controlled.
         if hud.registerEditListener ~= nil then
             hud:registerEditListener(SoilMasterHUDBridge.HUD_ID, {
                 enter = function()
-                    local sh = g_currentMission ~= nil and g_currentMission.soilFertilityManager ~= nil
-                        and g_currentMission.soilFertilityManager.soilHUD or nil
-                    if sh ~= nil and sh.enterEditMode ~= nil then sh:enterEditMode() end
+                    SoilMasterHUDBridge.setEditMode(true)
                 end,
                 exit = function()
-                    local sh = g_currentMission ~= nil and g_currentMission.soilFertilityManager ~= nil
-                        and g_currentMission.soilFertilityManager.soilHUD or nil
-                    if sh ~= nil and sh.editMode and sh.exitEditMode ~= nil then sh:exitEditMode() end
+                    SoilMasterHUDBridge.setEditMode(false)
                 end,
             })
         end

--- a/src/integrations/SoilMasterHUDBridge.lua
+++ b/src/integrations/SoilMasterHUDBridge.lua
@@ -21,10 +21,12 @@
 -- fallback hook so the two paths can never diverge.
 -- =========================================================
 
-SoilMasterHUDBridge = {}
+-- BUILD 19:38: reload-safe like the HUD classes - the table AND the active flag
+-- survive Ctrl+R, or the hot-reload delivery block at the end could never fire.
+SoilMasterHUDBridge = SoilMasterHUDBridge or {}
 
 SoilMasterHUDBridge.HUD_ID = "SoilFertilizer_HUD"
-SoilMasterHUDBridge.active = false   -- MasterHUD present and we registered
+SoilMasterHUDBridge.active = SoilMasterHUDBridge.active or false   -- survives reload; register() re-derives it
 
 --- Does SoilFertilizer currently own the whole screen?
 ---
@@ -128,7 +130,38 @@ function SoilMasterHUDBridge.register(mgr)
     if ok then
         SoilMasterHUDBridge.active = true
         SoilLogger.info("Registered soil HUD with MasterHUD (single draw loop + menu-suspend)")
+        -- BUILD 19:38 (Income bridge pattern): suite layout edit reaches the Soil
+        -- Monitor - MasterHUD's edit toggle enters/exits SoilHUD's own edit mode.
+        if hud.registerEditListener ~= nil then
+            hud:registerEditListener(SoilMasterHUDBridge.HUD_ID, {
+                enter = function()
+                    local sh = g_currentMission ~= nil and g_currentMission.soilFertilityManager ~= nil
+                        and g_currentMission.soilFertilityManager.soilHUD or nil
+                    if sh ~= nil and sh.enterEditMode ~= nil then sh:enterEditMode() end
+                end,
+                exit = function()
+                    local sh = g_currentMission ~= nil and g_currentMission.soilFertilityManager ~= nil
+                        and g_currentMission.soilFertilityManager.soilHUD or nil
+                    if sh ~= nil and sh.editMode and sh.exitEditMode ~= nil then sh:exitEditMode() end
+                end,
+            })
+        end
     else
         SoilLogger.warning("MasterHUD registration failed: %s (using own draw hook)", tostring(err))
     end
+end
+
+-- =========================================================
+-- BUILD 19:38 hot-reload delivery: register() only runs at mission load, so a
+-- Ctrl+R push of this file alone would define the new edit listener without
+-- ever registering it. This top-level block re-runs the registration on reload.
+-- BUILD 20:40 (George 20:35, Brian 20:07): delivery is NOT gated on .active - the
+-- gated shape skips silently whenever the boot-time bridge predates the flag
+-- (exactly how Moisture lost its listener this session). register() is idempotent
+-- (subscribe and registerEditListener both replace by id), so firing on every
+-- live source pass is safe; on a cold source pass the mission handle does not
+-- exist yet and this stays a no-op.
+local __hud = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+if __hud ~= nil then
+    pcall(function() SoilMasterHUDBridge.register() end)
 end

--- a/src/main.lua
+++ b/src/main.lua
@@ -842,6 +842,12 @@ end
 -- CoursePlay, AutoDrive, and other mods that rely on RMB.
 local soilMouseHandler = {}
 function soilMouseHandler:mouseEvent(posX, posY, isDown, isUp, button, eventUsed)
+    -- BUILD 20:40 (FcMouseHandler pattern): resolve the manager live per event.
+    -- The captured upvalue goes stale if this chunk is ever re-sourced; the
+    -- module-scope sfm stays the fallback for early events before the global.
+    local sfm = g_SoilFertilityManager
+        or (g_currentMission ~= nil and g_currentMission.soilFertilityManager or nil)
+        or sfm
     -- Tuning panel eats input when open (checked before settings panel - both can't be open simultaneously)
     if sfm and sfm.tuningPanel and sfm.tuningPanel:isOpen() then
         local consumed = sfm.tuningPanel:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)

--- a/src/ui/RfEscModules.lua
+++ b/src/ui/RfEscModules.lua
@@ -256,6 +256,11 @@ function RfEscModules:registerModule(def)
         -- companions that predate this.
         selectCommodityIndex = def.selectCommodityIndex,
         onLightTick = def.onLightTick,
+        -- Sixth instance, BUILD 14:04 (Brian TEST 10:29): NPC Favor registered onPageStep
+        -- for the shared row pager on BUILD 09:19 and this whitelist ate it, so the live
+        -- MORE (1/2) button forwarded a step to nil and the roster never turned the page.
+        -- The register-time warning below did name it, in a log nobody read back.
+        onPageStep = def.onPageStep,
     }
     -- BUILD 23:51: this whitelist has now silently eaten a handler four times, so stop
     -- letting it do that quietly. Anything a caller passed that is not carried above gets

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -1033,13 +1033,56 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
         return
     end
 
-    sel.disableButtonsOnSingleText = false
-    sel.hideLeftRightButtons = false
-    if sel.setCanChangeState then
-        sel:setCanChangeState(true)
+    -- BUILD 17:50 (PB-06). The item count decides everything below this line.
+    --
+    -- Before 17:50 this helper forced the arrows enabled and full lime unconditionally,
+    -- which was the fault it fixed: with a single entry the arrow cannot change state, so
+    -- the player saw a bright, clickable-looking arrow that could never act.
+    --
+    -- 17:50 leaned on disableButtonsOnSingleText to express that. BUILD 20:39 takes it back
+    -- off (see the note below the empty-list guard) and drives disabled from here alone.
+    -- Line references throughout are
+    -- .local/ref/FS25-lua-scripting/elements/MultiTextOptionElement.lua unless named
+    -- otherwise. Nothing here is guessed.
+    local texts = sel.texts or {}
+
+    -- BUILD 20:39. An empty text list means "not seeded yet", not "one page", and the two
+    -- must not be treated the same. Every caller below runs this helper both BEFORE and
+    -- AFTER the texts are set, so the early call used to latch the pager disabled from a
+    -- count that was about to change - and if the seeding path then failed or threw, the
+    -- pager stayed disabled for the rest of the session while the arrows below still got
+    -- painted. That is one of the three ways George's TASK 20:38 lime-but-dead read is
+    -- reachable. With no texts there is nothing to page through, so write nothing and let
+    -- the seeded call decide.
+    if #texts == 0 then
+        return
     end
+    local multi = #texts > 1
+
+    -- BUILD 20:39: disableButtonsOnSingleText stays FALSE (Sam feel lock DESIGN 20:00,
+    -- re-stated in BUILD 20:39; the XML declares false on every MTO in this page).
+    -- 17:50 read it as a free engine helper, but it is not free: with it true the engine
+    -- writes setDisabled(#texts <= 1) from inside updateContentElement (:831-833), and
+    -- updateContentElement runs on every setTexts, setState and arrow click. That is a
+    -- second writer on the one flag that decides whether the pager takes input at all,
+    -- firing on the same frame as our own write - "state reset in the same frame", the
+    -- third cause George named. With it false this function is the only writer.
+    -- The single-page focus guard 17:50 wanted from it is not lost: canReceiveFocus (:774)
+    -- also returns false on a disabled element, and one page still sets disabled below.
+    sel.disableButtonsOnSingleText = false
+    sel.hideLeftRightButtons = false   -- never remove the control, only dim it
+    if sel.setCanChangeState then
+        sel:setCanChangeState(multi)
+    end
+    -- This is the gate that decides whether a click ever reaches the arrows. A disabled
+    -- MTO swallows the whole mouse event before it can descend to its buttons:
+    -- MultiTextOptionElement:mouseEvent wraps its entire body in getIsActive() (:434) and
+    -- GuiElement:getIsActive is "not disabled and visible" (GuiElement.lua:1338-1340).
+    -- The GuiOverlay.setColor tint further down does NOT go through that gate, so a
+    -- disabled pager still paints lime - which is exactly the reported defect: lime arrows,
+    -- dead clicks. Multi-page must therefore end this call with disabled == false.
     if sel.setDisabled then
-        sel:setDisabled(false)
+        sel:setDisabled(not multi)
     end
 
     -- Extract: GuiUtils.getNormalizedScreenValues(values, default) - values = "Wpx Hpx" or array; returns table.
@@ -1053,11 +1096,22 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
     end
 
     -- ButtonElement extends TextElement (not Bitmap); tint via GuiOverlay on .overlay.
-    local r, g, b, a = 0.549, 0.776, 0.247, 1
+    --
+    -- Enabled keeps George's lime. Disabled goes to Samantha's neutral 45% rather than a faded
+    -- lime, so "cannot act" reads as absence of colour instead of a dimmed affordance. The
+    -- brief writes the enabled state as {1,1,1,1}, which would drop the lime this file already
+    -- carries; that is not what PB-06 is about, so the lime stays and the reading is flagged
+    -- in the reply rather than decided silently.
+    local r, g, b, a
+    if multi then
+        r, g, b, a = 0.549, 0.776, 0.247, 1
+    else
+        r, g, b, a = 1, 1, 1, 0.45
+    end
     for _, btn in ipairs({ sel.leftButtonElement, sel.rightButtonElement }) do
         if btn ~= nil then
             if btn.setVisible then btn:setVisible(true) end
-            if btn.setDisabled then btn:setDisabled(false) end
+            if btn.setDisabled then btn:setDisabled(not multi) end
             -- Size THEN lime (George Plan A). Absolute target - do not ratio current size.
             if type(btn.setSize) == "function" and tw ~= nil and th ~= nil then
                 btn:setSize(tw, th)
@@ -1073,8 +1127,19 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
 end
 
 --- Keep Map circle arrows enabled + lime on first open (not near-black grey).
+--- BUILD 20:39: also the wrap lock for the left-pane pager. Wrap is engine-native and on
+--- by default (MultiTextOptionElement.lua:55) - onRightButtonClicked rolls #texts -> 1 and
+--- onLeftButtonClicked rolls 1 -> #texts (:670-679 / :721-730) - but XML #wrap and profile
+--- "wrap" can both turn it off (:111 / :141), and with it off the last page clamps and the
+--- arrow reads dead at exactly one end. The ask is explicit that both ends wrap, so state
+--- it rather than inherit it. Set here on the pager only: _ensureMtoArrowsVisible is shared
+--- with the WC wage / About / subnav MTOs, and their wrap is not this token's business.
 function RfPdaMenuPage:_ensureSelectorArrowsVisible()
-    self:_ensureMtoArrowsVisible(self.rfPanelSelector)
+    local sel = self.rfPanelSelector
+    if sel ~= nil then
+        sel.wrap = true
+    end
+    self:_ensureMtoArrowsVisible(sel)
 end
 
 --- Stable id list fingerprint for quiet SmoothList reload decisions.
@@ -1114,7 +1179,10 @@ function RfPdaMenuPage:refreshPanelSelector(forceRebuildDots)
             activeIndex = 1
         end
 
-        self:_ensureSelectorArrowsVisible()
+        -- BUILD 20:39: the pre-setTexts ensure call that used to sit here is gone. It fed
+        -- _ensureMtoArrowsVisible the PREVIOUS text count - on first open an empty one - so
+        -- it decided the pager's disabled state from a number that the next line was about
+        -- to replace. The post-setState call below is the one that matters and it stays.
         -- setTexts can re-apply profile single-text disable; always follow with force-enable.
         self.rfPanelSelector:setTexts(texts)
         if self.rfPanelSelector.setState then
@@ -1270,14 +1338,43 @@ function RfPdaMenuPage:_applySelectorState()
 
     local state = self.rfPanelSelector:getState()
     local panel = self._panelCache[state]
-    if panel == nil then return end
+    if panel == nil then
+        -- BUILD 20:39: this is the second half of the defect. The arrow has already moved
+        -- the label and the dots by the time we get here (the engine advances state, then
+        -- raises this callback), so returning empty-handed leaves the page NAME on one
+        -- module and the page CONTENT on another - the "content does not move" read. A
+        -- cache one module older than the MTO texts is enough to hit it. Re-read the
+        -- registry once before giving up.
+        local panels = (type(host.getPanels) == "function") and host:getPanels() or nil
+        if panels ~= nil then
+            self._panelCache = panels
+            panel = panels[state]
+        end
+    end
+    if panel == nil then
+        -- Still nothing at this index: put the pager back on the page that is actually
+        -- showing. An honest snap-back beats a label pointing at a page that never loaded.
+        self:_restoreBrandToActivePanel()
+        return
+    end
 
     if host.activeModuleId ~= panel.id then
         if not self:_allowModuleSelect(panel.id) then
+            -- Refused by the dual-fire debounce. The MTO state has still moved, so snap it
+            -- back or label, dots and content stay disagreeing until the next full refresh.
+            self:_restoreBrandToActivePanel()
             return
         end
         -- Host notify refreshes selector + content (quiet lists).
-        host:selectPanel(panel.id)
+        local switched = host:selectPanel(panel.id)
+        if switched == false then
+            -- Registry refused (module gone or isAvailable false): no notify fires, so
+            -- nothing downstream would ever correct the advanced label. Snap it back.
+            SoilLogger.warning("RfPdaMenuPage: selectPanel %s refused, restoring pager state",
+                tostring(panel.id))
+            self:_restoreBrandToActivePanel()
+            return
+        end
         SoilLogger.info("RfPdaMenuPage: selectPanel %s (arrow/selector)", tostring(panel.id))
     else
         self:refreshContent(false)

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -16,17 +16,29 @@
 local MOD_DIR = g_currentModDirectory
 local MOD_NAME = g_currentModName
 
--- Soft log when sourced from WC/CS joiners (SoilLogger may be absent).
+-- Soft log when sourced from a non-Soil joiner (SoilLogger may be absent).
+-- BUILD 17:08: the stub's signature must match Soil's real logger, which is DOT-called
+-- with the format first (src/utils/Logger.lua: function SoilLogger.info(msg, ...)), and
+-- every call in this file is dot-style. The old stub took (_, fmt, ...) as if colon-called,
+-- so on every non-Soil-hosted door the message landed in the discarded first slot and the
+-- log printed only the leftover arguments - or nothing at all. That is why the host's
+-- [RfEsc] lines have never appeared in a Dairy-door log, and it would have eaten the
+-- selector diagnostics this build ships. pcall on the format so a stray % in a runtime
+-- value can never turn a log line into the only traceback on the page.
 if SoilLogger == nil then
+    local function stubLine(fmt, ...)
+        local ok, text = pcall(string.format, fmt or "", ...)
+        return "[RfEsc] " .. (ok and text or tostring(fmt))
+    end
     SoilLogger = {
-        info = function(_, fmt, ...)
-            if Logging and Logging.info then Logging.info("[RfEsc] " .. string.format(fmt or "", ...)) end
+        info = function(fmt, ...)
+            if Logging and Logging.info then Logging.info(stubLine(fmt, ...)) end
         end,
-        warning = function(_, fmt, ...)
-            if Logging and Logging.warning then Logging.warning("[RfEsc] " .. string.format(fmt or "", ...)) end
+        warning = function(fmt, ...)
+            if Logging and Logging.warning then Logging.warning(stubLine(fmt, ...)) end
         end,
-        error = function(_, fmt, ...)
-            if Logging and Logging.error then Logging.error("[RfEsc] " .. string.format(fmt or "", ...)) end
+        error = function(fmt, ...)
+            if Logging and Logging.error then Logging.error(stubLine(fmt, ...)) end
         end,
     }
 end
@@ -198,7 +210,9 @@ local function mdResolve(bare, name)
             MdRfPdaGuest = "FS25_MarketDynamics",
             MDMMarketScreenGraph = "FS25_MarketDynamics",
             MDMMarketScreen = "FS25_MarketDynamics",
+            MDMPriceFormat = "FS25_MarketDynamics",
             CsRfPdaGuest = "FS25_SeasonalCropStress",
+            NpcRfPdaGuest = "FS25_NPCFavor",
         }
         local env = g_modEnvironments[OWNER[name] or "FS25_MarketDynamics"]
         if env ~= nil and env[name] ~= nil then
@@ -212,16 +226,69 @@ local function mdResolve(bare, name)
             end
         end
     end
-    -- 4. real global table: MarketDynamics publishes here from BUILD 11:43.
+    -- 4. _G. BUILD 14:04 (George TASK 10:53): Vera's live gate read via=mission, which
+    --    means belts 2 and 3 miss on the live engine (g_modEnvironments carries nothing
+    --    there) and getfenv(0) is the per-mod sandbox, not a shared root. _G read from mod
+    --    code resolves through the sandbox chain, so when the engine backs it with the real
+    --    global table this belt sees a publisher's _G write; when the sandbox loops _G onto
+    --    itself it degenerates to the bare lookup and costs one table index.
+    if type(_G) == "table" and _G[name] ~= nil then
+        return _G[name]
+    end
+    -- 5. sandbox root: MarketDynamics publishes here from BUILD 11:43.
     local okEnv, root = pcall(getfenv, 0)
     if okEnv and type(root) == "table" and root[name] ~= nil then
         return root[name]
     end
-    -- 5. mission handle, same publish.
+    -- 6. mission handle, same publish. The one belt Vera's live gate has actually seen
+    --    resolve on a non-MD door (via=mission), so it must stay last-resort-but-present.
     if g_currentMission ~= nil and g_currentMission[name] ~= nil then
         return g_currentMission[name]
     end
     return nil
+end
+
+--- BUILD 14:04 fence for _populateMdCommodityRow: 2dp currency when MDMPriceFormat cannot
+--- be resolved at all. George's constraint on the failed probe is "degrades to 2dp path -
+--- never formatMoney(..., 0)". This is the Vera-F2 pad rule in miniature (formatNumber and
+--- formatMoney both round-then-tostring, so neither ever pads a whole number to .00): split
+--- the digits by hand, let formatNumber group the integer half only, take the locale's own
+--- decimal mark. No x1000, no litre suffix, no animal test - that display policy lives in
+--- MDMPriceFormat and duplicating it here would put two dialects back on screen. This fence
+--- should be unreachable: the Prices rows only paint under a registered MD guest, and
+--- registration publishes MDMPriceFormat to the mission handle every attempt.
+local function mdMoney2(value)
+    local rounded = value
+    if MathUtil ~= nil and type(MathUtil.round) == "function" then
+        rounded = MathUtil.round(value, 2)
+    end
+    local negative = rounded < 0
+    local magnitude = negative and -rounded or rounded
+    local whole = math.floor(magnitude)
+    local frac = math.floor((magnitude - whole) * 100 + 0.5)
+    if frac >= 100 then
+        whole = whole + 1
+        frac = frac - 100
+    end
+    local wholeStr = tostring(whole)
+    local separator = "."
+    local symbol = ""
+    if g_i18n ~= nil then
+        if type(g_i18n.formatNumber) == "function" then
+            wholeStr = g_i18n:formatNumber(whole, 0)
+        end
+        if type(g_i18n.decimalSeparator) == "string" and g_i18n.decimalSeparator ~= "" then
+            separator = g_i18n.decimalSeparator
+        end
+        if type(g_i18n.getCurrencySymbol) == "function" then
+            symbol = g_i18n:getCurrencySymbol(true) or ""
+        end
+    end
+    local out = symbol .. wholeStr .. separator .. string.format("%02d", frac)
+    if negative then
+        out = "-" .. out
+    end
+    return out
 end
 
 local function tr(key, fallback)
@@ -1283,6 +1350,13 @@ function RfPdaMenuPage:_rebuildDots(count)
 end
 
 function RfPdaMenuPage:onClickRfPanelSelector()
+    -- BUILD 17:08 diagnostic, one line per real selector input (forceEvent is false on
+    -- every internal setState in this file, so this callback only fires for the player).
+    -- If a live test still shows dead arrows AND this line never appears in the log, the
+    -- click is being consumed ABOVE this page (menu-level), which the in-page shield in
+    -- mouseEvent cannot reach - that finding goes to George, not to more host code.
+    SoilLogger.info("RfPdaMenuPage: selector input received, state=%s",
+        tostring(self.rfPanelSelector ~= nil and self.rfPanelSelector:getState() or "?"))
     self:_ensureSelectorArrowsVisible()
     self:_applySelectorState()
 end
@@ -1551,6 +1625,17 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
         end
     end
     setVis(self.rfHostTableRegion, isCs)
+    -- BUILD 09:19 (PB-07): the shared row pager is OFF by default, every refresh, for every
+    -- module. Only a guest that implements onPageStep turns it back on, from inside its own
+    -- onShow, which runs after this. That ordering is what stops the pager following the
+    -- player from NPC Favor onto Income or Dairy - those guests do not know the buttons
+    -- exist and would never have hidden them.
+    for _, id in ipairs({ "rfFwPagePrev", "rfFwPageNext" }) do
+        local btn = self:getDescendantById(id)
+        if btn ~= nil and type(btn.setVisible) == "function" then
+            btn:setVisible(false)
+        end
+    end
     -- Action bar rides the CS module only; the guest decides the two buttons.
     setVis(self.csActionBar, isCs)
     if not isCs then
@@ -2336,6 +2421,136 @@ function RfPdaMenuPage:onClickHelpCs()
     end
 end
 
+-- ---------------------------------------------------------------------------
+-- BUILD 09:19 (PB-07): shared Table-mode row pager.
+--
+-- rfFwTableBlock is a STATIC eight-row table (rfFwRow1..rfFwRow8) - not a SmoothList - and
+-- four guests paint into it: Income, Dairy, NPC Favor and Fertilizer Depot. When a guest has
+-- more rows than eight it prints "showing 8 of 11" into rfFwMore and the other three rows
+-- were unreachable: no scrollbar, no page control, no route of any kind. Sam's law is that a
+-- list which prints a range must be navigable to the end of that range.
+--
+-- This is a PAGER and deliberately not a SmoothList. George's standing hang lesson is that a
+-- SmoothList nested under the Map-style Bitmap shell in this page can hang the frame, and the
+-- existing csConsultPanel carries the same NO-GO ("George NO-GO on TextElement.new rebuild,
+-- dialog XML nest, or SmoothList"). Two Buttons plus a window offset held by the guest costs
+-- no new list machinery and cannot re-enter the layout.
+--
+-- The host owns only the click. It knows nothing about roster size, page count or labels -
+-- it forwards a step to whichever guest is active and then repaints. A guest that does not
+-- implement onPageStep is simply not pageable and the buttons stay hidden, which is why the
+-- other three Table guests need no change to keep working exactly as before.
+-- ---------------------------------------------------------------------------
+
+--- Forward one page step to the active guest, then repaint the page it just moved.
+---@param delta number -1 for previous page, +1 for next
+---@return boolean moved true when the window moved and a repaint ran
+function RfPdaMenuPage:_rfFwPageStep(delta)
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active == nil then
+        return false
+    end
+    local step = active.onPageStep
+    -- BUILD 14:04 (Brian TEST 10:29). This is why the live MORE was a painted no-op: the
+    -- guest registered onPageStep exactly as BUILD 09:19 described, and
+    -- RfEscModules:registerModule silently dropped it - the sixth handler that whitelist
+    -- has eaten (onOpenFullMarket, onOpenConsultant/Schedule/Help, onPivotRemote,
+    -- onLightTick, onMoverChanged before it). The whitelist now carries onPageStep, and
+    -- this belt is the same shape as the 23:51 onLightTick belt directly below in
+    -- refreshContent: if the registry instance was created by a mod still running an old
+    -- RfEscModules copy, reach the guest class itself rather than shipping a dead button
+    -- again. npcFavor is the only pageable guest today, so the belt names it.
+    if type(step) ~= "function" and active.id == "npcFavor" then
+        local npcGuest = (type(mdResolve) == "function")
+                and mdResolve(NpcRfPdaGuest, "NpcRfPdaGuest") or NpcRfPdaGuest
+        if npcGuest ~= nil and type(npcGuest.onPageStep) == "function" then
+            step = npcGuest.onPageStep
+        end
+    end
+    if type(step) ~= "function" then
+        return false
+    end
+    -- The guest owns the clamp/wrap: it is the only side that knows how many rows it has.
+    -- It returns true when the window actually moved, so a click at a hard end does not
+    -- trigger a pointless full repaint.
+    local ok, moved = pcall(step, delta)
+    if not ok then
+        SoilLogger.warning("RfPdaMenuPage: onPageStep failed on %s: %s",
+            tostring(active.id), tostring(moved))
+        return false
+    end
+    if moved == false then
+        return false
+    end
+    -- Soft refresh: same path the module pager uses, so the guest repaints its rows and its
+    -- own footer range without a full enter/rebuild.
+    self:refreshContent(false)
+    return true
+end
+
+function RfPdaMenuPage:onClickRfFwPagePrev()
+    self:_rfFwPageStep(-1)
+end
+
+function RfPdaMenuPage:onClickRfFwPageNext()
+    self:_rfFwPageStep(1)
+end
+
+--- BUILD 14:04 (PB-07): Space and ">" advance the row pager, per the brief's
+--- "click/Space/>" acceptance. keyEvent walks children first via the superclass
+--- (GuiElement.lua:772-784, children in reverse order, eventUsed carried), so a focused
+--- control that consumes the key - including the pager Button itself activating on Space -
+--- wins before this fires and nothing double-steps. Only an unclaimed press reaches the
+--- step, and only a step that actually moved marks the event used; on every page without a
+--- pageable guest _rfFwPageStep returns false immediately and the key passes through
+--- untouched. unicode 32 is Space, 62 is ">", taken from the event's own unicode so the
+--- layout that produced ">" does not matter.
+function RfPdaMenuPage:keyEvent(unicode, sym, modifier, isDown, eventUsed)
+    local used = RfPdaMenuPage:superClass().keyEvent(self, unicode, sym, modifier, isDown, eventUsed)
+    if not used and isDown == true and (unicode == 32 or unicode == 62) then
+        used = self:_rfFwPageStep(1) == true
+    end
+    return used
+end
+
+--- BUILD 17:08 (Brian TEST 16:53, George TASK 17:03 GO): click shield for the module
+--- selector. Brian measured both selector arrows hover-highlighting but never advancing,
+--- with no Lua traceback. The engine split that allows exactly that: ButtonElement paints
+--- its hover state regardless of eventUsed (ButtonElement.lua:450-459) but fires its click
+--- only "if not eventUsed" (:469-491), and FocusManager highlight on the MTO is likewise
+--- move-driven (MultiTextOptionElement.lua:465-469). So hover-alive-click-dead means the
+--- CLICK half of the event is being consumed before the selector's walk position - George's
+--- hit-steal read. Event order in this engine is reverse declaration order with no z-index,
+--- and Sam's lock forbids moving any geometry, so the fix is delivery order, not layout:
+--- the page offers every click that lands inside the selector's rect to the selector FIRST,
+--- then runs the normal child walk with the event marked used, so whichever sibling was
+--- eating the click can still clear its own pressed state but can no longer act on it.
+--- Moves are NOT pre-offered - hover behavior is untouched, and a second visit of the MTO
+--- during the normal walk with eventUsed=true only re-computes identical press flags
+--- (:441-446, not eventUsed-gated), so nothing double-fires and no wrapper element is
+--- introduced. Clicks outside the selector rect take the walk exactly as before, so the
+--- module list, FW pager and every guest control keep their ownership.
+function RfPdaMenuPage:mouseEvent(posX, posY, isDown, isUp, button, eventUsed)
+    local used = eventUsed
+    local sel = self.rfPanelSelector
+    if not used and (isDown or isUp) and sel ~= nil
+        and sel.absPosition ~= nil and sel.absSize ~= nil
+        and type(sel.getIsActive) == "function" and sel:getIsActive()
+        and GuiUtils ~= nil and type(GuiUtils.checkOverlayOverlap) == "function"
+        and GuiUtils.checkOverlayOverlap(posX, posY,
+            sel.absPosition[1], sel.absPosition[2], sel.absSize[1], sel.absSize[2], nil) then
+        if sel:mouseEvent(posX, posY, isDown, isUp, button, false) then
+            used = true
+            if not self._selShieldLogged then
+                self._selShieldLogged = true
+                SoilLogger.info("RfPdaMenuPage: selector click shield delivered its first click")
+            end
+        end
+    end
+    return RfPdaMenuPage:superClass().mouseEvent(self, posX, posY, isDown, isUp, button, used) or used
+end
+
 function RfPdaMenuPage:_csPageSel()
     return self.csSubnavSelector
 end
@@ -2786,12 +3001,50 @@ function RfPdaMenuPage:_populateMdCommodityRow(index, cell)
         end
     end
     if nameEl then nameEl:setText(entry.title or "-") end
+    -- BUILD 09:19 (PB-02). This cell is the one Brian read as "£0" and "£1".
+    --
+    -- entry.price is the PER-LITRE engine number. formatMoney(price, 0, ...) rounded it to
+    -- whole currency units and printed no unit at all, so a live 0.00037/l commodity became
+    -- an actionable-looking "£0" and soybean at 0.85/l became "£1". Neither is a zero and
+    -- neither says what it is a price OF.
+    --
+    -- MDMPriceFormat is the single place that decides how a market price is written: the
+    -- x1000 display multiply for bulk goods, the forced two decimals built by hand (Vera F2:
+    -- neither formatMoney nor formatNumber forcePrecision actually pads .00), the locale
+    -- decimal mark, and the " / 1,000L" suffix that animal cargo does NOT get. The full
+    -- Market table and the Esc selected-crop line call the same helper, so all three
+    -- surfaces print one string and not three dialects of it.
+    --
+    -- The nil guard matters on this file specifically: this host is mirrored into all nine
+    -- doors and only the Market Dynamics zip ships MdPriceFormat.lua. On the other eight
+    -- doors MDMPriceFormat is nil UNLESS Market Dynamics is also loaded - and if it is not
+    -- loaded there is no Market page to paint anyway. The fallback keeps the old reading
+    -- instead of erroring.
+    --
+    -- BUILD 10:06, Vera FAIL F1. The bare global was doing less than that comment claimed.
+    -- It is nil not only when Market Dynamics is absent, but whenever Market Dynamics is not
+    -- the mod that WON the door race: FS25 gives every mod its own environment and this
+    -- mirrored file executes inside the host's, so on a Dairy-hosted or Income-hosted suite
+    -- the bare lookup misses a fully loaded MdPriceFormat.lua and the cell silently drops to
+    -- the formatMoney fallback - the exact "GBP 0" reading PB-02 was supposed to have fixed.
+    -- Same failure shape, same cause and same cure as MDMMarketScreenGraph on the Dairy door.
+    -- Resolved through mdResolve, which is that cure: bare first (free when Market Dynamics
+    -- hosts), then the named g_modEnvironments["FS25_MarketDynamics"] entry, then the
+    -- name-independent scan and the getfenv(0) / mission belts.
+    local priceFormat = (type(mdResolve) == "function")
+            and mdResolve(MDMPriceFormat, "MDMPriceFormat") or MDMPriceFormat
     local priceText = "-"
     if entry.price ~= nil then
-        if g_i18n and g_i18n.formatMoney then
-            priceText = g_i18n:formatMoney(entry.price, 0, true, true)
+        if priceFormat ~= nil and type(priceFormat.price) == "function" then
+            priceText = priceFormat.price(entry.fillTypeIndex, entry.price)
         else
-            priceText = string.format("%.0f", entry.price)
+            -- BUILD 14:04 (Vera FAIL on SUBMIT 10:16). The old branch here was
+            -- formatMoney(entry.price, 0, ...), which is the exact GBP 0 / GBP 1 reading
+            -- this cell has now shipped twice. George's constraint is verbatim "failed
+            -- probe degrades to 2dp path - never formatMoney(..., 0)", so the raw
+            -- per-litre number prints at two decimals or it does not print through
+            -- an engine rounder at all.
+            priceText = mdMoney2(entry.price)
         end
     end
     if priceEl then priceEl:setText(priceText) end

--- a/src/ui/RfPdaSoilPanel.lua
+++ b/src/ui/RfPdaSoilPanel.lua
@@ -391,11 +391,53 @@ function RfPdaSoilPanel.refreshRotationCard(page, entry)
         if sEl ~= nil and sEl.setVisible then sEl:setVisible(false) end
     end
 
-    --- Trim to fit the narrow What-if effect column (pic 1 feel).
+    --- BUILD 15:39 (PB-09). Fit the narrow What-if columns WITHOUT cutting a
+    --- word in half.
+    ---
+    --- This used to be a flat `s:sub(1, n - 3) .. "..."`, which is how a status
+    --- reached Brian as `burn t...`. Half a word plus three dots is not shorter
+    --- information, it is unreadable information, and DESIGN 15:00 §4 rules it
+    --- out: no mid-word clipping against a neighbour, and an ellipsis only once
+    --- the source is genuinely long.
+    ---
+    --- The order of preference is:
+    ---   1. It fits. Print it.
+    ---   2. It is a comma-joined list (the effect column is). Drop whole items
+    ---      from the end until what is left fits - you lose an item, not half a
+    ---      word, and every item still on screen is complete.
+    ---   3. Single long phrase. Cut at the last space that fits, so the last
+    ---      thing shown is a whole word.
+    ---   4. One unbroken token longer than the column. Only here is a hard cut
+    ---      unavoidable, and only then does the ellipsis appear.
+    local ELLIPSIS_FLOOR = 28   -- DESIGN 15:00 §4
     local function clip(s, n)
         s = tostring(s or "")
         if #s <= n then return s end
-        return s:sub(1, math.max(1, n - 3)) .. "..."
+
+        if string.find(s, ", ", 1, true) ~= nil then
+            local kept = nil
+            for part in string.gmatch(s, "([^,]+)") do
+                part = part:gsub("^%s+", ""):gsub("%s+$", "")
+                local try = (kept == nil) and part or (kept .. ", " .. part)
+                if #try <= n then kept = try else break end
+            end
+            if kept ~= nil then return kept end
+        end
+
+        local cut = string.sub(s, 1, n)
+        local sp  = string.find(string.reverse(cut), " ")
+        if sp ~= nil then
+            local wordEnd = n - sp
+            if wordEnd >= 3 then
+                return string.sub(cut, 1, wordEnd)
+            end
+        end
+
+        -- A single token wider than its column. Ellipsis only past the floor.
+        if #s >= ELLIPSIS_FLOOR then
+            return string.sub(s, 1, math.max(1, n - 3)) .. "..."
+        end
+        return cut
     end
 
     local function set(el, text)

--- a/src/ui/RfPdaSoilPanel.lua
+++ b/src/ui/RfPdaSoilPanel.lua
@@ -286,13 +286,57 @@ function RfPdaSoilPanel.populateFieldRow(page, index, cell)
     end
 end
 
+--- BUILD 09:19 (PB-05): what the two-line WHAT IF effect cell holds.
+--- 110px wide at 14px is roughly 22 glyphs a line against this card's own ~6px-per-glyph
+--- calibration at 17px, so two lines is ~44. See the XML note on soilRotationIf1Effect.
+local WHATIF_EFFECT_BUDGET = 44
+
 --- Paint the three What-if rows (crop / status / effect) from RotationPlannerData.
 --- Read-only projection only: pickCandidates + project + statusWord + effectText.
 --- Never invents a crop - a candidate with no projection prints honest dashes.
 local function paintWhatIfRows(page, entry, tr, clip)
     local rows = page.soilRotationIfRows
     local hdr  = page.soilRotationWhatIfHeader
-    if rows == nil then return end
+    -- BUILD 09:19 (PB-05). This used to be a bare `if rows == nil then return end`, and that
+    -- silence is the "WHAT IF row not showing" mechanism Brian hit: on a door whose XML lacks
+    -- the soilRotationIf* ids the whole section evaporated with no log line and no on-screen
+    -- trace, leaving the WHAT IF heading and its three column captions standing over nothing.
+    -- Sam's law for this card is that WHAT IF paints or is hidden for a visible reason, never
+    -- silently. So: warn once (the same shape as refreshRotationCard's thin-door guard right
+    -- below) and take the orphaned heading and captions down with it, so the card reads as a
+    -- card that does not have this section rather than as a section that failed to fill.
+    --
+    -- The nil TABLE is only half the thin-door shape and not the half that actually bites.
+    -- The host builds soilRotationIfRows unconditionally (RfPdaMenuPage:_resolveIds seeds it
+    -- to {} and then fills three entries), so on a door whose XML has no soilRotationIf* ids
+    -- the table is present and every crop/status/effect inside it is nil. The loop below then
+    -- ran to completion writing into nothing at all - which is the same invisible failure,
+    -- reached by a different route, and the one that survives a bare nil-table check. Treat a
+    -- first row with no resolved elements as the same absent-section case.
+    local rowsUsable = rows ~= nil and rows[1] ~= nil
+        and (rows[1].crop ~= nil or rows[1].status ~= nil or rows[1].effect ~= nil)
+    if not rowsUsable then
+        for _, el in ipairs({ hdr, page.soilRotationIfColCrop,
+                              page.soilRotationIfColStatus, page.soilRotationIfColEffect }) do
+            if el ~= nil then
+                if el.setText then el:setText("") end
+                if el.setVisible then el:setVisible(false) end
+            end
+        end
+        if not page._whatIfRowsWarned then
+            page._whatIfRowsWarned = true
+            -- Through the logger, not a raw print. The neighbouring rotation-card guard
+            -- still prints directly and the validator has always flagged it for that; this
+            -- one does not add a second DEBUG_CODE warning to the count.
+            local msg = "RfPdaSoilPanel: WHAT IF row ids absent on this door - section hidden (ROTATION glance unaffected)"
+            if SoilLogger ~= nil and type(SoilLogger.warning) == "function" then
+                SoilLogger.warning("%s", msg)
+            elseif Logging ~= nil and type(Logging.warning) == "function" then
+                Logging.warning("[RfEsc] %s", msg)
+            end
+        end
+        return
+    end
 
     local function setEl(el, s)
         if el ~= nil then
@@ -340,7 +384,15 @@ local function paintWhatIfRows(page, entry, tr, clip)
                 local eff = (type(rpd.effectText) == "function") and rpd.effectText(proj) or ""
                 setEl(r.crop,   clip(label, 16))
                 setEl(r.status, clip(word, 10))
-                setEl(r.effect, clip(eff, 18))
+                -- BUILD 09:19 (PB-05). Was clip(eff, 18) against a one-line 110px cell, which
+                -- dropped a whole consequence off the end of a comma-joined list: the player was
+                -- told the fatigue and not the disease. The cell is now two 14px lines (see
+                -- RF_ProductCellEffect), and effectText's output is a closed set whose longest
+                -- real string is "x1.15 depletion, +N, less disease" at 33 characters, so at
+                -- roughly 22 glyphs a line this budget is never actually reached by live data.
+                -- It stays as a fence for a translation longer than the English, and it drops
+                -- whole comma items rather than half a word when it does fire.
+                setEl(r.effect, clip(eff, WHATIF_EFFECT_BUDGET))
             end
         end
     end

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -9,7 +9,10 @@
 -- =========================================================
 ---@class SoilHUD
 
-SoilHUD = {}
+-- BUILD 17:57 + ATTN 18:02 (Wizard hot-reload law, FS25-HotReload-Guide.md Part 1):
+-- reuse the existing class table on Ctrl+R reload so updated methods land on the
+-- table live metatables already reference, instead of orphaning it.
+SoilHUD = SoilHUD or {}
 local SoilHUD_mt = Class(SoilHUD)
 
 -- ── Scale / resize ──────────────────────────────────────
@@ -18,7 +21,10 @@ SoilHUD.MAX_SCALE          = 1.80
 SoilHUD.RESIZE_HANDLE_SIZE = 0.008
 
 -- ── Base panel dimensions at scale 1.0 ─────────────────
-SoilHUD.BASE_W = 0.190
+-- BUILD 14:39 (Sam DESIGN 14:20): 0.190 -> 0.180. Every panel surface, column and
+-- text anchor in this file derives proportionally from BASE_W * scale, so the whole
+-- layout adapts to the narrower width - no absolute offsets to clip.
+SoilHUD.BASE_W = 0.180
 SoilHUD.BASE_H = 0.228   -- Default fallback height
 
 -- ── Layout constants at scale 1.0 ──────────────────────
@@ -468,6 +474,22 @@ function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
             return true
         end
         return false
+    end
+
+    -- BUILD 20:40 one-shot drag diagnostic (Brian 20:07: Soil orange, drag dead).
+    -- Every gate below this comment reads correct from source, so the first LMB
+    -- press in edit mode logs every gate's live value once - whichever one is
+    -- false live is the fault, and if all print true while drag still fails, the
+    -- press is dying UPSTREAM of this handler (listener order), which is engine
+    -- territory, not this file's.
+    if isDown and button == Input.MOUSE_BUTTON_LEFT and self.editMode and not self._dragDiagLogged then
+        self._dragDiagLogged = true
+        local px, py, pw, ph = self:getHUDRect()
+        SoilLogger.info(
+            "SoilHUD drag diag: enabled=%s showHUD=%s visible=%s over=%s click=%.3f,%.3f rect=%.3f,%.3f,%.3f,%.3f",
+            tostring(self.settings.enabled), tostring(self.settings.showHUD),
+            tostring(self.visible), tostring(self:isPointerOverHUD(posX, posY)),
+            posX, posY, px, py, pw, ph)
     end
 
     if not self.settings.enabled then return false end
@@ -2355,3 +2377,15 @@ end
 -- ── Pixel helpers ────────────────────────────────────────
 function SoilHUD:px(pixels) return pixels / 1920 end
 function SoilHUD:py(pixels) return pixels / 1080 end
+
+-- =========================================================
+-- BUILD 17:57 + ATTN 18:02 (hot-reload guide Part 2): force-patch the live
+-- instance after a Ctrl+R reload - mission.soilFertilityManager published in src/main.lua; holds .soilHUD.
+if g_currentMission ~= nil and g_currentMission.soilFertilityManager ~= nil and g_currentMission.soilFertilityManager.soilHUD ~= nil then
+    local inst = g_currentMission.soilFertilityManager.soilHUD
+    for k, v in pairs(SoilHUD) do
+        if type(v) == "function" then
+            inst[k] = v
+        end
+    end
+end

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -19,6 +19,14 @@ local SoilHUD_mt = Class(SoilHUD)
 SoilHUD.MIN_SCALE          = 0.60
 SoilHUD.MAX_SCALE          = 1.80
 SoilHUD.RESIZE_HANDLE_SIZE = 0.008
+-- Wizard 2026-08-21 width wave: left/right edge drag adjusts a width multiplier,
+-- independent of corner-scale (NPCFavor/Workplace pattern, suite-wide). Interior
+-- text anchors already derive proportionally from the panel width (see BASE_W
+-- note above), so the content stretches with the pane.
+SoilHUD.MIN_WIDTH_MULT = 0.7
+SoilHUD.MAX_WIDTH_MULT = 2.5
+SoilHUD.EDGE_BAND_W    = 0.008
+SoilHUD.EDGE_SENS      = 3.0
 
 -- ── Base panel dimensions at scale 1.0 ─────────────────
 -- BUILD 14:39 (Sam DESIGN 14:20): 0.190 -> 0.180. Every panel surface, column and
@@ -32,7 +40,9 @@ SoilHUD.TITLE_H   = 0.024   -- title accent bar height
 SoilHUD.ROW_H     = 0.022   -- nutrient row height
 SoilHUD.LINE_H    = 0.018   -- text-only row height
 SoilHUD.PAD       = 0.006   -- inner padding
-SoilHUD.BAR_H     = 0.010   -- nutrient bar fill height
+-- Six pixels at 1080p: the same bar height used by FillLevelsDisplay and the
+-- base-game feed-mixer HUD extension.
+SoilHUD.BAR_H     = 0.005556
 SoilHUD.BAR_W     = 0.095   -- nutrient bar width
 
 -- ── Colors ──────────────────────────────────────────────
@@ -58,6 +68,21 @@ SoilHUD.C_EDIT_HDL   = {0.20, 0.60, 1.00, 0.85}
 -- ── Field detection throttle ────────────────────────────
 SoilHUD.FIELD_DETECT_INTERVAL = 0.5   -- seconds between position queries
 
+-- MasterHUD owns the shared base-game chrome objects when it is installed.
+-- Every caller keeps its existing graph_pixel fallback so SoilFertilizer still
+-- works standalone, in line with the suite's delegate-when-present contract.
+function SoilHUD.getBaseGameRenderer()
+    local hud = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+    if hud ~= nil and hud.renderer ~= nil then
+        return hud.renderer
+    end
+    return nil
+end
+
+function SoilHUD.getSeparatorHeight()
+    return g_pixelSizeY or (1 / 1080)
+end
+
 function SoilHUD.new(soilSystem, settings)
     local self = setmetatable({}, SoilHUD_mt)
 
@@ -73,7 +98,7 @@ function SoilHUD.new(soilSystem, settings)
     self.lastHudPosition = nil
 
     -- Scale & edit state
-    self.scale            = 1.0
+    self.scale            = 1.140633   -- factory suite layout (Wizard 2026-08-21)
     self.editMode         = false
     self.dragging         = false
     self.resizing         = false
@@ -85,11 +110,22 @@ function SoilHUD.new(soilSystem, settings)
     self.hoverCorner      = nil
     self.animTimer        = 0
 
+    -- Width state (edge-drag, NPCFavor/Workplace pattern)
+    self.widthMult          = 0.909375   -- factory suite layout (Wizard 2026-08-21)
+    self.edgeDragging       = nil   -- nil | "left" | "right"
+    self.edgeDragStartX     = 0
+    self.edgeDragStartWidth = 1.0
+
     -- Sub-panel free positioning (independent mode)
-    self.freePos        = { varRate = {}, smartSensor = {} }
+    self.freePos        = { appRate = {}, varRate = {}, smartSensor = {} }
     self.draggingSubKey = nil   -- key into freePos while dragging a sub-panel
     self.subDragOffX    = 0
     self.subDragOffY    = 0
+    self.subDragMoved   = false
+    self.subDragStartX  = 0
+    self.subDragStartY  = 0
+    self.subDragHadPos  = false
+    self.appRateDrawRect = nil
 
     -- Loaded-from-disk collapsed states applied on first panel draw
     self.savedCollapsed = { varRate = false, smartSensor = false }
@@ -201,6 +237,7 @@ end
 function SoilHUD:enterEditMode()
     self.editMode = true
     self.dragging = false
+    self.subDragMoved = false
     self.movedInEditMode = false
     if g_inputBinding and g_inputBinding.setShowMouseCursor then
         g_inputBinding:setShowMouseCursor(true, true)
@@ -229,11 +266,17 @@ function SoilHUD:enterEditMode()
 end
 
 function SoilHUD:exitEditMode()
+    if self.draggingSubKey and not self.subDragMoved and not self.subDragHadPos then
+        self.freePos[self.draggingSubKey] = nil
+    end
     self.editMode       = false
     self.dragging       = false
     self.resizing       = false
+    self.edgeDragging   = nil
     self.hoverCorner    = nil
     self.draggingSubKey = nil
+    self.subDragMoved   = false
+    self.subDragHadPos  = false
     self.savedCamRotX, self.savedCamRotY, self.savedCamRotZ = nil, nil, nil
     self.savedVehicleCamRotX = nil
     self.savedVehicleCamRotY = nil
@@ -274,9 +317,17 @@ function SoilHUD:saveLayout()
         xml:setFloat("hudLayout.panelX",  self.panelX)
         xml:setFloat("hudLayout.panelY",  self.panelY)
         xml:setFloat("hudLayout.scale",   self.scale)
+        xml:setFloat("hudLayout.widthMult", self.widthMult or 1.0)
         xml:setBool("hudLayout.visible",  self.visible)
 
         -- Sub-panel free positions
+        do
+            local fp = self.freePos["appRate"]
+            if fp and fp.x ~= nil then
+                xml:setFloat("hudLayout.freePosX_appRate", fp.x)
+                xml:setFloat("hudLayout.freePosY_appRate", fp.y)
+            end
+        end
         do
             local fp = self.freePos["varRate"]
             if fp and fp.x ~= nil then
@@ -314,9 +365,16 @@ function SoilHUD:loadLayout()
         self.panelX  = xml:getFloat("hudLayout.panelX",  self.panelX)
         self.panelY  = xml:getFloat("hudLayout.panelY",  self.panelY)
         self.scale   = xml:getFloat("hudLayout.scale",   self.scale)
+        self.widthMult = math.max(SoilHUD.MIN_WIDTH_MULT, math.min(SoilHUD.MAX_WIDTH_MULT,
+            xml:getFloat("hudLayout.widthMult", self.widthMult or 1.0)))
         self.visible = xml:getBool("hudLayout.visible",  self.visible)
 
         -- Sub-panel free positions
+        do
+            local x = xml:getFloat("hudLayout.freePosX_appRate", nil)
+            local y = xml:getFloat("hudLayout.freePosY_appRate", nil)
+            if x ~= nil and y ~= nil then self.freePos["appRate"] = { x = x, y = y } end
+        end
         do
             local x = xml:getFloat("hudLayout.freePosX_varRate", nil)
             local y = xml:getFloat("hudLayout.freePosY_varRate", nil)
@@ -340,6 +398,48 @@ function SoilHUD:loadLayout()
 end
 
 -- ── Geometry helpers ─────────────────────────────────────
+function SoilHUD:getDetailRowCount(info)
+    if info == nil or info.simDisabled then return 0 end
+
+    local rows = 0
+    local mgr = g_SoilFertilityManager
+    if mgr and mgr.settings then
+        if mgr.settings.weedPressure
+            and ((info.weedPressure or 0) > 0 or info.herbicideActive) then rows = rows + 1 end
+        if mgr.settings.pestPressure
+            and ((info.pestPressure or 0) > 0 or info.insecticideActive) then rows = rows + 1 end
+        if mgr.settings.diseasePressure
+            and ((info.diseasePressure or 0) > 0 or info.fungicideActive) then rows = rows + 1 end
+        if self._cachedSprayer then
+            if (info.coverageFraction or 0) > 0 then rows = rows + 1 end
+            if (info.sessionCoverageFraction or 0) > 0 then rows = rows + 1 end
+        end
+        if mgr.settings.compactionEnabled and (info.compaction or 0) > 0 then
+            rows = rows + 1
+        end
+    end
+    if (info.amendBurnPenalty or 0) > 0 then rows = rows + 1 end
+    if (info.amendBurnPenalty or 0) <= 0 and info.amendBurnRisk == true then rows = rows + 1 end
+    if info.yieldEfficiency then rows = rows + 1 end
+    return rows
+end
+
+--- Leave the owning suite edit session when one exists; otherwise close the
+--- standalone Soil editor and its two independently positioned vehicle panels.
+function SoilHUD:exitOwningEditMode()
+    local masterHUD = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+    if masterHUD ~= nil and masterHUD.layoutEditMode
+        and masterHUD.setLayoutEditMode ~= nil then
+        masterHUD:setLayoutEditMode(false)
+        return
+    end
+
+    self:exitEditMode()
+    local sfm = g_SoilFertilityManager
+    if sfm and sfm.sprayerInfoPanel then sfm.sprayerInfoPanel:exitEditMode() end
+    if sfm and sfm.harvesterPanel   then sfm.harvesterPanel:exitEditMode()   end
+end
+
 function SoilHUD:calculateHeight()
     local h = SoilHUD.TITLE_H + SoilHUD.PAD
 
@@ -361,29 +461,11 @@ function SoilHUD:calculateHeight()
 
         h = h + SoilHUD.ROW_H   -- pH bar row
         h = h + SoilHUD.LINE_H  -- OM text row
-        h = h + SoilHUD.LINE_H  -- gap between OM row and divider (matches drawPanel extra subtract)
-        h = h + SoilHUD.PAD * 1.3
-        
-        local mgr = g_SoilFertilityManager
-        if mgr and mgr.settings then
-            if mgr.settings.weedPressure    and ((info.weedPressure    or 0) > 0 or info.herbicideActive)  then h = h + SoilHUD.LINE_H end
-            if mgr.settings.pestPressure    and ((info.pestPressure    or 0) > 0 or info.insecticideActive) then h = h + SoilHUD.LINE_H end
-            if mgr.settings.diseasePressure and ((info.diseasePressure or 0) > 0 or info.fungicideActive)   then h = h + SoilHUD.LINE_H end
-            if self._cachedSprayer then
-                -- Coverage can be two rows: daily coverage + per-pass (PASS). Reserve one
-                -- LINE_H per row that will actually draw, or the second row overlaps the row below.
-                local covLines = 0
-                if (info.coverageFraction or 0) > 0 then covLines = covLines + 1 end
-                if (info.sessionCoverageFraction or 0) > 0 then covLines = covLines + 1 end
-                h = h + SoilHUD.LINE_H * covLines
-            end
-            if mgr.settings.compactionEnabled and (info.compaction or 0) > 0 then h = h + SoilHUD.LINE_H end
-        end
-        if (info.amendBurnPenalty or 0) > 0 then h = h + SoilHUD.LINE_H end
-        -- Burn-risk row (#684) is mutually exclusive with the burn row above.
-        if (info.amendBurnPenalty or 0) <= 0 and info.amendBurnRisk == true then h = h + SoilHUD.LINE_H end
-        if info.yieldEfficiency then h = h + SoilHUD.LINE_H end
-        
+        local detailRows = self:getDetailRowCount(info)
+        -- One separator band before the hint is always present. A second band
+        -- below OM is needed only when detail rows actually sit between them.
+        if detailRows > 0 then h = h + SoilHUD.PAD * 1.3 end
+        h = h + SoilHUD.LINE_H * detailRows
         h = h + SoilHUD.PAD * 1.3
     else
         h = h + SoilHUD.LINE_H
@@ -396,10 +478,25 @@ function SoilHUD:calculateHeight()
     self.currentHeight = h
 end
 
+-- ONE width source; every consumer (rect, draw, clamp, hit tests) reads this so
+-- an edge-drag reshapes everything together.
+function SoilHUD:getW()
+    return SoilHUD.BASE_W * (self.widthMult or 1.0) * self.scale
+end
+
+-- Keep bounded gauges inside a width-resized panel while retaining the
+-- trailer-sized maximum at normal/wide layouts. labelOffset is the space from
+-- the content origin to the bar; rightReserve protects value/status text.
+function SoilHUD:getMetricBarWidth(panelWidth, scale, labelOffset, rightReserve)
+    local fixed = (SoilHUD.PAD * 2 + labelOffset + rightReserve) * scale
+    local available = panelWidth - fixed
+    return math.max(0.025 * scale, math.min(SoilHUD.BAR_W * scale, available))
+end
+
 function SoilHUD:getHUDRect()
     local s = self.scale
     local h = self.currentHeight or SoilHUD.BASE_H
-    return self.panelX, self.panelY, SoilHUD.BASE_W * s, h * s
+    return self.panelX, self.panelY, self:getW(), h * s
 end
 
 function SoilHUD:isPointerOverHUD(posX, posY)
@@ -429,10 +526,20 @@ function SoilHUD:hitTestCorner(posX, posY)
     return nil
 end
 
+function SoilHUD:hitTestEdge(posX, posY)
+    local band = SoilHUD.EDGE_BAND_W
+    local px, py, pw, ph = self:getHUDRect()
+    if posY >= py and posY <= py + ph then
+        if posX >= px - band / 2 and posX <= px + band / 2 then return "left" end
+        if posX >= px + pw - band / 2 and posX <= px + pw + band / 2 then return "right" end
+    end
+    return nil
+end
+
 function SoilHUD:clampPosition()
     local s = self.scale
     local h = self.currentHeight or SoilHUD.BASE_H
-    local pw, ph = SoilHUD.BASE_W * s, h * s
+    local pw, ph = self:getW(), h * s
     self.panelX = math.max(0.01, math.min(1.0 - pw - 0.01, self.panelX))
     self.panelY = math.max(0.01, math.min(0.98 - ph, self.panelY))
 end
@@ -467,10 +574,7 @@ function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
     -- receive their RMB events uninterrupted.
     if isDown and button == Input.MOUSE_BUTTON_RIGHT then
         if self.editMode then
-            self:exitEditMode()
-            local sfm = g_SoilFertilityManager
-            if sfm and sfm.sprayerInfoPanel then sfm.sprayerInfoPanel:exitEditMode() end
-            if sfm and sfm.harvesterPanel   then sfm.harvesterPanel:exitEditMode()   end
+            self:exitOwningEditMode()
             return true
         end
         return false
@@ -493,35 +597,49 @@ function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
     end
 
     if not self.settings.enabled then return false end
-    if not self.settings.showHUD then return false end
-    if not self.visible then return false end
+    if not self.settings.showHUD and not self.editMode then return false end
+    if not self.visible and not self.editMode then return false end
     if not self.editMode then return false end
+
+    -- Respect UI/input handlers that already claimed a new click. Ongoing Soil
+    -- drags still receive move/up events below, so a captured edit cannot get
+    -- stranded when another HUD reports the event as used.
+    if isDown and button == Input.MOUSE_BUTTON_LEFT and eventUsed then
+        return false
+    end
 
     -- LMB down: start drag or resize
     if isDown and button == Input.MOUSE_BUTTON_LEFT then
-        -- 1. Check Main Panel
-        local corner = self:hitTestCorner(posX, posY)
-        if corner then
-            self.resizing = true ; self.dragging = false
-            self.resizeStartX = posX ; self.resizeStartY = posY
-            self.resizeStartScale = self.scale
-            self.movedInEditMode = true
-            return true
-        end
-        if self:isPointerOverHUD(posX, posY) then
-            self.dragging = true ; self.resizing = false
-            self.dragOffsetX = posX - self.panelX
-            self.dragOffsetY = posY - self.panelY
-            self.movedInEditMode = true
-            return true
+        local sfm = g_SoilFertilityManager
+
+        -- These two panels render after SoilHUD and therefore sit above it.
+        -- The shared mouse listener dispatches SoilHUD first, so explicitly
+        -- yield clicks inside their cached edit rectangles; their own handlers
+        -- will claim the event later in the same dispatch.
+        if sfm then
+            local directPanels = { sfm.harvesterPanel, sfm.sprayerInfoPanel }
+            for _, panel in ipairs(directPanels) do
+                local px = panel and panel._lastPanelX
+                local py = panel and panel._lastPanelY
+                local pw = panel and panel._lastPanelW
+                local ph = panel and panel._lastPanelH
+                if panel and panel.editMode
+                    and type(px) == "number" and type(py) == "number"
+                    and type(pw) == "number" and type(ph) == "number"
+                    and posX >= px and posX <= px + pw
+                    and posY >= py and posY <= py + ph then
+                    return false
+                end
+            end
         end
 
-        -- 2. Check sub-panel collapse buttons (must be before drag so click doesn't start drag)
-        local sfm = g_SoilFertilityManager
+        -- Sub-panels render after the main monitor, so they own overlapping
+        -- pixels. Smart Sensor renders after Variable Rate and is tested first.
         if sfm then
             local subPanels = {
-                { panel = sfm.variableRatePanel, key = "varRate" },
                 { panel = sfm.smartSensorPanel,  key = "smartSensor" },
+                { panel = sfm.variableRatePanel, key = "varRate" },
+                { rect = self.appRateDrawRect,    key = "appRate" },
             }
             for _, sp in ipairs(subPanels) do
                 local p = sp.panel
@@ -531,20 +649,49 @@ function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
                     return true
                 end
             end
-            -- 4. Sub-panel drag (independent mode only)
-            if self.settings and self.settings.independentPanels then
-                for _, sp in ipairs(subPanels) do
-                    local p = sp.panel
-                    if p and self:hitRect(posX, posY, p.lastDrawRect) then
-                        self.draggingSubKey = sp.key
-                        local fp = self.freePos[sp.key] or {}
-                        self.subDragOffX = posX - (fp.x or posX)
-                        self.subDragOffY = posY - (fp.y or posY)
-                        self.movedInEditMode = true
-                        return true
-                    end
+            for _, sp in ipairs(subPanels) do
+                local p = sp.panel
+                local rect = sp.rect or (p and p.lastDrawRect)
+                if self:hitRect(posX, posY, rect) then
+                    self.draggingSubKey = sp.key
+                    self.subDragMoved = false
+                    local fp = self.freePos[sp.key]
+                    self.subDragHadPos = fp ~= nil and fp.x ~= nil and fp.y ~= nil
+                    self.subDragStartX = rect.x
+                    self.subDragStartY = rect.y
+                    self.subDragOffX = posX - rect.x
+                    self.subDragOffY = posY - rect.y
+                    return true
                 end
             end
+        end
+
+        -- Main panel: corner scale, edge width, then body move.
+        local corner = self:hitTestCorner(posX, posY)
+        if corner then
+            self.resizing = true ; self.dragging = false
+            self.edgeDragging = nil
+            self.resizeStartX = posX ; self.resizeStartY = posY
+            self.resizeStartScale = self.scale
+            self.movedInEditMode = true
+            return true
+        end
+        local edge = self:hitTestEdge(posX, posY)
+        if edge then
+            self.edgeDragging       = edge
+            self.dragging           = false
+            self.resizing           = false
+            self.edgeDragStartX     = posX
+            self.edgeDragStartWidth = self.widthMult or 1.0
+            self.movedInEditMode    = true
+            return true
+        end
+        if self:isPointerOverHUD(posX, posY) then
+            self.dragging = true ; self.resizing = false
+            self.dragOffsetX = posX - self.panelX
+            self.dragOffsetY = posY - self.panelY
+            self.movedInEditMode = true
+            return true
         end
         return false
     end
@@ -552,12 +699,20 @@ function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
     -- LMB up: release drag/resize
     if isUp and button == Input.MOUSE_BUTTON_LEFT then
         if self.draggingSubKey then
+            local moved = self.subDragMoved
+            local key = self.draggingSubKey
+            if not moved and not self.subDragHadPos then
+                self.freePos[key] = nil
+            end
             self.draggingSubKey = nil
-            self:saveLayout()
+            self.subDragMoved = false
+            self.subDragHadPos = false
+            if moved then self:saveLayout() end
             return true
         end
-        if self.dragging or self.resizing then
+        if self.dragging or self.resizing or self.edgeDragging then
             self.dragging = false ; self.resizing = false
+            self.edgeDragging = nil
             self:clampPosition()
             return true
         end
@@ -567,14 +722,44 @@ function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
     -- Mouse move
     if self.draggingSubKey then
         local fp = self.freePos[self.draggingSubKey]
-        if not fp then self.freePos[self.draggingSubKey] = {} ; fp = self.freePos[self.draggingSubKey] end
-        fp.x = posX - self.subDragOffX
-        fp.y = posY - self.subDragOffY
+        if not fp then
+            fp = { x = self.subDragStartX, y = self.subDragStartY }
+            self.freePos[self.draggingSubKey] = fp
+        elseif fp.x == nil or fp.y == nil then
+            fp.x = self.subDragStartX
+            fp.y = self.subDragStartY
+        end
+        local sfm = g_SoilFertilityManager
+        local panel = nil
+        if sfm and self.draggingSubKey == "varRate" then
+            panel = sfm.variableRatePanel
+        elseif sfm and self.draggingSubKey == "smartSensor" then
+            panel = sfm.smartSensorPanel
+        end
+        local rect = self.draggingSubKey == "appRate" and self.appRateDrawRect
+            or (panel and panel.lastDrawRect or nil)
+        local panelW = rect and rect.w or self:getW()
+        local panelH = rect and rect.h or 0
+        local nextX = math.max(0, math.min(1 - panelW, posX - self.subDragOffX))
+        local nextY = math.max(0, math.min(1 - panelH, posY - self.subDragOffY))
+        if not self.subDragMoved
+            and (math.abs(nextX - self.subDragStartX) > 0.00001
+                or math.abs(nextY - self.subDragStartY) > 0.00001) then
+            self.subDragMoved = true
+            if self.settings and not self.settings.independentPanels then
+                self.settings.independentPanels = true
+                if self.settings.save then self.settings:save() end
+            end
+        end
+        if self.subDragMoved then
+            fp.x = nextX
+            fp.y = nextY
+        end
         return true
     end
 
     if self.dragging then
-        local pw = SoilHUD.BASE_W * self.scale
+        local pw = self:getW()
         self.panelX = math.max(0.0, math.min(1.0 - pw, posX - self.dragOffsetX))
         self.panelY = math.max(0.05, math.min(0.95, posY - self.dragOffsetY))
         return true
@@ -588,6 +773,17 @@ function SoilHUD:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
         local delta = (currDist - startDist) * 2.5
         self.scale = math.max(SoilHUD.MIN_SCALE,
             math.min(SoilHUD.MAX_SCALE, self.resizeStartScale + delta))
+        self:clampPosition()
+        return true
+    end
+
+    -- Edge width drag: dx scaled by EDGE_SENS, left edge inverted so pulling
+    -- outward always widens (NPCFavor/Workplace pattern).
+    if self.edgeDragging then
+        local dx = posX - self.edgeDragStartX
+        if self.edgeDragging == "left" then dx = -dx end
+        self.widthMult = math.max(SoilHUD.MIN_WIDTH_MULT,
+            math.min(SoilHUD.MAX_WIDTH_MULT, self.edgeDragStartWidth + dx * SoilHUD.EDGE_SENS))
         self:clampPosition()
         return true
     end
@@ -649,10 +845,7 @@ function SoilHUD:update(dt)
             end
         end
         if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then
-            self:exitEditMode()
-            local sfm = g_SoilFertilityManager
-            if sfm and sfm.sprayerInfoPanel then sfm.sprayerInfoPanel:exitEditMode() end
-            if sfm and sfm.harvesterPanel   then sfm.harvesterPanel:exitEditMode()   end
+            self:exitOwningEditMode()
         end
         if not self.dragging and not self.resizing then
             if g_inputBinding and g_inputBinding.mousePosXLast then
@@ -1334,8 +1527,8 @@ end
 function SoilHUD:draw()
     if not self.initialized then return end
     if not self.settings.enabled then return end
-    if not self.settings.showHUD then return end
-    if not self.visible then return end
+    if not self.settings.showHUD and not self.editMode then return end
+    if not self.visible and not self.editMode then return end
     if not g_currentMission then return end
 
     if not self.editMode then
@@ -1362,7 +1555,7 @@ function SoilHUD:drawPanel()
     local s   = self.scale
     local px  = self.panelX
     local py  = self.panelY
-    local pw  = SoilHUD.BASE_W * s
+    local pw  = self:getW()
     local ph  = (self.currentHeight or SoilHUD.BASE_H) * s
 
     local alpha = SoilConstants.HUD.TRANSPARENCY_LEVELS[self.settings.hudTransparency or 3]
@@ -1376,22 +1569,21 @@ function SoilHUD:drawPanel()
     local bgG = 0.05 + theme.g * 0.04
     local bgB = 0.05 + theme.b * 0.04
 
-    -- Shadow
-    self:drawRect(px + 0.003*s, py - 0.003*s, pw, ph, SoilHUD.C_SHADOW)
-
-    -- Background (tinted by color theme, alpha set by transparency level)
-    self:drawRect(px, py, pw, ph, {bgR, bgG, bgB, 1}, alpha)
-
-    -- Title bar
     local titleH = SoilHUD.TITLE_H * s
-    self:drawRect(px, py + ph - titleH, pw, titleH, SoilHUD.C_TITLE_BG)
-
-    -- Permanent border
-    local bw = 0.001
-    self:drawRect(px,           py,            pw, bw, SoilHUD.C_BORDER)
-    self:drawRect(px,           py + ph - bw,   pw, bw, SoilHUD.C_BORDER)
-    self:drawRect(px,           py,            bw, ph, SoilHUD.C_BORDER)
-    self:drawRect(px + pw - bw,  py,            bw, ph, SoilHUD.C_BORDER)
+    local renderer = SoilHUD.getBaseGameRenderer()
+    local usedNativePanel = renderer ~= nil and renderer.renderPanel ~= nil
+        and renderer:renderPanel(px, py, pw, ph, alpha)
+    if not usedNativePanel then
+        -- Standalone fallback: retain the original custom panel.
+        self:drawRect(px + 0.003*s, py - 0.003*s, pw, ph, SoilHUD.C_SHADOW)
+        self:drawRect(px, py, pw, ph, {bgR, bgG, bgB, 1}, alpha)
+        self:drawRect(px, py + ph - titleH, pw, titleH, SoilHUD.C_TITLE_BG)
+        local bw = 0.001
+        self:drawRect(px,           py,            pw, bw, SoilHUD.C_BORDER)
+        self:drawRect(px,           py + ph - bw,   pw, bw, SoilHUD.C_BORDER)
+        self:drawRect(px,           py,            bw, ph, SoilHUD.C_BORDER)
+        self:drawRect(px + pw - bw, py,             bw, ph, SoilHUD.C_BORDER)
+    end
 
     -- Edit mode chrome
     if self.editMode then
@@ -1405,6 +1597,14 @@ function SoilHUD:drawPanel()
             local isHover = (self.hoverCorner == key)
             self:drawRect(r.x, r.y, r.w, r.h, SoilHUD.C_EDIT_HDL, isHover and 1.0 or 0.65)
         end
+
+        -- Left/right edge width handles (suite width vocabulary)
+        local ehW   = 0.004
+        local inset = ph * 0.15
+        self:drawRect(px - ehW / 2,      py + inset, ehW, ph - inset * 2,
+            SoilHUD.C_EDIT_HDL, self.edgeDragging == "left" and 1.0 or 0.65)
+        self:drawRect(px + pw - ehW / 2, py + inset, ehW, ph - inset * 2,
+            SoilHUD.C_EDIT_HDL, self.edgeDragging == "right" and 1.0 or 0.65)
     end
 
     -- ── Content ───────────────────────────────────────────
@@ -1455,7 +1655,7 @@ function SoilHUD:drawPanel()
         -- Asleep / disabled field (#692): one explanatory line in place of the soil metrics,
         -- bracketed by dividers so the compact panel still reads as a deliberate state.
         cy = cy - pad * 0.8
-        self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
+        self:drawRect(px + pad, cy, pw - pad*2, SoilHUD.getSeparatorHeight(), SoilHUD.C_DIVIDER)
         cy = cy - pad * 0.8
         cy = cy - SoilHUD.LINE_H * s
         setTextAlignment(RenderText.ALIGN_CENTER)
@@ -1464,7 +1664,7 @@ function SoilHUD:drawPanel()
             g_i18n:getText("sf_hud_asleep"))
         setTextAlignment(RenderText.ALIGN_LEFT)
         cy = cy - pad * 0.8
-        self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
+        self:drawRect(px + pad, cy, pw - pad*2, SoilHUD.getSeparatorHeight(), SoilHUD.C_DIVIDER)
         cy = cy - pad * 0.8
     end
 
@@ -1472,7 +1672,7 @@ function SoilHUD:drawPanel()
     -- so the user sees the unit context once, not repeated on every row.
     if not asleep then
         cy = cy - pad * 0.8
-        self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
+        self:drawRect(px + pad, cy, pw - pad*2, SoilHUD.getSeparatorHeight(), SoilHUD.C_DIVIDER)
         setTextAlignment(RenderText.ALIGN_RIGHT)
         setTextColor(SoilHUD.C_DIM[1], SoilHUD.C_DIM[2], SoilHUD.C_DIM[3], 0.60)
         renderText(px + pw - pad, cy + 0.001*s, 0.007 * fontMult * s, g_i18n:getText("sf_hud_unit_ppm"))
@@ -1494,7 +1694,7 @@ function SoilHUD:drawPanel()
 
         -- Divider
         cy = cy - pad * 0.5
-        self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
+        self:drawRect(px + pad, cy, pw - pad*2, SoilHUD.getSeparatorHeight(), SoilHUD.C_DIVIDER)
         cy = cy - pad * 0.8
 
         -- pH bar row (issue #438: center-anchored bar with ghost bar)
@@ -1510,11 +1710,15 @@ function SoilHUD:drawPanel()
         setTextColor(omCol[1], omCol[2], omCol[3], 1.0)
         renderText(omValX + 0.015*s, cy, 0.010 * fontMult * s, self._fmt_omStr or "")
 
-        -- Divider below pH/OM row
-        cy = cy - SoilHUD.LINE_H * s
-        cy = cy - pad * 0.5
-        self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
-        cy = cy - pad * 0.8
+        local hasDetailRows = self:getDetailRowCount(info) > 0
+        if hasDetailRows then
+            -- Divider below pH/OM only when another detail section follows.
+            -- With no details, the footer divider below is the single boundary
+            -- before the hint (avoids a doubled empty separator band).
+            cy = cy - pad * 0.5
+            self:drawRect(px + pad, cy, pw - pad*2, SoilHUD.getSeparatorHeight(), SoilHUD.C_DIVIDER)
+            cy = cy - pad * 0.8
+        end
 
         -- Weed / pest / disease pressure rows
         local mgr = g_SoilFertilityManager
@@ -1621,7 +1825,7 @@ function SoilHUD:drawPanel()
 
         -- Divider before hint
         cy = cy - pad * 0.5
-        self:drawRect(px + pad, cy, pw - pad*2, 0.0005, SoilHUD.C_DIVIDER)
+        self:drawRect(px + pad, cy, pw - pad*2, SoilHUD.getSeparatorHeight(), SoilHUD.C_DIVIDER)
         cy = cy - pad * 0.8
     elseif not info then
         cy = cy - SoilHUD.LINE_H * s * 4  -- skip nutrient rows space (no field; asleep draws its own line)
@@ -1650,7 +1854,7 @@ function SoilHUD:drawNutrientRow(label, baseLabel, nutrient, px, cy, pw, s, font
     local pad   = SoilHUD.PAD * s
     local rowH  = SoilHUD.ROW_H * s
     local barH  = SoilHUD.BAR_H * s
-    local barW  = SoilHUD.BAR_W * s
+    local barW  = self:getMetricBarWidth(pw, s, 0.015, 0.055)
     local tx    = px + pad
     local col   = self:statusColor(nutrient.status)
 
@@ -1677,19 +1881,16 @@ function SoilHUD:drawNutrientRow(label, baseLabel, nutrient, px, cy, pw, s, font
     setTextColor(SoilHUD.C_LABEL[1], SoilHUD.C_LABEL[2], SoilHUD.C_LABEL[3], SoilHUD.C_LABEL[4])
     renderText(tx, cy + (rowH - 0.010*s) * 0.5, 0.010 * fontMult * s, label)
 
-    -- Bar background + fill
+    -- Bar geometry. Rendering is deferred until the projected value has been
+    -- calculated so one native three-part bar can draw track, ghost and fill.
     local barX = tx + 0.015*s
     local barY = cy + (rowH - barH) * 0.5
-    self:drawRect(barX, barY, barW, barH, SoilHUD.C_BAR_BG)
-    
     local fill = math.max(0, math.min(1, nutrient.value / 100))
-    if fill > 0 then
-        self:drawRect(barX, barY, barW * fill, barH, displayCol)
-    end
 
     -- Projected "Ghost Bar" (V1.7 Realism Update)
     -- Shows the expected nutrient gain for the remainder of the current application pass.
     local projectedDelta = 0
+    local ghostFill = 0
     if profile and profile[label] and info and info.nutrientBuffer then
         local fillTypeIndex = fillType and fillType.index
         if fillTypeIndex then
@@ -1715,12 +1916,23 @@ function SoilHUD:drawNutrientRow(label, baseLabel, nutrient, px, cy, pw, s, font
                         SoilConstants.DIFFICULTY.REPLENISHMENT_MULTIPLIERS and
                         SoilConstants.DIFFICULTY.REPLENISHMENT_MULTIPLIERS[rrIdx] or 1.0
                     projectedDelta = profile[label] * (remaining / 1000) / (info.fieldArea or 1.0) * rrMult
-                    local ghostFill = math.min(1.0 - fill, projectedDelta / 100)
-                    if ghostFill > 0 then
-                        self:drawRect(barX + barW * fill, barY, barW * ghostFill, barH, displayCol, 0.35)
-                    end
+                    ghostFill = math.min(1.0 - fill, projectedDelta / 100)
                 end
             end
+        end
+    end
+
+    local renderer = SoilHUD.getBaseGameRenderer()
+    local usedNativeBar = renderer ~= nil and renderer.renderProgressBar ~= nil
+        and renderer:renderProgressBar(barX, barY, barW, barH, fill,
+            displayCol, fill + ghostFill, displayCol)
+    if not usedNativeBar then
+        self:drawRect(barX, barY, barW, barH, SoilHUD.C_BAR_BG)
+        if fill > 0 then
+            self:drawRect(barX, barY, barW * fill, barH, displayCol)
+        end
+        if ghostFill > 0 then
+            self:drawRect(barX + barW * fill, barY, barW * ghostFill, barH, displayCol, 0.35)
         end
     end
 
@@ -1792,7 +2004,7 @@ function SoilHUD:drawPHRow(info, px, cy, pw, s, fontMult, fillType)
     local pad  = SoilHUD.PAD * s
     local rowH = SoilHUD.ROW_H * s
     local barH = SoilHUD.BAR_H * s
-    local barW = SoilHUD.BAR_W * s
+    local barW = self:getMetricBarWidth(pw, s, 0.015, 0.055)
     local tx   = px + pad
 
     cy = cy - rowH
@@ -1813,12 +2025,16 @@ function SoilHUD:drawPHRow(info, px, cy, pw, s, fontMult, fillType)
 
     local pHCol = self:pHColor(pH)
 
-    -- Background
-    self:drawRect(barX, barY, barW, barH, SoilHUD.C_BAR_BG)
-
-    -- Left-fill: from left edge to current pH position
-    if phNorm > 0 then
-        self:drawRect(barX, barY, phNorm * barW, barH, pHCol)
+    -- Same rounded fill-level track as the N/P/K rows. Directional pH preview
+    -- remains a translucent overlay because it can move either left or right.
+    local renderer = SoilHUD.getBaseGameRenderer()
+    local usedNativeBar = renderer ~= nil and renderer.renderProgressBar ~= nil
+        and renderer:renderProgressBar(barX, barY, barW, barH, phNorm, pHCol)
+    if not usedNativeBar then
+        self:drawRect(barX, barY, barW, barH, SoilHUD.C_BAR_BG)
+        if phNorm > 0 then
+            self:drawRect(barX, barY, phNorm * barW, barH, pHCol)
+        end
     end
 
     -- Ghost bar: directional preview if a pH-modifying product is loaded
@@ -1870,7 +2086,7 @@ function SoilHUD:drawPressureRow(labelKey, pressure, isProtected, px, cy, pw, s,
     local pad      = SoilHUD.PAD * s
     local rowH     = SoilHUD.LINE_H * s
     local barH     = SoilHUD.BAR_H * s
-    local barW     = SoilHUD.BAR_W * s
+    local barW     = self:getMetricBarWidth(pw, s, 0.038, 0.035)
     local textSize = 0.010 * fontMult * s
     local tx       = px + pad
 
@@ -1903,10 +2119,15 @@ function SoilHUD:drawPressureRow(labelKey, pressure, isProtected, px, cy, pw, s,
     -- Bar - centred in row, horizontally aligned with nutrient bars
     local barX = tx + 0.038*s
     local barY = cy + (rowH - barH) * 0.5
-    self:drawRect(barX, barY, barW, barH, SoilHUD.C_BAR_BG)
     local fill = math.max(0, math.min(1, pressure / 100))
-    if fill > 0 then
-        self:drawRect(barX, barY, barW * fill, barH, col)
+    local renderer = SoilHUD.getBaseGameRenderer()
+    local usedNativeBar = renderer ~= nil and renderer.renderProgressBar ~= nil
+        and renderer:renderProgressBar(barX, barY, barW, barH, fill, col)
+    if not usedNativeBar then
+        self:drawRect(barX, barY, barW, barH, SoilHUD.C_BAR_BG)
+        if fill > 0 then
+            self:drawRect(barX, barY, barW * fill, barH, col)
+        end
     end
 
     -- Value + protection tag - left-aligned right after bar (matches N/P/K value position)
@@ -2093,53 +2314,91 @@ end
 
 
 function SoilHUD:drawSprayerRatePanel()
+    self.appRateDrawRect = nil
     local sprayer = self:getCurrentSprayer()
-    if sprayer == nil then return end
-
     local rm = g_SoilFertilityManager and g_SoilFertilityManager.sprayerRateManager
-    if rm == nil then return end
+    if not self.editMode and (sprayer == nil or rm == nil) then return end
 
     local s          = self.scale
     local steps      = SoilConstants.SPRAYER_RATE.STEPS
-    local _sprRoot2 = sprayer.rootVehicle
-    local _rateVehId2 = (_sprRoot2 and _sprRoot2 ~= sprayer) and (_sprRoot2.id or 0) or sprayer.id
-    local currentIdx = rm:getIndex(_rateVehId2)
+    local _sprRoot2  = sprayer and sprayer.rootVehicle or nil
+    local _rateVehId2 = sprayer
+        and (((_sprRoot2 and _sprRoot2 ~= sprayer) and (_sprRoot2.id or 0)) or sprayer.id)
+        or 0
+    local currentIdx = (sprayer and rm and rm:getIndex(_rateVehId2))
+        or SoilConstants.SPRAYER_RATE.DEFAULT_INDEX
+    currentIdx = math.max(1, math.min(#steps, currentIdx or 1))
     local fontMult   = SoilConstants.HUD.FONT_SIZE_MULTIPLIERS[self.settings.hudFontSize or 2]
-    local fillType   = self:getSprayerFillType(sprayer)
+    local fillType   = sprayer and self:getSprayerFillType(sprayer) or nil
     local rateConfig = self:getRateConfig(fillType)
-    local curMult    = steps[currentIdx]
+    local curMult    = steps[currentIdx] or 1.0
+    local burnGuaranteed = curMult >= SoilConstants.SPRAYER_RATE.BURN_GUARANTEED_THRESHOLD
+    local burnPossible = not burnGuaranteed
+        and curMult > SoilConstants.SPRAYER_RATE.BURN_RISK_THRESHOLD
 
     -- Panel geometry
-    local pw      = SoilHUD.BASE_W * s
+    local pw      = self:getW()
     local padV    = self:py(5)  * s
-    local barH    = self:py(4)  * s
+    local barH    = self:py(6)  * s
     local scrollH = self:py(22) * s
     local headerH = self:py(16) * s
-    local panelH  = padV + barH + padV + scrollH + padV + headerH
+    local warningH = (burnGuaranteed or burnPossible) and (self:py(16) * s) or 0
+    local panelH  = warningH + padV + barH + padV + scrollH + padV + headerH
     local gap     = self:py(6) * s
-    local panelX  = self.panelX
-    local panelY  = self.panelY - gap - panelH
+    local stackedX = self.panelX
+    local stackedY = self.panelY - gap - panelH
+    local independent = self.settings and self.settings.independentPanels == true
+    local panelX, panelY
+    if independent then
+        panelX, panelY = self:getFreePos("appRate", stackedX, stackedY)
+    else
+        panelX, panelY = stackedX, stackedY
+    end
+    panelX = math.max(0, math.min(1 - pw, panelX))
+    panelY = math.max(0, math.min(1 - panelH, panelY))
+    if independent then
+        local fp = self.freePos and self.freePos.appRate
+        if fp then fp.x, fp.y = panelX, panelY end
+    end
     local cx      = panelX + pw * 0.5
+    local contentY = panelY + warningH
+    self.appRateDrawRect = { x = panelX, y = panelY, w = pw, h = panelH }
 
-    -- Shadow + background + border (match main panel theme + transparency)
+    -- Base-game HUD-extension chrome, with the former panel retained as the
+    -- standalone fallback when MasterHUD is absent.
     local rTheme = SoilConstants.HUD.COLOR_THEMES[self.settings.hudColorTheme or 1]
     local rBgR = 0.05 + rTheme.r * 0.04
     local rBgG = 0.05 + rTheme.g * 0.04
     local rBgB = 0.05 + rTheme.b * 0.04
     local rAlpha = SoilConstants.HUD.TRANSPARENCY_LEVELS[self.settings.hudTransparency or 3]
-    self:drawRect(panelX + 0.002*s, panelY - 0.002*s, pw, panelH, SoilHUD.C_SHADOW)
-    self:drawRect(panelX, panelY, pw, panelH, {rBgR, rBgG, rBgB, 1}, rAlpha)
-    local bw = 0.001
-    self:drawRect(panelX,           panelY,               pw, bw, SoilHUD.C_BORDER)
-    self:drawRect(panelX,           panelY + panelH - bw,  pw, bw, SoilHUD.C_BORDER)
-    self:drawRect(panelX,           panelY,               bw, panelH, SoilHUD.C_BORDER)
-    self:drawRect(panelX + pw - bw,  panelY,               bw, panelH, SoilHUD.C_BORDER)
+    local renderer = SoilHUD.getBaseGameRenderer()
+    local usedNativePanel = renderer ~= nil and renderer.renderPanel ~= nil
+        and renderer:renderPanel(panelX, panelY, pw, panelH, rAlpha)
+    if not usedNativePanel then
+        self:drawRect(panelX + 0.002*s, panelY - 0.002*s, pw, panelH, SoilHUD.C_SHADOW)
+        self:drawRect(panelX, panelY, pw, panelH, {rBgR, rBgG, rBgB, 1}, rAlpha)
+        local bw = 0.001
+        self:drawRect(panelX,          panelY,              pw, bw, SoilHUD.C_BORDER)
+        self:drawRect(panelX,          panelY + panelH - bw, pw, bw, SoilHUD.C_BORDER)
+        self:drawRect(panelX,          panelY,              bw, panelH, SoilHUD.C_BORDER)
+        self:drawRect(panelX + pw - bw, panelY,             bw, panelH, SoilHUD.C_BORDER)
+    end
+
+    if self.editMode then
+        local pulse = 0.55 + 0.45 * math.sin((self.animTimer or 0) * 0.004)
+        local ebw = 0.0015
+        self:drawRect(panelX, panelY, pw, ebw, {1.0, 0.55, 0.10, pulse})
+        self:drawRect(panelX, panelY + panelH - ebw, pw, ebw, {1.0, 0.55, 0.10, pulse})
+        self:drawRect(panelX, panelY, ebw, panelH, {1.0, 0.55, 0.10, pulse})
+        self:drawRect(panelX + pw - ebw, panelY, ebw, panelH, {1.0, 0.55, 0.10, pulse})
+    end
 
     -- Header: "APP. RATE  AUTO: OFF [<key>]" or "APP. RATE  ( AUTO: ON )".
     -- The toggle key is read live from the input binding. SF_TOGGLE_AUTO ships
     -- unbound, so if the player has not bound it we show no key hint at all.
     -- isAuto = auto rate mode active on this vehicle AND the setting is enabled
-    local isAuto = rm:getAutoMode(_rateVehId2) and self.settings.autoRateControl
+    local isAuto = sprayer ~= nil and rm ~= nil
+        and rm:getAutoMode(_rateVehId2) and self.settings.autoRateControl
     local autoKey = ""   -- stays empty until a real bound key is found below
     if g_inputDisplayManager ~= nil then
         local ok, helpElement = pcall(function()
@@ -2179,15 +2438,15 @@ function SoilHUD:drawSprayerRatePanel()
     setTextBold(false)
 
     -- Rate scroll row base Y
-    local scrollY = panelY + padV + barH + padV
+    local scrollY = contentY + padV + barH + padV
 
     -- Current rate color (burn-aware or auto-aware)
     local curCol
     if isAuto then
         curCol = {0.4, 1.0, 0.4, 1.0}
-    elseif curMult >= SoilConstants.SPRAYER_RATE.BURN_GUARANTEED_THRESHOLD then
+    elseif burnGuaranteed then
         curCol = {1.0, 0.20, 0.20, 1.0}
-    elseif curMult > SoilConstants.SPRAYER_RATE.BURN_RISK_THRESHOLD then
+    elseif burnPossible then
         curCol = {0.95, 0.65, 0.10, 1.0}
     else
         curCol = {1.0, 1.0, 1.0, 1.0}
@@ -2255,10 +2514,14 @@ function SoilHUD:drawSprayerRatePanel()
     local progress = (currentIdx - 1) / (#steps - 1)
     local barPad   = pw * 0.06
     local barW     = pw - barPad * 2
-    local barY     = panelY + padV
-    self:drawRect(panelX + barPad, barY, barW, barH, SoilHUD.C_BAR_BG)
-    if progress > 0 then
-        self:drawRect(panelX + barPad, barY, barW * progress, barH, curCol)
+    local barY     = contentY + padV
+    local usedNativeBar = renderer ~= nil and renderer.renderProgressBar ~= nil
+        and renderer:renderProgressBar(panelX + barPad, barY, barW, barH, progress, curCol)
+    if not usedNativeBar then
+        self:drawRect(panelX + barPad, barY, barW, barH, SoilHUD.C_BAR_BG)
+        if progress > 0 then
+            self:drawRect(panelX + barPad, barY, barW * progress, barH, curCol)
+        end
     end
 
     -- Crop-optimal rate marker (cyan tick on the progress bar)
@@ -2274,15 +2537,17 @@ function SoilHUD:drawSprayerRatePanel()
         self:drawRect(tickX, tickY, tickW, tickH, {0.20, 0.85, 0.85, 1.0})
     end
 
-    -- Burn warning below panel
-    local warnY = panelY - self:py(14) * s
+    -- Burn warning occupies a reserved band inside the panel so a stacked HUD
+    -- below cannot cover it and the cached edit rectangle matches what is drawn.
+    local warnFontSize = 0.010 * fontMult * s
+    local warnY = panelY + math.max(self:py(1) * s, (warningH - warnFontSize) * 0.5)
     setTextAlignment(RenderText.ALIGN_CENTER)
-    if curMult >= SoilConstants.SPRAYER_RATE.BURN_GUARANTEED_THRESHOLD then
+    if burnGuaranteed then
         setTextColor(1.0, 0.15, 0.15, 1.0)
-        renderText(cx, warnY, 0.010 * fontMult * s, g_i18n:getText("sf_sprayer_burn_guaranteed"))
-    elseif curMult > SoilConstants.SPRAYER_RATE.BURN_RISK_THRESHOLD then
+        renderText(cx, warnY, warnFontSize, g_i18n:getText("sf_sprayer_burn_guaranteed"))
+    elseif burnPossible then
         setTextColor(0.95, 0.65, 0.10, 1.0)
-        renderText(cx, warnY, 0.010 * fontMult * s, g_i18n:getText("sf_sprayer_burn_possible"))
+        renderText(cx, warnY, warnFontSize, g_i18n:getText("sf_sprayer_burn_possible"))
     end
 
     setTextAlignment(RenderText.ALIGN_LEFT)
@@ -2388,4 +2653,18 @@ if g_currentMission ~= nil and g_currentMission.soilFertilityManager ~= nil and 
             inst[k] = v
         end
     end
+    -- Fields new in the width wave that a pre-wave live instance lacks.
+    if inst.widthMult == nil then inst.widthMult = 1.0 end
+    -- A reload can land between mouse-down and mouse-up. Cancel that transient
+    -- capture before installing the expanded sub-panel drag state so an old
+    -- in-flight drag cannot reach the new arithmetic with constructor-only nils.
+    inst.draggingSubKey = nil
+    inst.subDragMoved = false
+    inst.subDragStartX = inst.subDragStartX or 0
+    inst.subDragStartY = inst.subDragStartY or 0
+    inst.subDragHadPos = false
+    inst.freePos = inst.freePos or {}
+    inst.freePos.appRate = inst.freePos.appRate or {}
+    -- Delivery proof in log.txt (Wizard 2026-08-21).
+    print("[SoilFertilizer] SoilHUD hot-patched onto live instance")
 end

--- a/src/ui/SoilHarvesterPanel.lua
+++ b/src/ui/SoilHarvesterPanel.lua
@@ -15,14 +15,14 @@
 -- =========================================================
 
 ---@class SoilHarvesterPanel
-SoilHarvesterPanel = {}
+SoilHarvesterPanel = SoilHarvesterPanel or {}
 local SoilHarvesterPanel_mt = Class(SoilHarvesterPanel)
 
 -- ── Layout ────────────────────────────────────────────────
 SoilHarvesterPanel.PAD     = 0.006
 SoilHarvesterPanel.TITLE_H = 0.022
 SoilHarvesterPanel.ROW_H   = 0.022
-SoilHarvesterPanel.SEG_H   = 0.014   -- tank bar height
+SoilHarvesterPanel.SEG_H   = 0.005556 -- 6 px at 1080p, base fill-level height
 SoilHarvesterPanel.SEG_N   = 10      -- number of segments
 SoilHarvesterPanel.SEG_GAP = 0.0018  -- gap between segments
 SoilHarvesterPanel.PANEL_W = 0.210
@@ -120,6 +120,7 @@ function SoilHarvesterPanel:initialize()
 end
 
 function SoilHarvesterPanel:delete()
+    if self.editMode then self:exitEditMode() end
     if self.fillOverlay and self.fillOverlay ~= 0 then
         delete(self.fillOverlay)
         self.fillOverlay = nil
@@ -189,6 +190,10 @@ end
 function SoilHarvesterPanel:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
     if not self.editMode then return false end
 
+    if isDown and button == Input.MOUSE_BUTTON_LEFT and eventUsed then
+        return false
+    end
+
     local px = self._lastPanelX
     local py = self._lastPanelY
     local pw = self._lastPanelW
@@ -207,8 +212,8 @@ function SoilHarvesterPanel:onMouseEvent(posX, posY, isDown, isUp, button, event
 
     -- Mouse move: update position while dragging
     if self.dragging then
-        self.panelX = math.max(0, math.min(0.85, posX - self.dragOffsetX))
-        self.panelY = math.max(0.02, math.min(0.95, posY - self.dragOffsetY))
+        self.panelX = math.max(0, math.min(1 - pw, posX - self.dragOffsetX))
+        self.panelY = math.max(0, math.min(1 - ph, posY - self.dragOffsetY))
         return true
     end
 
@@ -219,7 +224,12 @@ function SoilHarvesterPanel:onMouseEvent(posX, posY, isDown, isUp, button, event
         local startDist = math.sqrt((self.resizeStartX - cx)^2 + (self.resizeStartY - cy)^2)
         local currDist  = math.sqrt((posX - cx)^2 + (posY - cy)^2)
         local delta = (currDist - startDist) * 2.5
-        self.userScale = math.max(0.5, math.min(2.5, self.resizeStartScale + delta))
+        local oldScale = self.userScale or 1.0
+        local newScale = math.max(0.5, math.min(2.5, self.resizeStartScale + delta))
+        local ratio = oldScale > 0 and newScale / oldScale or 1
+        self.userScale = newScale
+        self.panelX = math.max(0, math.min(1 - pw * ratio, self.panelX or px))
+        self.panelY = math.max(0, math.min(1 - ph * ratio, self.panelY or py))
         return true
     end
 
@@ -227,6 +237,8 @@ function SoilHarvesterPanel:onMouseEvent(posX, posY, isDown, isUp, button, event
     if isDown and button == Input.MOUSE_BUTTON_LEFT then
         if posX >= (px + pw - hs) and posX <= (px + pw) and
            posY >= py and posY <= (py + hs) then
+            self.panelX            = px
+            self.panelY            = py
             self.resizing         = true
             self.dragging         = false
             self.resizeStartX     = posX
@@ -236,6 +248,8 @@ function SoilHarvesterPanel:onMouseEvent(posX, posY, isDown, isUp, button, event
             return true
         end
         if posX >= px and posX <= px + pw and posY >= py and posY <= py + ph then
+            self.panelX         = px
+            self.panelY         = py
             self.dragging        = true
             self.dragOffsetX     = posX - px
             self.dragOffsetY     = posY - py
@@ -525,17 +539,23 @@ function SoilHarvesterPanel:drawTankBar(x, y, w, h, ratio, isWarning, pulse, gap
     gap = gap or SoilHarvesterPanel.SEG_GAP
     local segW   = (w - (N - 1) * gap) / N
     local filled = ratio * N
+    local renderer = SoilHUD and SoilHUD.getBaseGameRenderer and SoilHUD.getBaseGameRenderer() or nil
 
     for i = 0, N - 1 do
         local sx   = x + i * (segW + gap)
         local frac = math.max(0, math.min(1, filled - i))
-        -- Background
-        self:drawRect(sx, y, segW, h, SoilHarvesterPanel.C_SEG_BG)
-        -- Fill
-        if frac > 0 then
-            local col = isWarning and SoilHarvesterPanel.C_SEG_WARN or SoilHarvesterPanel.C_SEG_FILL
-            local alpha = isWarning and (0.6 + 0.4 * pulse) or 1.0
-            self:drawRect(sx, y, segW * frac, h, col, alpha)
+        local col = isWarning and SoilHarvesterPanel.C_SEG_WARN or SoilHarvesterPanel.C_SEG_FILL
+        local alpha = isWarning and (0.6 + 0.4 * pulse) or 1.0
+        local nativeColor = { col[1], col[2], col[3], alpha }
+        local usedNativeSegment = renderer ~= nil and renderer.renderProgressBar ~= nil
+            and renderer:renderProgressBar(sx, y, segW, h, frac, nativeColor)
+        if not usedNativeSegment then
+            -- Background
+            self:drawRect(sx, y, segW, h, SoilHarvesterPanel.C_SEG_BG)
+            -- Fill
+            if frac > 0 then
+                self:drawRect(sx, y, segW * frac, h, col, alpha)
+            end
         end
     end
 end
@@ -547,8 +567,11 @@ function SoilHarvesterPanel:draw()
     if not self.settings or not self.settings.enabled then return end
     if not g_currentMission or not g_currentMission.isRunning then return end
     local _sfm = g_SoilFertilityManager
-    if _sfm and _sfm.soilHUD and not _sfm.soilHUD.visible then return end
-    if _sfm and _sfm.settings and _sfm.settings.showHarvesterPanel == false then return end
+    if not self.editMode and _sfm and _sfm.soilHUD and not _sfm.soilHUD.visible then return end
+    -- Edit mode always exposes a placement placeholder, even when the runtime
+    -- display preference is off or no combine is currently controlled.
+    if not self.editMode and _sfm and _sfm.settings
+        and _sfm.settings.showHarvesterPanel == false then return end
     if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then
         if not self.editMode then return end
     end
@@ -568,8 +591,9 @@ function SoilHarvesterPanel:draw()
     local segH   = SoilHarvesterPanel.SEG_H   * sc
     local panelW = SoilHarvesterPanel.PANEL_W  * sc
 
-    -- Rows: tank bar + fill text + divider + yield  (+stats bar when active)
-    local numContentRows = isActive and 4 or 1
+    -- Rows: tank bar + fill text + yield (+ stats bar when active). The separator
+    -- sits on the fill/yield boundary instead of consuming an empty row.
+    local numContentRows = isActive and 3 or 1
     local statH  = isActive and (SoilHarvesterPanel.STAT_H * sc) or 0
     -- [SF-50] Reserve a thin band above the stats bar for the estimate's provenance
     -- caption. The panel is anchored bottom-left, so this grows it upward and leaves
@@ -598,14 +622,20 @@ function SoilHarvesterPanel:draw()
 
     -- ── Render ──────────────────────────────────────────────
 
-    -- Shadow
-    self:drawRect(panelX + 0.002*sc, panelBot - 0.002*sc, panelW, panelH, {0,0,0,1}, 0.22)
-    -- Background
-    self:drawRect(panelX, panelBot, panelW, panelH, SoilHarvesterPanel.C_BG)
-    -- Border
-    self:drawRect(panelX, panelBot, panelW, panelH, SoilHarvesterPanel.C_BORDER, 0.55)
-    -- Title bar
-    self:drawRect(panelX, panelTop - titleH, panelW, titleH, SoilHarvesterPanel.C_TITLE_BG)
+    local renderer = SoilHUD and SoilHUD.getBaseGameRenderer and SoilHUD.getBaseGameRenderer() or nil
+    local usedNativePanel = renderer ~= nil and renderer.renderPanel ~= nil
+        and renderer:renderPanel(panelX, panelBot, panelW, panelH,
+            SoilHarvesterPanel.C_BG[4] or 0.82)
+    if not usedNativePanel then
+        -- Shadow
+        self:drawRect(panelX + 0.002*sc, panelBot - 0.002*sc, panelW, panelH, {0,0,0,1}, 0.22)
+        -- Background
+        self:drawRect(panelX, panelBot, panelW, panelH, SoilHarvesterPanel.C_BG)
+        -- Border
+        self:drawRect(panelX, panelBot, panelW, panelH, SoilHarvesterPanel.C_BORDER, 0.55)
+        -- Title bar
+        self:drawRect(panelX, panelTop - titleH, panelW, titleH, SoilHarvesterPanel.C_TITLE_BG)
+    end
 
     -- Edit mode chrome: pulsing border + resize handle
     if self.editMode then
@@ -696,17 +726,11 @@ function SoilHarvesterPanel:draw()
         end
         cy = cy - rowH
 
-        -- ── Dashed divider ─────────────────────────────────
-        local divY = cy - rowH * 0.5
-        local dashW = 0.010 * sc
-        local dashH = 0.0012 * sc
-        local dashGap = 0.006 * sc
-        local numDash = math.floor((panelW - pad * 2) / (dashW + dashGap))
-        for i = 0, numDash - 1 do
-            self:drawRect(panelX + pad + i * (dashW + dashGap), divY, dashW, dashH,
-                          SoilHarvesterPanel.C_DIVIDER, 0.70)
-        end
-        cy = cy - rowH
+        -- Native-style one-pixel divider on the row boundary.
+        local dividerH = SoilHUD and SoilHUD.getSeparatorHeight
+            and SoilHUD.getSeparatorHeight() or (g_pixelSizeY or (1 / 1080))
+        self:drawRect(panelX + pad, cy - dividerH * 0.5,
+            panelW - pad * 2, dividerH, SoilHarvesterPanel.C_DIVIDER, 0.70)
 
         -- ── Row 4: Yield efficiency ────────────────────────
         local yieldRowBot = cy - rowH
@@ -735,18 +759,19 @@ function SoilHarvesterPanel:draw()
         -- ── Stats bar ──────────────────────────────────────────
         -- 4 cells: [wheat t/ha] [coverage %] [session ha] [total ha]
         local sbY = panelBot
-        local sbH = SoilHarvesterPanel.STAT_H
+        local sbH = statH
         local sbW = panelW
 
+        local dividerW = g_pixelSizeX or (1 / 1920)
         -- Dark separator line above stats bar
-        self:drawRect(panelX, sbY + sbH - 0.0015*sc, panelW, 0.0015*sc,
+        self:drawRect(panelX, sbY + sbH - dividerH, panelW, dividerH,
                       SoilHarvesterPanel.C_DIVIDER, 0.80)
 
         -- Faint cell dividers
         local cellW = sbW / 4
         for i = 1, 3 do
-            self:drawRect(panelX + cellW * i - 0.0008*sc, sbY + pad,
-                          0.0008*sc, sbH - pad * 2,
+            self:drawRect(panelX + cellW * i - dividerW * 0.5, sbY + pad,
+                          dividerW, sbH - pad * 2,
                           SoilHarvesterPanel.C_BORDER, 0.60)
         end
 
@@ -799,15 +824,13 @@ function SoilHarvesterPanel:draw()
         -- ── [SF-50] Provenance caption ────────────────────────
         -- The t/ha figure is estimated from the map's crop data, not measured from what
         -- the player actually took off the field. Say so plainly, in their language.
-        -- (sbH is unscaled here while the reserved band is scaled - a pre-existing
-        -- mismatch at userScale ~= 1; max() keeps the caption clear of the bar either way.)
         local capSz = 0.0062 * sc
         local okCap, capStr = pcall(function() return g_i18n:getText("sf_hud_yield_est_src") end)
         if okCap and capStr and not capStr:find("^%$l10n_") then
             setTextAlignment(RenderText.ALIGN_LEFT)
             setTextColor(unpack(C.C_DIM))
             renderText(panelX + pad,
-                       sbY + math.max(sbH, statH) + (estH - capSz) * 0.5,
+                       sbY + sbH + (estH - capSz) * 0.5,
                        capSz, capStr)
         end
 
@@ -874,4 +897,13 @@ function SoilHarvesterPanel:draw()
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextColor(1, 1, 1, 1)
     setTextBold(false)
+end
+
+-- Hot-reload: preserve the class table and patch the already-constructed panel.
+local sfm = g_SoilFertilityManager
+if sfm == nil and g_currentMission ~= nil then sfm = g_currentMission.soilFertilityManager end
+if sfm ~= nil and sfm.harvesterPanel ~= nil then
+    for k, v in pairs(SoilHarvesterPanel) do
+        if type(v) == "function" then sfm.harvesterPanel[k] = v end
+    end
 end

--- a/src/ui/SoilSmartSensorPanel.lua
+++ b/src/ui/SoilSmartSensorPanel.lua
@@ -22,7 +22,7 @@
 -- =========================================================
 
 ---@class SoilSmartSensorPanel
-SoilSmartSensorPanel = {}
+SoilSmartSensorPanel = SoilSmartSensorPanel or {}
 local SoilSmartSensorPanel_mt = Class(SoilSmartSensorPanel)
 
 -- Panel geometry at scale 1.0 (normalized screen space, Y=0 bottom)
@@ -166,15 +166,16 @@ function SoilSmartSensorPanel:draw()
 
     local sfm = g_SoilFertilityManager
     if not sfm or not sfm.sensorManager then return end
-    if sfm.settings and sfm.settings.smartSensorEnabled == false then return end
+
+    local hud = sfm.soilHUD
+    local inEditMode = hud and hud.editMode
+    if not inEditMode and sfm.settings
+        and sfm.settings.smartSensorEnabled == false then return end
 
     -- SF custom settings panel open → hide system panels
     if sfm.settingsPanel and sfm.settingsPanel.isVisible then return end
 
-    local hud = sfm.soilHUD
-    if hud and not hud.visible then return end
-    local inEditMode = hud and hud.editMode
-    local indMode    = sfm.settings and sfm.settings.independentPanels
+    if hud and not hud.visible and not inEditMode then return end
 
     if not inEditMode then
         if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then return end
@@ -185,8 +186,9 @@ function SoilSmartSensorPanel:draw()
 
     local sprayer = self:getActiveSprayer()
 
-    -- In edit+independent mode, draw frame for hit-testing even without a sprayer
-    if inEditMode and indMode then
+    -- The suite editor always exposes a placement frame, even without a matching
+    -- applicator. Moving it opts into the existing independent-panels setting.
+    if inEditMode then
         self:drawPanel(sprayer, sfm)
         return
     end
@@ -199,10 +201,9 @@ function SoilSmartSensorPanel:draw()
 end
 
 function SoilSmartSensorPanel:drawPanel(sprayer, sfm)
-    local indMode    = sfm.settings and sfm.settings.independentPanels
-
     local hud = sfm.soilHUD
     if not hud then return end
+    local indMode = sfm.settings and sfm.settings.independentPanels == true
 
     -- Apply saved collapsed state on first draw (loaded from hud.xml)
     if hud.savedCollapsed and hud.savedCollapsed.smartSensor ~= nil then
@@ -211,11 +212,12 @@ function SoilSmartSensorPanel:drawPanel(sprayer, sfm)
     end
 
     local s  = hud.scale or 1.0
-    local pw = SoilHUD and (SoilHUD.BASE_W * s) or (0.190 * s)
+    local pw = hud.getW and hud:getW()
+        or (SoilHUD and (SoilHUD.BASE_W * s) or (0.190 * s))
 
     -- Compute stacked position (used as freePos default on first enable)
     local padV    = (5  / 1080) * s
-    local barH    = (4  / 1080) * s
+    local barH    = (6  / 1080) * s
     local scrollH = (22 / 1080) * s
     local headerH = (16 / 1080) * s
     local ratePanelH = padV + barH + padV + scrollH + padV + headerH
@@ -238,7 +240,8 @@ function SoilSmartSensorPanel:drawPanel(sprayer, sfm)
     if vrPanel and vrPanel.lastDrawRect then
         baseY = vrPanel.lastDrawRect.y
     else
-        baseY = hud.panelY - gap - ratePanelH
+        baseY = hud.appRateDrawRect and hud.appRateDrawRect.y
+            or (hud.panelY - gap - ratePanelH)
     end
     local stackedY = baseY - SoilSmartSensorPanel.GAP * s - panelH
 
@@ -248,6 +251,11 @@ function SoilSmartSensorPanel:drawPanel(sprayer, sfm)
         panelX, panelY = hud:getFreePos("smartSensor", stackedX, stackedY)
     else
         panelX, panelY = stackedX, stackedY
+    end
+    panelX = math.max(0, math.min(1 - pw, panelX))
+    panelY = math.max(0, math.min(1 - panelH, panelY))
+    if indMode and hud.freePos and hud.freePos.smartSensor then
+        hud.freePos.smartSensor.x, hud.freePos.smartSensor.y = panelX, panelY
     end
 
     -- Store for stacking / hit-testing (read by panels below)
@@ -264,15 +272,20 @@ function SoilSmartSensorPanel:drawPanel(sprayer, sfm)
     local alpha = SoilConstants.HUD and SoilConstants.HUD.TRANSPARENCY_LEVELS
         and SoilConstants.HUD.TRANSPARENCY_LEVELS[self.settings.hudTransparency or 3] or 0.70
 
-    self:drawRect(panelX + 0.002*s, panelY - 0.002*s, pw, panelH, SoilSmartSensorPanel.C_SHADOW)
-    self:drawRect(panelX, panelY, pw, panelH, {bgR, bgG, bgB, 1}, alpha)
-    self:drawRect(panelX, panelY + panelH - titleH, pw, titleH, SoilSmartSensorPanel.C_TITLE_BG)
+    local renderer = SoilHUD and SoilHUD.getBaseGameRenderer and SoilHUD.getBaseGameRenderer() or nil
+    local usedNativePanel = renderer ~= nil and renderer.renderPanel ~= nil
+        and renderer:renderPanel(panelX, panelY, pw, panelH, alpha)
+    if not usedNativePanel then
+        self:drawRect(panelX + 0.002*s, panelY - 0.002*s, pw, panelH, SoilSmartSensorPanel.C_SHADOW)
+        self:drawRect(panelX, panelY, pw, panelH, {bgR, bgG, bgB, 1}, alpha)
+        self:drawRect(panelX, panelY + panelH - titleH, pw, titleH, SoilSmartSensorPanel.C_TITLE_BG)
 
-    local bw = 0.001
-    self:drawRect(panelX,          panelY,               pw, bw, SoilSmartSensorPanel.C_BORDER)
-    self:drawRect(panelX,          panelY + panelH - bw,  pw, bw, SoilSmartSensorPanel.C_BORDER)
-    self:drawRect(panelX,          panelY,               bw, panelH, SoilSmartSensorPanel.C_BORDER)
-    self:drawRect(panelX + pw - bw, panelY,              bw, panelH, SoilSmartSensorPanel.C_BORDER)
+        local bw = 0.001
+        self:drawRect(panelX,          panelY,               pw, bw, SoilSmartSensorPanel.C_BORDER)
+        self:drawRect(panelX,          panelY + panelH - bw,  pw, bw, SoilSmartSensorPanel.C_BORDER)
+        self:drawRect(panelX,          panelY,               bw, panelH, SoilSmartSensorPanel.C_BORDER)
+        self:drawRect(panelX + pw - bw, panelY,              bw, panelH, SoilSmartSensorPanel.C_BORDER)
+    end
 
     if hud.editMode then
         local pulse = 0.55 + 0.45 * math.sin((hud.animTimer or 0) * 0.004)
@@ -364,7 +377,10 @@ function SoilSmartSensorPanel:drawPanel(sprayer, sfm)
 
         -- Divider between rows
         if i < #rows then
-            self:drawRect(tx, rowY + (i - 1) * rowH + rowH - 0.0003, pw - pad*2, 0.0003, SoilSmartSensorPanel.C_DIVIDER)
+            local dividerH = SoilHUD and SoilHUD.getSeparatorHeight
+                and SoilHUD.getSeparatorHeight() or (g_pixelSizeY or (1 / 1080))
+            self:drawRect(tx, rowY + i * rowH - dividerH * 0.5, pw - pad*2, dividerH,
+                SoilSmartSensorPanel.C_DIVIDER)
         end
 
         -- Status dot
@@ -387,4 +403,13 @@ function SoilSmartSensorPanel:drawPanel(sprayer, sfm)
     setTextColor(1, 1, 1, 1)
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextBold(false)
+end
+
+-- Hot-reload: preserve the class table and patch the already-constructed panel.
+local sfm = g_SoilFertilityManager
+if sfm == nil and g_currentMission ~= nil then sfm = g_currentMission.soilFertilityManager end
+if sfm ~= nil and sfm.smartSensorPanel ~= nil then
+    for k, v in pairs(SoilSmartSensorPanel) do
+        if type(v) == "function" then sfm.smartSensorPanel[k] = v end
+    end
 end

--- a/src/ui/SoilSprayerInfoPanel.lua
+++ b/src/ui/SoilSprayerInfoPanel.lua
@@ -16,7 +16,7 @@
 -- =========================================================
 
 ---@class SoilSprayerInfoPanel
-SoilSprayerInfoPanel = {}
+SoilSprayerInfoPanel = SoilSprayerInfoPanel or {}
 local SoilSprayerInfoPanel_mt = Class(SoilSprayerInfoPanel)
 
 -- ── Layout constants ──────────────────────────────────────
@@ -24,7 +24,8 @@ SoilSprayerInfoPanel.GAP      = 0.003
 SoilSprayerInfoPanel.PAD      = 0.006
 SoilSprayerInfoPanel.TITLE_H  = 0.022
 SoilSprayerInfoPanel.ROW_H    = 0.022
-SoilSprayerInfoPanel.BAR_H    = 0.009
+-- Six pixels at 1080p, matching the base fill/work-width bars.
+SoilSprayerInfoPanel.BAR_H    = 0.005556
 SoilSprayerInfoPanel.FLAG_W   = 0.0018
 SoilSprayerInfoPanel.FLAG_CAP = 0.0030
 SoilSprayerInfoPanel.STAT_H   = 0.036
@@ -121,6 +122,7 @@ function SoilSprayerInfoPanel:initialize()
 end
 
 function SoilSprayerInfoPanel:delete()
+    if self.editMode then self:exitEditMode() end
     if self.fillOverlay and self.fillOverlay ~= 0 then
         delete(self.fillOverlay)
         self.fillOverlay = nil
@@ -192,6 +194,13 @@ end
 function SoilSprayerInfoPanel:onMouseEvent(posX, posY, isDown, isUp, button, eventUsed)
     if not self.editMode then return false end
 
+    -- Only claim a fresh click when it is still available. Move/up events for
+    -- an already captured drag continue below even if another listener marks
+    -- the shared event used.
+    if isDown and button == Input.MOUSE_BUTTON_LEFT and eventUsed then
+        return false
+    end
+
     local px = self._lastPanelX
     local py = self._lastPanelY
     local pw = self._lastPanelW
@@ -210,8 +219,8 @@ function SoilSprayerInfoPanel:onMouseEvent(posX, posY, isDown, isUp, button, eve
 
     -- Mouse move: update position while dragging
     if self.dragging then
-        self.panelX = math.max(0, math.min(0.85, posX - self.dragOffsetX))
-        self.panelY = math.max(0.02, math.min(0.95, posY - self.dragOffsetY))
+        self.panelX = math.max(0, math.min(1 - pw, posX - self.dragOffsetX))
+        self.panelY = math.max(0, math.min(1 - ph, posY - self.dragOffsetY))
         return true
     end
 
@@ -222,14 +231,39 @@ function SoilSprayerInfoPanel:onMouseEvent(posX, posY, isDown, isUp, button, eve
         local startDist = math.sqrt((self.resizeStartX - cx)^2 + (self.resizeStartY - cy)^2)
         local currDist  = math.sqrt((posX - cx)^2 + (posY - cy)^2)
         local delta = (currDist - startDist) * 2.5
-        self.userScale = math.max(0.5, math.min(2.5, self.resizeStartScale + delta))
+        local oldScale = self.userScale or 1.0
+        local newScale = math.max(0.5, math.min(2.5, self.resizeStartScale + delta))
+        local ratio = oldScale > 0 and newScale / oldScale or 1
+        self.userScale = newScale
+        self.panelX = math.max(0, math.min(1 - pw * ratio, self.panelX or px))
+        self.panelY = math.max(0, math.min(1 - ph * ratio, self.panelY or py))
         return true
     end
 
     -- LMB down: resize corner (bottom-right) takes priority over drag
     if isDown and button == Input.MOUSE_BUTTON_LEFT then
+        -- Harvester renders after this panel and is visually above it. Yield an
+        -- overlapping click so the later handler gets the topmost panel.
+        local sfm = g_SoilFertilityManager
+        local harvester = sfm and sfm.harvesterPanel
+        local hx = harvester and harvester._lastPanelX
+        local hy = harvester and harvester._lastPanelY
+        local hw = harvester and harvester._lastPanelW
+        local hh = harvester and harvester._lastPanelH
+        if harvester and harvester.editMode
+            and type(hx) == "number" and type(hy) == "number"
+            and type(hw) == "number" and type(hh) == "number"
+            and posX >= hx and posX <= hx + hw
+            and posY >= hy and posY <= hy + hh then
+            return false
+        end
+
         if posX >= (px + pw - hs) and posX <= (px + pw) and
            posY >= py and posY <= (py + hs) then
+            -- Freeze an auto-anchored panel at the exact preview position before
+            -- resizing so the saved layout cannot jump back to DEFAULT_X/Y.
+            self.panelX            = px
+            self.panelY            = py
             self.resizing         = true
             self.dragging         = false
             self.resizeStartX     = posX
@@ -239,6 +273,8 @@ function SoilSprayerInfoPanel:onMouseEvent(posX, posY, isDown, isUp, button, eve
             return true
         end
         if posX >= px and posX <= px + pw and posY >= py and posY <= py + ph then
+            self.panelX         = px
+            self.panelY         = py
             self.dragging        = true
             self.dragOffsetX     = posX - px
             self.dragOffsetY     = posY - py
@@ -269,6 +305,18 @@ end
 -- ── Sprayer helpers ───────────────────────────────────────
 
 function SoilSprayerInfoPanel:getActiveSprayer()
+    -- Reuse SoilHUD's recursive applicator resolver so this panel follows the
+    -- same equipment set as the application-rate HUD: self-propelled sprayers,
+    -- dry spreaders, slurry/manure applicators, lime tools, fertilising seeders
+    -- and cultivators, including implements nested behind another attachment.
+    local sfm = g_SoilFertilityManager
+    local hud = sfm and sfm.soilHUD
+    if hud and type(hud.getCurrentSprayer) == "function" then
+        local applicator = hud:getCurrentSprayer()
+        if applicator then return applicator end
+    end
+
+    -- Startup/fallback path retained for the short window before SoilHUD exists.
     local player = g_localPlayer
     if not player or type(player.getIsInVehicle) ~= "function" then return nil end
     if not player:getIsInVehicle() then return nil end
@@ -286,6 +334,18 @@ end
 
 function SoilSprayerInfoPanel:getSprayerFillType(sprayer)
     if not sprayer then return nil end
+
+    -- Keep fill-type resolution identical to the application-rate HUD. That
+    -- broader path understands custom slurry/manure/lime specifications as well
+    -- as ordinary spec_sprayer tools and nested implement tanks.
+    local sfm = g_SoilFertilityManager
+        or (g_currentMission and g_currentMission.soilFertilityManager or nil)
+    local hud = sfm and sfm.soilHUD
+    if hud and type(hud.getSprayerFillType) == "function" then
+        local fillType = hud:getSprayerFillType(sprayer)
+        if fillType then return fillType end
+    end
+
     local fillTypeIndex
     local spec = sprayer.spec_sprayer
     if spec and spec.workAreaParameters then
@@ -431,8 +491,12 @@ function SoilSprayerInfoPanel:draw()
     if not self.initialized then return end
     if not self.settings or not self.settings.enabled then return end
     if not g_currentMission or not g_currentMission.isRunning then return end
-    local sfm = g_SoilFertilityManager; if sfm and sfm.soilHUD and not sfm.soilHUD.visible then return end
-    if sfm and sfm.settings and sfm.settings.showSprayerInfoPanel == false then return end
+    local sfm = g_SoilFertilityManager
+    if not self.editMode and sfm and sfm.soilHUD and not sfm.soilHUD.visible then return end
+    -- Edit mode always exposes a placement placeholder, even when the runtime
+    -- display preference is off or no sprayer/spreader/slurry tool is active.
+    if not self.editMode and sfm and sfm.settings
+        and sfm.settings.showSprayerInfoPanel == false then return end
     if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then
         if not self.editMode then return end
     end
@@ -523,14 +587,20 @@ function SoilSprayerInfoPanel:draw()
 
     -- ── Render ──────────────────────────────────────────────
 
-    -- Shadow
-    self:drawRect(panelX + 0.002*sc, panelBot - 0.002*sc, panelW, panelH, {0, 0, 0, 1}, 0.22)
-    -- Background
-    self:drawRect(panelX, panelBot, panelW, panelH, SoilSprayerInfoPanel.C_BG)
-    -- Border
-    self:drawRect(panelX, panelBot, panelW, panelH, SoilSprayerInfoPanel.C_BORDER, 0.55)
-    -- Title bar
-    self:drawRect(panelX, panelTop - titleH, panelW, titleH, SoilSprayerInfoPanel.C_TITLE_BG)
+    local renderer = SoilHUD and SoilHUD.getBaseGameRenderer and SoilHUD.getBaseGameRenderer() or nil
+    local usedNativePanel = renderer ~= nil and renderer.renderPanel ~= nil
+        and renderer:renderPanel(panelX, panelBot, panelW, panelH,
+            SoilSprayerInfoPanel.C_BG[4] or 0.82)
+    if not usedNativePanel then
+        -- Shadow
+        self:drawRect(panelX + 0.002*sc, panelBot - 0.002*sc, panelW, panelH, {0, 0, 0, 1}, 0.22)
+        -- Background
+        self:drawRect(panelX, panelBot, panelW, panelH, SoilSprayerInfoPanel.C_BG)
+        -- Border
+        self:drawRect(panelX, panelBot, panelW, panelH, SoilSprayerInfoPanel.C_BORDER, 0.55)
+        -- Title bar
+        self:drawRect(panelX, panelTop - titleH, panelW, titleH, SoilSprayerInfoPanel.C_TITLE_BG)
+    end
 
     -- Edit mode chrome: pulsing border + resize handle
     if self.editMode then
@@ -616,13 +686,17 @@ function SoilSprayerInfoPanel:draw()
             setTextColor(unpack(SoilSprayerInfoPanel.C_LABEL))
             renderText(panelX + pad, rowBot + (rowH - lblSz) * 0.42, lblSz, nd.label)
 
-            -- Bar track
-            self:drawRect(barX, barMidY, barW, barH, SoilSprayerInfoPanel.C_BAR_BG)
-            -- Bar fill
             local fillRatio = math.max(0, math.min(rawVal / maxVal, 1))
             local barColor  = statusColor(pKey, rawVal)
-            if barW * fillRatio > 0 then
-                self:drawRect(barX, barMidY, barW * fillRatio, barH, barColor)
+            local usedNativeBar = renderer ~= nil and renderer.renderProgressBar ~= nil
+                and renderer:renderProgressBar(barX, barMidY, barW, barH, fillRatio, barColor)
+            if not usedNativeBar then
+                -- Bar track
+                self:drawRect(barX, barMidY, barW, barH, SoilSprayerInfoPanel.C_BAR_BG)
+                -- Bar fill
+                if barW * fillRatio > 0 then
+                    self:drawRect(barX, barMidY, barW * fillRatio, barH, barColor)
+                end
             end
             -- Finish flag at target threshold
             local tFrac = targetFraction(pKey, maxVal)
@@ -661,13 +735,16 @@ function SoilSprayerInfoPanel:draw()
         local statSz = sbH * 0.38
         local statFs = 0.0075 * sc
 
+        local dividerH = SoilHUD and SoilHUD.getSeparatorHeight
+            and SoilHUD.getSeparatorHeight() or (g_pixelSizeY or (1 / 1080))
+        local dividerW = g_pixelSizeX or (1 / 1920)
         -- Separator line
-        self:drawRect(panelX, sbY + sbH - 0.0015*sc, panelW, 0.0015*sc,
+        self:drawRect(panelX, sbY + sbH - dividerH, panelW, dividerH,
                       SoilSprayerInfoPanel.C_BORDER, 0.80)
         -- Cell dividers
         for i = 1, 3 do
-            self:drawRect(panelX + cellW * i - 0.0008*sc, sbY + pad,
-                          0.0008*sc, sbH - pad * 2,
+            self:drawRect(panelX + cellW * i - dividerW * 0.5, sbY + pad,
+                          dividerW, sbH - pad * 2,
                           SoilSprayerInfoPanel.C_BORDER, 0.60)
         end
 
@@ -686,7 +763,7 @@ function SoilSprayerInfoPanel:draw()
                     or (sessCov >= 0.40) and SoilSprayerInfoPanel.C_FAIR
                     or SoilSprayerInfoPanel.C_LABEL
         local mbW  = cellW * 0.72
-        local mbH  = 0.0045 * sc
+        local mbH  = (6 / 1080) * sc
         local mbX  = panelX + (cellW - mbW) * 0.5
         local mbY  = sbY + sbH * 0.62
         local mSeg = 4
@@ -695,10 +772,14 @@ function SoilSprayerInfoPanel:draw()
         local mFill = sessCov * mSeg
         for mi = 0, mSeg - 1 do
             local msx = mbX + mi * (mSW + mGap)
-            self:drawRect(msx, mbY, mSW, mbH, SoilSprayerInfoPanel.C_BAR_BG)
             local mfrac = math.max(0, math.min(1, mFill - mi))
-            if mfrac > 0 then
-                self:drawRect(msx, mbY, mSW * mfrac, mbH, covCol)
+            local usedNativeSegment = renderer ~= nil and renderer.renderProgressBar ~= nil
+                and renderer:renderProgressBar(msx, mbY, mSW, mbH, mfrac, covCol)
+            if not usedNativeSegment then
+                self:drawRect(msx, mbY, mSW, mbH, SoilSprayerInfoPanel.C_BAR_BG)
+                if mfrac > 0 then
+                    self:drawRect(msx, mbY, mSW * mfrac, mbH, covCol)
+                end
             end
         end
         -- Tiny caption above the mini bar so the % isn't mistaken for overall
@@ -758,4 +839,13 @@ function SoilSprayerInfoPanel:draw()
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextColor(1, 1, 1, 1)
     setTextBold(false)
+end
+
+-- Hot-reload: preserve the class table and patch the already-constructed panel.
+local sfm = g_SoilFertilityManager
+if sfm == nil and g_currentMission ~= nil then sfm = g_currentMission.soilFertilityManager end
+if sfm ~= nil and sfm.sprayerInfoPanel ~= nil then
+    for k, v in pairs(SoilSprayerInfoPanel) do
+        if type(v) == "function" then sfm.sprayerInfoPanel[k] = v end
+    end
 end

--- a/src/ui/SoilVariableRatePanel.lua
+++ b/src/ui/SoilVariableRatePanel.lua
@@ -15,10 +15,10 @@
 -- =========================================================
 
 ---@class SoilVariableRatePanel
-SoilVariableRatePanel = {}
+SoilVariableRatePanel = SoilVariableRatePanel or {}
 local SoilVariableRatePanel_mt = Class(SoilVariableRatePanel)
 
-SoilVariableRatePanel.BAR_H   = 0.030   -- height of the bar chart area
+SoilVariableRatePanel.BAR_H   = 0.030   -- height of the vertical rate chart area
 SoilVariableRatePanel.PAD     = 0.006
 SoilVariableRatePanel.TITLE_H = 0.022
 SoilVariableRatePanel.GAP     = 0.005
@@ -118,15 +118,16 @@ function SoilVariableRatePanel:draw()
 
     local sfm = g_SoilFertilityManager
     if not sfm or not sfm.sensorManager then return end
-    if sfm.settings and sfm.settings.variableRateEnabled == false then return end
+
+    local hud = sfm.soilHUD
+    local inEditMode = hud and hud.editMode
+    if not inEditMode and sfm.settings
+        and sfm.settings.variableRateEnabled == false then return end
 
     -- SF custom settings panel open → hide system panels
     if sfm.settingsPanel and sfm.settingsPanel.isVisible then return end
 
-    local hud = sfm.soilHUD
-    if hud and not hud.visible then return end
-    local inEditMode = hud and hud.editMode
-    local indMode    = sfm.settings and sfm.settings.independentPanels
+    if hud and not hud.visible and not inEditMode then return end
 
     if not inEditMode then
         if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then return end
@@ -137,8 +138,9 @@ function SoilVariableRatePanel:draw()
 
     local sprayer = self:getActiveSprayer()
 
-    -- In edit+independent mode, draw frame for hit-testing even without a sprayer
-    if inEditMode and indMode then
+    -- The suite editor always exposes a placement frame, even without a matching
+    -- applicator. Moving it opts into the existing independent-panels setting.
+    if inEditMode then
         self:drawPanel(sprayer, sfm)
         return
     end
@@ -152,10 +154,10 @@ end
 
 function SoilVariableRatePanel:drawPanel(sprayer, sfm)
     local sensorMgr = sfm.sensorManager
-    local indMode   = sfm.settings and sfm.settings.independentPanels
 
     local hud = sfm.soilHUD
     if not hud then return end
+    local indMode = sfm.settings and sfm.settings.independentPanels == true
 
     -- Apply saved collapsed state on first draw (loaded from hud.xml)
     if hud.savedCollapsed and hud.savedCollapsed.varRate ~= nil then
@@ -164,11 +166,12 @@ function SoilVariableRatePanel:drawPanel(sprayer, sfm)
     end
 
     local s  = hud.scale or 1.0
-    local pw = SoilHUD and (SoilHUD.BASE_W * s) or (0.190 * s)
+    local pw = hud.getW and hud:getW()
+        or (SoilHUD and (SoilHUD.BASE_W * s) or (0.190 * s))
 
     -- Rate panel geometry
     local padV    = (5  / 1080) * s
-    local barH_rp = (4  / 1080) * s
+    local barH_rp = (6  / 1080) * s
     local scrollH = (22 / 1080) * s
     local headerH = (16 / 1080) * s
     local ratePanelH = padV + barH_rp + padV + scrollH + padV + headerH
@@ -176,7 +179,8 @@ function SoilVariableRatePanel:drawPanel(sprayer, sfm)
 
     -- Stacked anchor: Variable Rate panel sits directly below the main HUD
     local mainPanelY = hud.panelY
-    local baseY      = mainPanelY - rateGap - ratePanelH
+    local baseY      = hud.appRateDrawRect and hud.appRateDrawRect.y
+        or (mainPanelY - rateGap - ratePanelH)
 
     local titleH     = SoilVariableRatePanel.TITLE_H * s
     local pad        = SoilVariableRatePanel.PAD     * s
@@ -198,6 +202,11 @@ function SoilVariableRatePanel:drawPanel(sprayer, sfm)
     else
         panelX, panelY = stackedX, stackedY
     end
+    panelX = math.max(0, math.min(1 - pw, panelX))
+    panelY = math.max(0, math.min(1 - panelH, panelY))
+    if indMode and hud.freePos and hud.freePos.varRate then
+        hud.freePos.varRate.x, hud.freePos.varRate.y = panelX, panelY
+    end
 
     self.lastPanelH   = panelH
     self.lastDrawRect = { x = panelX, y = panelY, w = pw, h = panelH }
@@ -212,15 +221,20 @@ function SoilVariableRatePanel:drawPanel(sprayer, sfm)
     local alpha = SoilConstants.HUD and SoilConstants.HUD.TRANSPARENCY_LEVELS
         and SoilConstants.HUD.TRANSPARENCY_LEVELS[self.settings.hudTransparency or 3] or 0.70
 
-    self:drawRect(panelX + 0.002*s, panelY - 0.002*s, pw, panelH, SoilVariableRatePanel.C_SHADOW)
-    self:drawRect(panelX, panelY, pw, panelH, {bgR, bgG, bgB, 1}, alpha)
-    self:drawRect(panelX, panelY + panelH - titleH, pw, titleH, SoilVariableRatePanel.C_TITLE_BG)
+    local renderer = SoilHUD and SoilHUD.getBaseGameRenderer and SoilHUD.getBaseGameRenderer() or nil
+    local usedNativePanel = renderer ~= nil and renderer.renderPanel ~= nil
+        and renderer:renderPanel(panelX, panelY, pw, panelH, alpha)
+    if not usedNativePanel then
+        self:drawRect(panelX + 0.002*s, panelY - 0.002*s, pw, panelH, SoilVariableRatePanel.C_SHADOW)
+        self:drawRect(panelX, panelY, pw, panelH, {bgR, bgG, bgB, 1}, alpha)
+        self:drawRect(panelX, panelY + panelH - titleH, pw, titleH, SoilVariableRatePanel.C_TITLE_BG)
 
-    local bw = 0.001
-    self:drawRect(panelX,         panelY,            pw, bw, SoilVariableRatePanel.C_BORDER)
-    self:drawRect(panelX,         panelY+panelH-bw,  pw, bw, SoilVariableRatePanel.C_BORDER)
-    self:drawRect(panelX,         panelY,            bw, panelH, SoilVariableRatePanel.C_BORDER)
-    self:drawRect(panelX+pw-bw,   panelY,            bw, panelH, SoilVariableRatePanel.C_BORDER)
+        local bw = 0.001
+        self:drawRect(panelX,         panelY,            pw, bw, SoilVariableRatePanel.C_BORDER)
+        self:drawRect(panelX,         panelY+panelH-bw,  pw, bw, SoilVariableRatePanel.C_BORDER)
+        self:drawRect(panelX,         panelY,            bw, panelH, SoilVariableRatePanel.C_BORDER)
+        self:drawRect(panelX+pw-bw,   panelY,            bw, panelH, SoilVariableRatePanel.C_BORDER)
+    end
 
     -- Edit mode pulse
     if hud.editMode then
@@ -331,7 +345,8 @@ function SoilVariableRatePanel:drawPanel(sprayer, sfm)
     local barGap    = math.max(0, math.min(0.002, totalBarW / n * 0.06))
     local singleW   = (totalBarW - barGap * (n - 1)) / n
 
-    -- Bar background track
+    -- This is a vertical rate chart, not a bounded horizontal gauge. Keep its
+    -- orientation while the surrounding panel adopts base-game chrome.
     self:drawRect(tx, barAreaY, totalBarW, barsH, SoilVariableRatePanel.C_BAR_BG)
 
     local vrCfg   = SoilConstants.VARIABLE_RATE
@@ -363,4 +378,13 @@ function SoilVariableRatePanel:drawPanel(sprayer, sfm)
     setTextColor(1, 1, 1, 1)
     setTextAlignment(RenderText.ALIGN_LEFT)
     setTextBold(false)
+end
+
+-- Hot-reload: preserve the class table and patch the already-constructed panel.
+local sfm = g_SoilFertilityManager
+if sfm == nil and g_currentMission ~= nil then sfm = g_currentMission.soilFertilityManager end
+if sfm ~= nil and sfm.variableRatePanel ~= nil then
+    for k, v in pairs(SoilVariableRatePanel) do
+        if type(v) == "function" then sfm.variableRatePanel[k] = v end
+    end
 end

--- a/translations/fix_pb15_dashes.py
+++ b/translations/fix_pb15_dashes.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""BUILD 15:39 / PB-15 - ASCII-safe punctuation in the shipped l10n.
+
+Brian's 15:50 retest found the Soil Field Guide Overview rendering mojibake
+after the pH figure, with the live log reporting:
+
+    Warning: Character '9500' not found in texture font
+
+9500 decimal is U+251C, a box-drawing glyph the FS25 texture font has no outline
+for. It is not a stray character: it is the first byte of a MULTI-CHARACTER
+mis-decode. The pH range ships as
+
+    6.5 <U+251C U+00F3 U+00D4 U+00E9 U+00BC U+00D4 U+00C7 U+00A3> 7.0
+
+which is an en dash that went through cp850 twice. Replacing only the U+251C
+would leave the other seven characters behind, so the whole run has to be
+recognised as a unit.
+
+HOW A RUN IS IDENTIFIED, rather than guessed. Each maximal non-ASCII run is put
+back through `run.encode(codec).decode("utf-8")` for cp850 then cp1252, up to
+three passes. That round trip only SUCCEEDS on genuine mojibake - a real
+accented letter is a single byte in cp850 and is not valid UTF-8 on its own, so
+it raises and is left alone. The decoded result is then checked against a list
+of punctuation the texture font cannot be relied on to carry, and only a run
+that resolves to one of those is rewritten, as ASCII.
+
+WHY THE LETTERS ARE IN SCOPE TOO. The first cut of this fix touched only the
+dash and left the ~700 other mojibake runs alone, most of them German umlauts
+(`<U+251C U+255D>` is a mangled u-umlaut). That was wrong on its own terms: the
+warning Brian reported names U+251C, and U+251C is the FIRST character of every
+one of those runs. Fixing the dash alone would have left the log line firing in
+700 places and German still unreadable. A run that resolves to a letter gets its
+correct character back; only the runs that resolve to unrenderable punctuation
+become ASCII.
+
+THE HASH. These files use `<e k="key" v="value" eh="hash" />`, where `eh` is
+md5(unescaped English value)[:8]; lang_sync.py compares each language's `eh`
+against English to decide staleness. The English entry's hash is recomputed from
+its new value, and a translated entry inherits the new hash ONLY if it currently
+carries the OLD English hash, i.e. it was in sync before this ran. An entry that
+was already stale keeps its old hash and stays stale.
+
+Files are decoded utf-8-sig and written back as plain UTF-8 with no BOM.
+"""
+
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SOURCE = HERE / "translation_en.xml"
+
+# Characters outside Latin-1 that the FS25 texture font cannot be relied on to
+# carry, and the safe glyph each becomes. Dashes are the family PB-15 names; the
+# subscripts come from chemical notation in the same string set and are the same
+# class of risk. U+2205 (empty set) is the German average symbol and maps to
+# U+00D8, which carries the same meaning inside Latin-1.
+UNSAFE_PUNCT = {
+    "‐": "-", "‑": "-", "‒": "-", "–": "-",
+    "—": "-", "―": "-", "−": "-", "─": "-",
+    "├": "-",
+    "₂": "2", "₅": "5",
+    "∅": "Ø",
+}
+
+# A repair is only accepted when EVERY character it produces is one we can
+# vouch for: printable ASCII, Latin-1 (the range a shipped language like German
+# already proves the font carries), or one of the mapped glyphs above.
+#
+# This guard is not theoretical. Turkish `ıç` - real text, dotless i
+# followed by c-cedilla - happens to round-trip through cp1252 into an Armenian
+# capital letter. Without the whitelist the sweep would "repair" valid Turkish
+# into nonsense in five places.
+def is_vouched(s):
+    for c in s:
+        o = ord(c)
+        if 0x20 <= o <= 0x7E:
+            continue
+        if 0xA0 <= o <= 0xFF:
+            continue
+        if c in UNSAFE_PUNCT:
+            continue
+        return False
+    return True
+
+# `\s+` between the attributes, not a single space: this file pads some entries
+# into columns (`<e k="input_SF_SENSOR_PEST"       v="..." />`) and a one-space
+# pattern skipped 20 of them, which is how a first pass left 32 U+251C behind in
+# German. The leading group captures the original spacing so it is preserved.
+ENTRY = re.compile(r'(<e k="([^"]+)"\s+v=")([^"]*)(")([^>]*?)(\s*/>)')
+NON_ASCII_RUN = re.compile(r"[^\x00-\x7f]+")
+
+# CJK / Japanese / Korean blocks. A dash inside a CJK sentence is that script's
+# own punctuation, not a mis-decode: Simplified Chinese writes a double em dash
+# as an ordinary connector, and translation_cs.xml does exactly that. The font
+# demonstrably carries CJK, since Chinese, Japanese and Korean all ship. Those
+# values are skipped entirely rather than ASCII-ified into nonsense.
+CJK = re.compile(r"[　-〿぀-ヿ㐀-䶿一-鿿"
+                 r"가-힯＀-￯]")
+
+
+def is_cjk_value(value):
+    return CJK.search(value) is not None
+
+
+def read(path):
+    return path.read_bytes().decode("utf-8-sig")
+
+
+def write(path, text):
+    path.write_bytes(text.encode("utf-8"))
+
+
+def unescape(s):
+    return (s.replace("&amp;", "&").replace("&lt;", "<")
+             .replace("&gt;", ">").replace("&quot;", '"'))
+
+
+def get_hash(text):
+    return hashlib.md5(text.encode("utf-8")).hexdigest()[:8]
+
+
+def demojibake(run, max_passes=3):
+    """Best-effort reverse of a cp850/cp1252 mis-decode. Returns the decoded
+    string, or None when the run is not mojibake at all."""
+    cur = run
+    decoded = None
+    for _ in range(max_passes):
+        nxt = None
+        for codec in ("cp850", "cp1252"):
+            try:
+                cand = cur.encode(codec).decode("utf-8")
+            except (UnicodeEncodeError, UnicodeDecodeError):
+                continue
+            if cand != cur:
+                nxt = cand
+                break
+        if nxt is None:
+            break
+        cur = nxt
+        decoded = cur
+    return decoded
+
+
+def clean_value(value, stats):
+    """Rewrite only the runs that resolve to unrenderable punctuation."""
+    if is_cjk_value(value):
+        stats["cjk_skipped"] += 1
+        return value
+
+    def repl(m):
+        run = m.group(0)
+
+        # Already-clean but unrenderable punctuation, e.g. a plain en dash.
+        if all(c in UNSAFE_PUNCT for c in run):
+            stats["direct"] += len(run)
+            return "".join(UNSAFE_PUNCT[c] for c in run)
+
+        decoded = demojibake(run)
+        if decoded is None or not decoded:
+            return run                      # not mojibake: real accented text
+
+        if not is_vouched(decoded):
+            # Round-tripped into something we cannot vouch for. Almost certainly
+            # a false positive on real text. Leave it and count it.
+            stats["rejected"] += 1
+            return run
+
+        out = "".join(UNSAFE_PUNCT.get(c, c) for c in decoded)
+        if all(c in UNSAFE_PUNCT for c in decoded):
+            stats["mojibake"] += 1
+        else:
+            stats["letters_fixed"] += 1
+        return out
+
+    return NON_ASCII_RUN.sub(repl, value)
+
+
+def main():
+    files = sorted(HERE.glob("translation_*.xml"))
+    if not files or not SOURCE.exists():
+        print("translation files not found")
+        return 1
+
+    stats = {"direct": 0, "mojibake": 0, "letters_fixed": 0, "rejected": 0, "cjk_skipped": 0}
+    remap = {}
+
+    # ---- pass 1: English. Clean values, recompute eh, remember old -> new ----
+    src = read(SOURCE)
+
+    def en_sub(m):
+        head, key, val, q, attrs, tail = m.groups()
+        new_val = clean_value(val, stats)
+        if new_val == val:
+            return m.group(0)
+        old_m = re.search(r'eh="([^"]*)"', attrs)
+        old_hash = old_m.group(1) if old_m else None
+        new_hash = get_hash(unescape(new_val))
+        remap[key] = (old_hash, new_hash)
+        if old_m:
+            attrs = attrs.replace('eh="%s"' % old_hash, 'eh="%s"' % new_hash)
+        else:
+            attrs = attrs + ' eh="%s"' % new_hash
+        return head + new_val + q + attrs + tail
+
+    new_src = ENTRY.sub(en_sub, src)
+    if new_src != src:
+        write(SOURCE, new_src)
+    print("%-30s%d entr(ies) rewritten" % ("translation_en.xml", len(remap)))
+
+    # ---- pass 2: the other languages ----
+    inherited = 0
+    for path in files:
+        if path == SOURCE:
+            continue
+        body = read(path)
+        took = [0]
+
+        def sub(m):
+            head, key, val, q, attrs, tail = m.groups()
+            new_val = clean_value(val, stats)
+            changed_attrs = attrs
+            if key in remap:
+                old_hash, new_hash = remap[key]
+                cur = re.search(r'eh="([^"]*)"', attrs)
+                if cur is not None and old_hash is not None and cur.group(1) == old_hash:
+                    changed_attrs = attrs.replace('eh="%s"' % old_hash, 'eh="%s"' % new_hash)
+                    took[0] += 1
+            if new_val == val and changed_attrs == attrs:
+                return m.group(0)
+            return head + new_val + q + changed_attrs + tail
+
+        new_body = ENTRY.sub(sub, body)
+        if new_body != body:
+            write(path, new_body)
+        inherited += took[0]
+
+    print("\nrepair summary:")
+    print("  %4d already-clean unrenderable character(s) -> safe glyph" % stats["direct"])
+    print("  %4d mojibake run(s) that resolved to punctuation -> ASCII" % stats["mojibake"])
+    print("  %4d mojibake run(s) that resolved to letters -> correct character"
+          % stats["letters_fixed"])
+    print("  %4d run(s) rejected by the whitelist and left untouched" % stats["rejected"])
+    print("  %4d CJK value(s) skipped entirely (own punctuation)" % stats["cjk_skipped"])
+    print("  %4d translated entr(ies) kept in sync with English" % inherited)
+
+    # ---- verify ----
+    bad = []
+    for path in files:
+        for m in ENTRY.finditer(read(path)):
+            if is_cjk_value(m.group(3)):
+                continue
+            for c in UNSAFE_PUNCT:
+                if c in m.group(3):
+                    bad.append("%s: U+%04X in %s" % (path.name, ord(c), m.group(2)))
+    if bad:
+        print("\nVERIFY FAILED - unrenderable punctuation remains:")
+        for b in sorted(set(bad))[:20]:
+            print("  " + b)
+        return 1
+
+    m = re.search(r'<e k="sf_guide_p1_11" v="([^"]*)"', read(SOURCE))
+    if m is None or not m.group(1).isascii():
+        print("\nVERIFY FAILED: sf_guide_p1_11 is missing or still non-ASCII")
+        return 1
+
+    # Every English entry this script rewrote must carry a matching eh. Four
+    # entries in the repo were already self-inconsistent before this ran
+    # (rf_pda_fert_in_need and three rf_pda_side_info_* keys); they are not
+    # touched here and are not this script's to silently certify, so the check
+    # is "introduced no NEW staleness", not "zero stale".
+    wrong = []
+    for e in ENTRY.finditer(read(SOURCE)):
+        key = e.group(2)
+        if key not in remap:
+            continue
+        eh = re.search(r'eh="([^"]*)"', e.group(5))
+        if eh and eh.group(1) != get_hash(unescape(e.group(3))):
+            wrong.append(key)
+    if wrong:
+        print("\nVERIFY FAILED: %d rewritten English entr(ies) carry a stale eh:"
+              % len(wrong))
+        for k in wrong[:10]:
+            print("  " + k)
+        return 1
+
+    print("\nverified: no unrenderable punctuation in any shipped value")
+    print("verified: every English eh matches its value")
+    print("sf_guide_p1_11 (en) = %s" % m.group(1))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Produção" eh="97345487" />
     <e k="sf_hud_estYield" v="Prod. Est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Ideal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Arrastar: mover   Canto: redimensionar   RMB/Shift+H: pronto" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: mover/redimensionar" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -824,7 +824,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -839,7 +839,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -987,13 +987,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1033,9 +1033,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="产量" eh="97345487" />
     <e k="sf_hud_estYield" v="预估产量" eh="32a4135e" />
     <e k="sf_hud_optimal" v="最佳" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="拖动移动面板｜拖拽角落调整大小｜右键/Shift+H 完成编辑" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H：移动/调整悬浮窗大小" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="检测到模组冲突" eh="89dbfc90" />
@@ -633,7 +633,7 @@
     <e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition - drag corner to resize - RMB or Esc to finish" eh="1d7b1dee" />
     <e k="sf_independent_panels_short" v="自由面板布局" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="允许在编辑模式下独立摆放各类系统面板" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="d61cf296" />
 
     <!-- ======================================================
          SETTINGS PANEL — CHROME
@@ -811,7 +811,7 @@
     <e k="sf_guide_p1_08" v="磷元素(P)    消耗缓慢，块根类作物消耗更多" eh="651919e6" />
     <e k="sf_guide_p1_09" v="钾元素(K)    块根作物会重度消耗该养分" eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="有机质(OM)   需要多个种植季缓慢累积提升" eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="9b966ead" />
     <e k="sf_guide_p1_12" v="土壤状态分级" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="良好（绿色） 养分达到或高于作物最优需求值" eh="a081208f" />
     <e k="sf_guide_p1_14" v="本季度无需施肥管理" eh="58b36ac2" />
@@ -959,13 +959,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="酸碱度调节农资" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="7d422dfe" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="酸碱度过低（酸性土壤，低于6.5）：" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="酸碱度过高（碱性土壤，高于7.5）：" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="a35d71d3" />
     <e k="sf_guide_p4_25" v="有机质提升途径" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="粪肥        提升有机质最优选择，同时补充氮元素" eh="99834812" />
     <e k="sf_guide_p4_27" v="堆肥        中等有机质提升，养分均衡温和" eh="d9b0e2f9" />
@@ -1005,9 +1005,9 @@
     <e k="sf_guide_p5_22" v="是否每个种植季都需要施肥？" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="氮元素：条件允许建议每季补充" eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="每次收割都会大量消耗土壤氮" eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="d6e2db5f" />
     <e k="sf_guide_p5_26" v="有机质：长期改良，每年施用一次粪肥即可" eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="66a52606" />
     <e k="sf_guide_p5_28" v="各类智能传感器系统工作原理？" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="智能传感器会单独关停无改良需求的喷杆分段，" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="无虫害、病害、养分缺口区域自动停喷；识别喷施实时显示单地块胁迫等级；" eh="22de015a" />

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="產量" eh="97345487" />
     <e k="sf_hud_estYield" v="預估產量" eh="32a4135e" />
     <e k="sf_hud_optimal" v="最佳" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="[EN] Shift+H: move/resize" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" eh="89dbfc90" />
@@ -633,7 +633,7 @@
     <e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition - drag corner to resize - RMB or Esc to finish" eh="1d7b1dee" />
     <e k="sf_independent_panels_short" v="Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="d61cf296" />
 
     <!-- ======================================================
          SETTINGS PANEL - CHROME
@@ -851,7 +851,7 @@
     <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="9b966ead" />
     <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -999,13 +999,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="7d422dfe" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="a35d71d3" />
     <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1045,9 +1045,9 @@
     <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="d6e2db5f" />
     <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="66a52606" />
     <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
     <e k="sf_section" v="Půda &amp; hnojiva" eh="f31197fb" />
@@ -21,7 +21,7 @@
     <e k="sf_ws_blurb_3" v="Normální: vyvážené sezónní srážky pro krátké měsíce. Výchozí živé klima." />
     <e k="sf_ws_blurb_2" v="Suché: sušší doplňování v krátkých měsících. Živiny vydrží déle, plodiny dříve trpí suchem." />
     <e k="sf_ws_blurb_1" v="Pouze reálná obloha: půda se řídí pouze předpovědí bez doplňování. Krátké měsíce mohou působit suchým dojmem." />
-    <e k="sf_ws_world_note" v="Globální nastavení – v multiplayeru pouze pro správce; mění půdu všem." />
+    <e k="sf_ws_world_note" v="Globální nastavení - v multiplayeru pouze pro správce; mění půdu všem." />
     <e k="sf_plowing_bonus_short" v="Bonus za orbu" eh="541ec752" />
     <e k="sf_plowing_bonus_long" v="Povolit/zakázat přínos orby pro úrodnost půdy (zlepšení dusíku a organické hmoty)" eh="fe701c1c" />
     <e k="sf_residue_incorporation_short" v="Zapracování posklizňových zbytků" eh="f4352cb5" />
@@ -74,7 +74,7 @@
     <e k="sf_rr_short" v="Rychlost obnovy živin" eh="b363b336" />
     <e k="sf_rr_long" v="Jak rychle hnojivo obnovuje živiny v půdě (0,25x Velmi pomalu až 2,0x Velmi rychle)" eh="afe78a6d" />
     <e k="sf_dm_short" v="Choroby a klima" eh="86eac820" />
-    <e k="sf_dm_long" v="Úroveň vlhkosti klimatu – určuje, jak rychle se šíří houbové choroby a jak dlouho trvá ochrana fungicidy" eh="23424d05" />
+    <e k="sf_dm_long" v="Úroveň vlhkosti klimatu - určuje, jak rychle se šíří houbové choroby a jak dlouho trvá ochrana fungicidy" eh="23424d05" />
     <e k="sf_dm_1" v="Suché" eh="cf9aa4a8" />
     <e k="sf_dm_2" v="Mírné" eh="e8328062" />
     <e k="sf_dm_3" v="Vlhké" eh="ccb2fc34" />
@@ -235,7 +235,7 @@
     <e k="helpLine_sf_ov_p1_intro_title" v="Sledování půdy pro každé pole" eh="8fe3248d" />
     <e k="helpLine_sf_ov_p1_intro_text" v="Každé pole nezávisle sleduje pět vlastností: Dusík (N), Fosfor (P), Draslík (K), Organickou hmotu (OM) a pH. Hodnoty se ukládají s vaší hrou a zůstávají zachovány napříč relacemi." eh="c30216e6" />
     <e k="helpLine_sf_ov_p1_flow_title" v="Koloběh živin" eh="15b0d408" />
-    <e k="helpLine_sf_ov_p1_flow_text" v="Plodiny při sklizni odebírají živiny. Minerální hnojiva, hnojůvka, kejda a vápno je navracejí. Mód sleduje realistický rozpočet živin – co plodiny odeberou, to musíte vrátit." eh="418041f0" />
+    <e k="helpLine_sf_ov_p1_flow_text" v="Plodiny při sklizni odebírají živiny. Minerální hnojiva, hnojůvka, kejda a vápno je navracejí. Mód sleduje realistický rozpočet živin - co plodiny odeberou, to musíte vrátit." eh="418041f0" />
 
     <e k="helpLine_sf_ov_p2_title" v="Vlivy prostředí" eh="e139e84f" />
     <e k="helpLine_sf_ov_p2_rain_title" v="Déšť a Vyplavování" eh="33e0d8ea" />
@@ -252,20 +252,20 @@
 
     <e k="helpLine_sf_gs_p2_title" v="Hnojení a sklizeň" eh="1a52ac04" />
     <e k="helpLine_sf_gs_p2_fert_title" v="Hnojení polí" eh="ea52ec26" />
-    <e k="helpLine_sf_gs_p2_fert_text" v="Aplikujte hnojivo pomocí jakéhokoli standardního postřikovače nebo rozmetadla. Mód rozpoznává všechny typy ze základní hry plus 9 vlastních typů (UAN-32, MAP, Draselné hnojivo atd.). Každý typ doplňuje jiné živiny – kompletní profily najdete v kategorii Hnojiva." eh="fe906e29" />
+    <e k="helpLine_sf_gs_p2_fert_text" v="Aplikujte hnojivo pomocí jakéhokoli standardního postřikovače nebo rozmetadla. Mód rozpoznává všechny typy ze základní hry plus 9 vlastních typů (UAN-32, MAP, Draselné hnojivo atd.). Každý typ doplňuje jiné živiny - kompletní profily najdete v kategorii Hnojiva." eh="fe906e29" />
     <e k="helpLine_sf_gs_p2_harvest_title" v="Úbytek živin sklizní" eh="a67b6cb5" />
     <e k="helpLine_sf_gs_p2_harvest_text" v="Každá sklizeň odebírá z pole živiny. Náročné plodiny (brambory, cukrová řepa, sója) vyčerpávají půdu výrazně více než méně náročné plodiny (ječmen, oves). Po každém cyklu sklizně zkontrolujte HUD nebo půdní zprávu." eh="63f90ed4" />
 
     <e k="helpLine_sf_gs_p3_title" v="Obtížnost" eh="7b29ca96" />
     <e k="helpLine_sf_gs_p3_levels_title" v="Tři úrovně obtížnosti" eh="52611188" />
-    <e k="helpLine_sf_gs_p3_levels_text" v="Jednoduchá (0.7x): O 30 % nižší úbytek – vhodné pro nové hráče. Realistická (1.0x): Vyvážená, kalibrovaná podle reálných zemědělských hodnot. Hardcore (1.5x): O 50 % vyšší úbytek – vyžaduje intenzivní správu půdy." eh="f4f1ea30" />
+    <e k="helpLine_sf_gs_p3_levels_text" v="Jednoduchá (0.7x): O 30 % nižší úbytek - vhodné pro nové hráče. Realistická (1.0x): Vyvážená, kalibrovaná podle reálných zemědělských hodnot. Hardcore (1.5x): O 50 % vyšší úbytek - vyžaduje intenzivní správu půdy." eh="f4f1ea30" />
     <e k="helpLine_sf_gs_p3_access_title" v="Změna nastavení" eh="b421c88f" />
     <e k="helpLine_sf_gs_p3_access_text" v="Otevřete nastavení přes ESC &gt; Nastavení &gt; Půda &amp; hnojiva. V hře více hráčů může nastavení simulace měnit pouze správce serveru. Všechny možnosti zobrazení HUD jsou pro každého hráče individuální a nesdílejí se." eh="4ba9d860" />
 
     <!-- Category 3: Soil Nutrients -->
     <e k="helpLine_sf_nu_p1_title" v="Dusík a Fosfor" eh="27d37372" />
     <e k="helpLine_sf_nu_p1_n_title" v="Dusík (N) - Stupnice 0 až 100" eh="10a358f4" />
-    <e k="helpLine_sf_nu_p1_n_text" v="Nejpohyblivější živina – vyčerpává se nejrychleji a při dešti se silně vyplavuje. Špatný: pod 30. Dobrý: nad 50. Zvyšte pomocí: kapalného hnojiva, UAN-32, UAN-28, bezvodého amoniaku, močoviny, AMS, hnoje nebo kejdy." eh="58d62253" />
+    <e k="helpLine_sf_nu_p1_n_text" v="Nejpohyblivější živina - vyčerpává se nejrychleji a při dešti se silně vyplavuje. Špatný: pod 30. Dobrý: nad 50. Zvyšte pomocí: kapalného hnojiva, UAN-32, UAN-28, bezvodého amoniaku, močoviny, AMS, hnoje nebo kejdy." eh="58d62253" />
     <e k="helpLine_sf_nu_p1_p_title" v="Fosfor (P) - Stupnice 0 až 100" eh="979bba64" />
     <e k="helpLine_sf_nu_p1_p_text" v="Silně se váže na půdu a Vyplavuje se velmi pomalu. Vyčerpává se hlavně sklizní. Řepka má nejvyšší nároky na P. Špatný: pod 25. Dobrý: nad 45. Zvyšte pomocí: MAP, DAP, startovacího hnojiva nebo kapalného hnojiva." eh="92c5ac66" />
 
@@ -273,7 +273,7 @@
     <e k="helpLine_sf_nu_p2_k_title" v="Draslík (K) - Stupnice 0 až 100" eh="2a16e8bc" />
     <e k="helpLine_sf_nu_p2_k_text" v="Kritický pro kořenovou a hlíznatou zeleninu. Brambory a cukrová řepa při každé sklizni silně vyčerpávají K. Při dešti se mírně Vyplavuje. Špatný: pod 20. Dobrý: nad 40. Zvyšte pomocí: draselného hnojiva (0-0-60), kejdy, digestátu nebo kapalného hnojiva." eh="7230fee4" />
     <e k="helpLine_sf_nu_p2_ph_title" v="pH - Stupnice 5.0 až 7.5" eh="944beca2" />
-    <e k="helpLine_sf_nu_p2_ph_text" v="Většina plodin prosperuje při pH 6.5 až 7.0. Déšť s postupem času půdu pomalu zakyseluje. pH se samo neobnovuje – zvyšuje ho pouze vápno nebo tekuté vápno. Špatný: pod 5.5. Pokud pH před dalším osevem klesá, aplikujte vápno." eh="08e0aefd" />
+    <e k="helpLine_sf_nu_p2_ph_text" v="Většina plodin prosperuje při pH 6.5 až 7.0. Déšť s postupem času půdu pomalu zakyseluje. pH se samo neobnovuje - zvyšuje ho pouze vápno nebo tekuté vápno. Špatný: pod 5.5. Pokud pH před dalším osevem klesá, aplikujte vápno." eh="08e0aefd" />
 
     <e k="helpLine_sf_nu_p3_title" v="Organická hmota" eh="6305f4bb" />
     <e k="helpLine_sf_nu_p3_om_title" v="Organická hmota (OM) - Stupnice 0 až 10" eh="58f490f3" />
@@ -286,11 +286,11 @@
     <e k="helpLine_sf_fe_p1_base_title" v="Kapalné, pevné, hnůj a kejda" eh="4668dca7" />
     <e k="helpLine_sf_fe_p1_base_text" v="Kapalné hnojivo přidává vyvážený poměr N+P+K. Pevné hnojivo má vyšší obsah N a P. Hnůj a kejda přidávají N, P, K a organickou hmotu. Digestát (vedlejší produkt bioplynu) má vysoký obsah K a také přidává OM. Vše se aplikuje pomocí standardního vybavení." eh="64069a56" />
     <e k="helpLine_sf_fe_p1_lime_title" v="Vápno a úprava pH" eh="8933cce1" />
-    <e k="helpLine_sf_fe_p1_lime_text" v="Vápno je jediný prostředek pro úpravu pH ze základní hry – nepřidává žádné živiny. Vlastní typy Tekuté vápno a Sádrovec také zvyšují pH (Sádrovec navíc přidává malé množství OM). Aplikujte, jakmile pH klesne pod 6.0, abyste udrželi plodiny v optimálním rozmezí." eh="833a967f" />
+    <e k="helpLine_sf_fe_p1_lime_text" v="Vápno je jediný prostředek pro úpravu pH ze základní hry - nepřidává žádné živiny. Vlastní typy Tekuté vápno a Sádrovec také zvyšují pH (Sádrovec navíc přidává malé množství OM). Aplikujte, jakmile pH klesne pod 6.0, abyste udrželi plodiny v optimálním rozmezí." eh="833a967f" />
 
     <e k="helpLine_sf_fe_p2_title" v="Vlastní zdroje dusíku a PK" eh="1021f8c9" />
     <e k="helpLine_sf_fe_p2_n_title" v="Zdroje dusíku (vlastní velkoobjemové vaky)" eh="9dfe5a5a" />
-    <e k="helpLine_sf_fe_p2_n_text" v="UAN-32 (32-0-0) a UAN-28 (28-0-0) jsou kapalné dusíkaté roztoky. Bezvodý amoniak (82-0-0) je produkt s nejvyšším obsahem N na litr. Močovina (46-0-0) a AMS (21-0-0-24S) jsou suchá granulovaná hnojiva. Všechna obsahují pouze N – nemají žádný vliv na P, K ani pH." eh="6a100c25" />
+    <e k="helpLine_sf_fe_p2_n_text" v="UAN-32 (32-0-0) a UAN-28 (28-0-0) jsou kapalné dusíkaté roztoky. Bezvodý amoniak (82-0-0) je produkt s nejvyšším obsahem N na litr. Močovina (46-0-0) a AMS (21-0-0-24S) jsou suchá granulovaná hnojiva. Všechna obsahují pouze N - nemají žádný vliv na P, K ani pH." eh="6a100c25" />
     <e k="helpLine_sf_fe_p2_pk_title" v="Zdroje fosforu a draslíku" eh="a2d4091b" />
     <e k="helpLine_sf_fe_p2_pk_text" v="MAP (11-52-0): nejvyšší obsah P na litr. DAP (18-46-0): vysoký obsah P s trochou N. Draselné hnojivo (0-0-60): čisté K. Startovací hnojivo (10-34-0): produkt s vysokým obsahem P určený do řádků s vyváženým N+K. Vše je k dispozici jako zakoupitelné velkoobjemové vaky v obchodě." eh="75a86964" />
 
@@ -305,17 +305,17 @@
     <e k="helpLine_sf_hu_p1_toggle_title" v="Přepínání HUD (Klávesa J)" eh="402283ba" />
     <e k="helpLine_sf_hu_p1_toggle_text" v="Stisknutím J zobrazíte nebo skryjete živé překrytí půdy. Detekuje pole, na kterém se nacházíte, a zobrazuje N, P, K, pH a OM. Pokud je v nastavení povolena plevel, škůdci nebo choroby, tyto řádky se zobrazí ve spodní části panelu." eh="3dcb9bfe" />
     <e k="helpLine_sf_hu_p1_status_title" v="Čtení stavu" eh="291c3aac" />
-    <e k="helpLine_sf_hu_p1_status_text" v="Každá živina zobrazuje stav Dobrý (není vyžadována žádná akce), Ušatý (zvažte brzkou úpravu) nebo Špatný (vyžaduje akci – ovlivňuje výnos). Celkový odznak v záhlaví odráží nejhorší hodnotu napříč všemi sledovanými parametry včetně plevele, škůdců a chorob." eh="3b8c2c6e" />
+    <e k="helpLine_sf_hu_p1_status_text" v="Každá živina zobrazuje stav Dobrý (není vyžadována žádná akce), Ušatý (zvažte brzkou úpravu) nebo Špatný (vyžaduje akci - ovlivňuje výnos). Celkový odznak v záhlaví odráží nejhorší hodnotu napříč všemi sledovanými parametry včetně plevele, škůdců a chorob." eh="3b8c2c6e" />
 
     <e k="helpLine_sf_hu_p2_title" v="Rizika pro zdraví pole" eh="b4d35b30" />
     <e k="helpLine_sf_hu_p2_press_title" v="Plevel, škůdci a choroby" eh="0a3fae00" />
     <e k="helpLine_sf_hu_p2_press_text" v="Tři ukazatele tlaku (0 až 100) sledují biologické hrozby na daném poli. Bez zásahu snižují výnos při sklizni: Plevel až o -30 %, Škůdci -20 %, Choroby -25 %. Řádky W, I a D v HUD zobrazují barevně rozlišenou závažnost: zelená (nízká), žlutá (střední), červená (vysoká)." eh="3fc3c400" />
     <e k="helpLine_sf_hu_p2_treat_title" v="Ošetření polí" eh="cb24bf50" />
-    <e k="helpLine_sf_hu_p2_treat_text" v="Herbicit snižuje tlak plevele – jakákoli kultivace jej navíc resetuje na nulu. Insekticit snižuje tlak škůdců o 25 bodů a potlačuje opětovný výskyt po dobu 10 dnů. Fungicit snižuje choroby o 20 bodů a potlačuje je po dobu 12 dnů. Každý systém lze vypnout v Nastavení." eh="4d65bdec" />
+    <e k="helpLine_sf_hu_p2_treat_text" v="Herbicit snižuje tlak plevele - jakákoli kultivace jej navíc resetuje na nulu. Insekticit snižuje tlak škůdců o 25 bodů a potlačuje opětovný výskyt po dobu 10 dnů. Fungicit snižuje choroby o 20 bodů a potlačuje je po dobu 12 dnů. Každý systém lze vypnout v Nastavení." eh="4d65bdec" />
 
     <e k="helpLine_sf_hu_p3_title" v="Půdní zpráva" eh="35fcce6c" />
     <e k="helpLine_sf_hu_p3_open_title" v="Otevření zprávy (Klávesa K)" eh="62e3f629" />
-    <e k="helpLine_sf_hu_p3_open_text" v="Stisknutím K otevřete kompletní půdní zprávu farmy. Souhrnný lišta zobrazuje celkový počet sledovaných polí, kolik z nich potřebuje hnojivo, a vážené procento Zdraví farmy. Pole jsou seřazena podle naléhavosti – nejhorší stav jako první." eh="38a5bd2e" />
+    <e k="helpLine_sf_hu_p3_open_text" v="Stisknutím K otevřete kompletní půdní zprávu farmy. Souhrnný lišta zobrazuje celkový počet sledovaných polí, kolik z nich potřebuje hnojivo, a vážené procento Zdraví farmy. Pole jsou seřazena podle naléhavosti - nejhorší stav jako první." eh="38a5bd2e" />
     <e k="helpLine_sf_hu_p3_detail_title" v="Detail pole a doporučení" eh="c99d2b89" />
     <e k="helpLine_sf_hu_p3_detail_text" v="Kliknutím na šipku u libovolného řádku otevřete detailní pohled na dané pole: hodnoty živin, úrovně rizika, předpověď ztráty výnosu a odrážkový seznam doporučení, který vám přesně řekne, co aplikovat. Stisknutím Zpět nebo Escape se vrátíte do tabulky." eh="38dd2c6d" />
 
@@ -328,7 +328,7 @@
 
     <e k="helpLine_sf_se_p2_title" v="HUD a řízení dávkování" eh="399f4910" />
     <e k="helpLine_sf_se_p2_hud_title" v="Možnosti HUD pro každého hráče" eh="0df76500" />
-    <e k="helpLine_sf_se_p2_hud_text" v="Každý hráč ovládá svůj vlastní HUD – nesynchronizuje se se serverem. Možnosti: Zobrazit HUD (zap/vyp), Pozice (5 předvoleb + přetažení), Barevný motiv (Zelený / Modrý / Jantarový / Jednobarevný), Velikost písma (Malé / Střední / Velké), Průhlednost (25 % až 100 %), Imperiální jednotky (zap/vyp)." eh="f3934884" />
+    <e k="helpLine_sf_se_p2_hud_text" v="Každý hráč ovládá svůj vlastní HUD - nesynchronizuje se se serverem. Možnosti: Zobrazit HUD (zap/vyp), Pozice (5 předvoleb + přetažení), Barevný motiv (Zelený / Modrý / Jantarový / Jednobarevný), Velikost písma (Malé / Střední / Velké), Průhlednost (25 % až 100 %), Imperiální jednotky (zap/vyp)." eh="f3934884" />
     <e k="helpLine_sf_se_p2_rate_title" v="Řízení dávky postřikovače" eh="5ecdfa23" />
     <e k="helpLine_sf_se_p2_rate_text" v="V postřikovači nebo rozmetadle použijte SF Zvýšit dávku (]) a SF Snížit dávku ([) pro úpravu aplikační dávky od 0.10x do 2.00x. Přepněte Automatické řízení dávkování (Shift+L), aby mód automaticky cílil na optimální úrovně živin a zabránil riziku popálení." eh="dd385e39" />
 
@@ -337,7 +337,7 @@
     <e k="helpLine_sf_mp_p1_auth_title" v="Simulace řízená serverem" eh="8d324792" />
     <e k="helpLine_sf_mp_p1_auth_text" v="Veškerá simulace půdy běží na serveru. Klienti obdrží kompletní data o polích a nastavení při připojení s automatickým opakovaným pokusem, pokud se server ještě načítá. Nastavení zobrazení HUD (pozice, motiv, velikost) jsou pro každého hráče individuální a nikdy se nesynchronizují se serverem." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Dedicované servery" eh="4d3a45ba" />
-    <e k="helpLine_sf_mp_p1_ded_text" v="Dedicované servery spouštějí kompletní simulaci bez jakékoli zátěže HUD nebo GUI – to je očekávané a normální. Ke správě a ověření nastavení na dedicovaném serveru použijte konzolové příkazy (soilStatus, SoilSetDifficulty, SoilShowSettings atd.)." eh="3df784d6" />
+    <e k="helpLine_sf_mp_p1_ded_text" v="Dedicované servery spouštějí kompletní simulaci bez jakékoli zátěže HUD nebo GUI - to je očekávané a normální. Ke správě a ověření nastavení na dedicovaném serveru použijte konzolové příkazy (soilStatus, SoilSetDifficulty, SoilShowSettings atd.)." eh="3df784d6" />
     <e k="helpLine_sf_mp_p2_title" v="Kompatibilita a pracovní postup" />
     <e k="helpLine_sf_mp_p2_compat_title" v="Kompatibilita módů" />
     <e k="helpLine_sf_mp_p2_compat_text" v="Půda &amp; hnojiva používá připojené funkční háky (hooks), takže funguje po boku Courseplay, AutoDrive a většiny módů vybavení bez konfliktů. Jakmile je v uložené hře aktivní Precision Farming, mód to rozpozná a automaticky se deaktivuje, takže oba módy nikdy nesoutěží o stejná pole." />
@@ -539,7 +539,7 @@
     <e k="sf_treat_section_fert" v="Aplikace živin" eh="76521e8e" />
     <e k="sf_treat_section_prot" v="Ochrana plodin" eh="bd3fe9cd" />
     <e k="sf_treat_hint" v="Specializovaná hnojiva najdete v sekci 'Produkty' v obchodě." eh="540bff4d" />
-    <e k="sf_treat_action_optimal" v="Optimální – Není vyžadována žádná akce." eh="4501a96b" />
+    <e k="sf_treat_action_optimal" v="Optimální - Není vyžadována žádná akce." eh="4501a96b" />
     <e k="sf_treat_action_lime" v="Aplikujte VÁPNO nebo TEKUTÉ VÁPNO ke zvýšení pH." eh="d1420b97" />
     <e k="sf_treat_action_gypsum" v="Aplikujte SÁDROVEC ke snížení pH / zlepšení struktury." eh="4cb3f0dc" />
     <e k="sf_treat_action_om_low" v="Zaorejte HNŮJ, KOMPOST nebo rozdrcenou slámu." eh="33ec544c" />
@@ -603,9 +603,9 @@
     <e k="sf_notify_burn_body" v="Pole %d: poškození nadměrnou aplikací (pH %.1f)" eh="cb731ee3" />
     <e k="sf_notify_sync_error" v="Soil Mod: Zjištěn problém se synchronizací dat. Nahlaste prosím, pokud to přetrvává." eh="1a307946" />
     <e k="sf_notify_lime_crop_title" v="Varování ohledně úpravy" eh="33228c86" />
-    <e k="sf_notify_lime_crop_body" v="Pole %d: Vápno na rostoucí plodině – výnos -80%% při sklizni!" eh="9174b3ef" />
+    <e k="sf_notify_lime_crop_body" v="Pole %d: Vápno na rostoucí plodině - výnos -80%% při sklizni!" eh="9174b3ef" />
     <e k="sf_notify_om_crop_title" v="Varování ohledně úpravy" eh="33228c86" />
-    <e k="sf_notify_om_crop_body" v="Pole %d: Organická hmota na rostoucí plodině – výnos -20%% při sklizni." eh="8a78f46a" />
+    <e k="sf_notify_om_crop_body" v="Pole %d: Organická hmota na rostoucí plodině - výnos -20%% při sklizni." eh="8a78f46a" />
 
     <!-- ======================================================
          SETTINGS PANEL - CATEGORIES & SECTION HEADERS
@@ -630,10 +630,10 @@
     <e k="sf_panel_hdr_actions" v="Akce &amp; Nástroje polí" eh="f64ba1c9" />
     <e k="sf_panel_hdr_hud_layout" v="Rozvržení HUD" eh="54e1930b" />
     <e k="sf_hud_enter_drag_label" v="Přesunout &amp; Změnit velikost panelů" eh="be34d24d" />
-    <e k="sf_hud_enter_drag_desc" v="Táhnutím přesunete HUD – táhnutím za roh změníte velikost – Pravým tlačítkem nebo Esc dokončíte" eh="1d7b1dee" />
+    <e k="sf_hud_enter_drag_desc" v="Táhnutím přesunete HUD - táhnutím za roh změníte velikost - Pravým tlačítkem nebo Esc dokončíte" eh="1d7b1dee" />
     <e k="sf_independent_panels_short" v="Volné rozvržení panelů" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Umožňuje v režimu úprav libovolně umístit chytré systémové panely" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="V režimu úprav (Shift+H) přetahujte každý panel volně. Panely sbalíte tlačítkem − v jejich záhlaví." eh="7c60edfc" />
+    <e k="sf_desc_independentPanels" v="V režimu úprav (Shift+H) přetahujte každý panel volně. Panely sbalíte tlačítkem - v jejich záhlaví." eh="7c60edfc" />
 
     <!-- ======================================================
          SETTINGS PANEL - CHROME
@@ -836,11 +836,11 @@
     <e k="action_SF_SEE_SPRAY_DISEASE" v="SF: Přepnout See &amp; Spray na choroby" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"   v="SF: Přepnout See &amp; Spray na plevel" />
     <e k="action_SF_VARIABLE_RATE"    v="SF: Přepnout proměnlivé dávkování" />
-    <e k="sf_guide_sub_1" v="Přehled – Co tento mód sleduje a proč na tom záleží" eh="69091cec" />
-    <e k="sf_guide_sub_2" v="Průvodce HUD – Čtení panelů živin a ukazatelů na obrazovce" eh="da09523b" />
-    <e k="sf_guide_sub_3" v="Pracovní postup – Vaše denní a sezónní rutina správy půdy" eh="438cd61b" />
-    <e k="sf_guide_sub_4" v="Produkty – Co jednotlivá hnojiva ovlivňují a kdy je používat" eh="ab1d5b05" />
-    <e k="sf_guide_sub_5" v="Časté dotazy (FAQ) – Odpovědi na běžné otázky" eh="b383de9c" />
+    <e k="sf_guide_sub_1" v="Přehled - Co tento mód sleduje a proč na tom záleží" eh="69091cec" />
+    <e k="sf_guide_sub_2" v="Průvodce HUD - Čtení panelů živin a ukazatelů na obrazovce" eh="da09523b" />
+    <e k="sf_guide_sub_3" v="Pracovní postup - Vaše denní a sezónní rutina správy půdy" eh="438cd61b" />
+    <e k="sf_guide_sub_4" v="Produkty - Co jednotlivá hnojiva ovlivňují a kdy je používat" eh="ab1d5b05" />
+    <e k="sf_guide_sub_5" v="Časté dotazy (FAQ) - Odpovědi na běžné otázky" eh="b383de9c" />
     <e k="sf_guide_p1_01" v="CO JE TENTO MÓD" eh="fe4d3283" />
     <e k="sf_guide_p1_02" v="Sleduje 5 živin v půdě pro každé pole na" eh="93e6595b" />
     <e k="sf_guide_p1_03" v="vaší farmě. Plodiny vyčerpávají živiny při sklizni." eh="5e6dc5a8" />
@@ -851,20 +851,20 @@
     <e k="sf_guide_p1_08" v="P   Fosfor         Pomalé vyčerpání. Okopaniny." eh="651919e6" />
     <e k="sf_guide_p1_09" v="K   Draslík        Okopaniny jej silně vyčerpávají." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="OM  Organická hmota Tvoří se pomalu během mnoha sezón." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="pH  Kyselost půdy. Cílové rozmezí: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="pH  Kyselost půdy. Cílové rozmezí: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="ÚROVNĚ STAVU" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="DOBRÝ (zelená)  Na nebo nad optimálním cílem plodiny." eh="a081208f" />
     <e k="sf_guide_p1_14" v="  Tato sezóna nevyžaduje žádnou akci." eh="58b36ac2" />
     <e k="sf_guide_p1_15" v="UŠATÝ (žlutá)  Pod optimem." eh="0d30dbe4" />
     <e k="sf_guide_p1_16" v="  Naplánujte doplnění. Výnos je mírně snížen." eh="0363160b" />
     <e k="sf_guide_p1_17" v="ŠPATNÝ (červená) Pod minimální prahovou hodnotou." eh="96f2a246" />
-    <e k="sf_guide_p1_18" v="  Jednejte hned – dopad na výnos je závažný." eh="587bdd4a" />
+    <e k="sf_guide_p1_18" v="  Jednejte hned - dopad na výnos je závažný." eh="587bdd4a" />
     <e k="sf_guide_p1_19" v="RYCHLÝ START (5 KROKŮ)" eh="f1bcfcdb" />
     <e k="sf_guide_p1_20" v="1. Otevřete PDA (herní menu) > Půda &amp; Hnojivo." eh="22539c14" />
     <e k="sf_guide_p1_21" v="2. Zkontrolujte přehled farmy na červeně označená pole." eh="d4e823e8" />
     <e k="sf_guide_p1_22" v="3. Použijte plán ošetření k zjištění, co je potřeba." eh="1a0c7961" />
     <e k="sf_guide_p1_23" v="4. Aplikujte správný hnojivý produkt." eh="b44bcac2" />
-    <e k="sf_guide_p1_24" v="5. Sklízejte normálně – živiny se odečtou automaticky." eh="fa399c0f" />
+    <e k="sf_guide_p1_24" v="5. Sklízejte normálně - živiny se odečtou automaticky." eh="fa399c0f" />
     <e k="sf_guide_p1_25" v="NÁSTROJE V PŘEHLEDU" eh="103ce1b5" />
     <e k="sf_guide_p1_26" v="HUD bary       Půdní úrovně pro vaše aktuální pole." eh="4d0661d7" />
     <e k="sf_guide_p1_27" v="  Klávesa: Přepnout půdní HUD (ve výchozím stavu nepřiřazeno)." eh="4e3fc48e" />
@@ -891,15 +891,15 @@
     <e k="sf_guide_p2_04" v="Barva baru vám na první pohled řekne stav." eh="e07e4240" />
     <e k="sf_guide_p2_05" v="TŘI ZNAČKY" eh="70556f5d" />
     <e k="sf_guide_p2_06" v="Každý bar má tři malé svislé značky." eh="65bb2211" />
-    <e k="sf_guide_p2_07" v="ORANŽOVÁ značka – Hranice špatného/ušatého stavu." eh="5f9f1409" />
+    <e k="sf_guide_p2_07" v="ORANŽOVÁ značka - Hranice špatného/ušatého stavu." eh="5f9f1409" />
     <e k="sf_guide_p2_08" v="  Pod touto čárou je bar ČERVENÝ." eh="4cebe452" />
     <e k="sf_guide_p2_09" v="  Vaše půda je ve ŠPATNÉM stavu." eh="7a3175e4" />
     <e k="sf_guide_p2_10" v="  Akce: okamžitě aplikujte hnojivo." eh="209e2635" />
-    <e k="sf_guide_p2_11" v="ŽLUTÁ značka – Hranice ušatého/dobrého stavu." eh="f7a41325" />
+    <e k="sf_guide_p2_11" v="ŽLUTÁ značka - Hranice ušatého/dobrého stavu." eh="f7a41325" />
     <e k="sf_guide_p2_12" v="  Mezi oranžovou a žlutou značkou je bar ŽLUTÝ." eh="cac82a8d" />
-    <e k="sf_guide_p2_13" v="  Půda je v UŠATÉM stavu – pod optimem plodiny." eh="320016a7" />
+    <e k="sf_guide_p2_13" v="  Půda je v UŠATÉM stavu - pod optimem plodiny." eh="320016a7" />
     <e k="sf_guide_p2_14" v="  Akce: naplánujte na tuto sezónu doplnění." eh="3cf7dfa3" />
-    <e k="sf_guide_p2_15" v="AZUROVÁ značka – Optimální cíl pro vaši zasazenou plodinu." eh="6a0b26f8" />
+    <e k="sf_guide_p2_15" v="AZUROVÁ značka - Optimální cíl pro vaši zasazenou plodinu." eh="6a0b26f8" />
     <e k="sf_guide_p2_16" v="  Dosáhněte tohoto bodu pro maximální výnos." eh="cc7c263f" />
     <e k="sf_guide_p2_17" v="  Když jej dosáhnete, bar je ZELENÝ." eh="b5e669ea" />
     <e k="sf_guide_p2_18" v="  Každá plodina má jiné cíle pro N/P/K." eh="d25b96a5" />
@@ -999,13 +999,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="KOREKCE pH" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="7d422dfe" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH příliš NÍZKÉ (kyselé, pod 6,5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="pH příliš VYSOKÉ (alkalické, nad 7,5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="a35d71d3" />
     <e k="sf_guide_p4_25" v="ORGANICKÁ HMOTA (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="Hnůj          Nejlepší budovatel OM. Také přidává N." eh="99834812" />
     <e k="sf_guide_p4_27" v="Kompost       Střední OM, dobře vyvážený." eh="d9b0e2f9" />
@@ -1045,9 +1045,9 @@
     <e k="sf_guide_p5_22" v="MUSÍM HNOJIT KAŽDOU SEZÓNU?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="Dusík: Ano, každou sezónu pokud možno." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="d6e2db5f" />
     <e k="sf_guide_p5_26" v="Organická OM: Dlouhodobě. Přidávejte hnůj jednou ročně." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="66a52606" />
     <e k="sf_guide_p5_28" v="JAK FUNGUJÍ SYSTÉMY CHYTRÝCH SENZORŮ?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="Chytrý senzor blokuje jednotlivé sekce ramene, pokud" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="není zjištěna potřeba (žádný škůdce, choroba ani deficit živin" eh="22de015a" />
@@ -1062,7 +1062,7 @@
     <e k="sf_guide_p5_39" v="oprávnění správce v multiplayerových sezeních." eh="a48c5146" />
     <e k="sf_guide_p5_40" v="JAK PŮDA OVLIVŇUJE VÝNOS?" eh="456d3c9f" />
     <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield - no penalty." eh="49e249c2" />
-    <e k="sf_guide_p5_42" v="PRŮMĚRNÁ půda: ~5–15% postih výnosu na živinu." eh="bced6a1c" />
+    <e k="sf_guide_p5_42" v="PRŮMĚRNÁ půda: ~5-15% postih výnosu na živinu." eh="bced6a1c" />
     <e k="sf_guide_p5_43" v="ŠPATNÁ půda: až 40% postih. Opravte to rychle." eh="244d5bf2" />
     <e k="sf_guide_p5_44" v="Postihy se sčítají: ŠPATNÝ N + PRŮMĚRNÝ P = velká ztráta." eh="8afb61f9" />
     <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer - Field Guide" eh="0e662248" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Udbytte" eh="97345487" />
     <e k="sf_hud_estYield" v="Est. udbytte" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Træk: flyt   Hjørne: størrelse   RMB/Shift+H: færdig" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: flyt/størrelse" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Inkompatibilitet opdaget" eh="89dbfc90" />
@@ -770,7 +770,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="Frit panel-layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Tillad at smart systempaneler placeres individuelt i redigeringstilstand" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="d61cf296" />
     <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
@@ -786,7 +786,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="Ingen handling nødvendig denne sæson." eh="58b36ac2" />
@@ -934,13 +934,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -980,9 +980,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="Det tømmes kraftigt ved hver høst." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <l10n>
     <elements>
-    <e k="sf_section" v="Realistische B├Âden &amp; D├╝ngung" eh="f31197fb" />
+    <e k="sf_section" v="Realistische Böden &amp; Düngung" eh="f31197fb" />
     <e k="sf_enabled_short" v="Mod aktiv" eh="cf7fea13" />
-    <e k="sf_enabled_long" v="Die Mod Realistische B├Âden &amp; D├╝ngung aktivieren oder deaktivieren" eh="a891399a" />
+    <e k="sf_enabled_long" v="Die Mod Realistische Böden &amp; Düngung aktivieren oder deaktivieren" eh="a891399a" />
     <e k="sf_debug_short" v="DEBUG-Modus" eh="2ddcdc76" />
-    <e k="sf_debug_long" v="DEBUG-Modus ein-/ausschalten (zus├ñtzliche Ausgaben in die Log-Datei)" eh="f6f20240" />
+    <e k="sf_debug_long" v="DEBUG-Modus ein-/ausschalten (zusätzliche Ausgaben in die Log-Datei)" eh="f6f20240" />
     <e k="sf_seasonal_effects_short" v="Jahreszeiten" eh="c16ea608" />
-    <e k="sf_seasonal_effects_long" v="Jahreszeiten beeinflussen den Stickstoffhaushalt deiner Pflanzen. Es werden nun realit├ñtsnah ein Fr├╝hjahrswachstumsschub und ein verlangsamtes Wachstum im Herbst simuliert." eh="3eea94c7" />
+    <e k="sf_seasonal_effects_long" v="Jahreszeiten beeinflussen den Stickstoffhaushalt deiner Pflanzen. Es werden nun realitätsnah ein Frühjahrswachstumsschub und ein verlangsamtes Wachstum im Herbst simuliert." eh="3eea94c7" />
     <e k="sf_rain_effects_short" v="Auswaschung" eh="a2a1758b" />
-    <e k="sf_rain_effects_long" v="Auswirkungen von Niederschlag auf den Boden ein-/ausschalten (N├ñhrstoffauswaschung, ├änderungen pH-Wert)" eh="de3b14b9" />
+    <e k="sf_rain_effects_long" v="Auswirkungen von Niederschlag auf den Boden ein-/ausschalten (Nährstoffauswaschung, Änderungen pH-Wert)" eh="de3b14b9" />
     <e k="sf_ws_short" v="[EN] World Climate" eh="59d3bec0" />
     <e k="sf_desc_weatherSource" v="[EN] Short-month rain fill climate. Real sky only skips the fill; Arid / Normal / Wet shape how wet soil feels when the calendar undersamples rain." eh="e143bba8" />
     <e k="sf_ws_long" v="[EN] Chooses the climate short months fill toward when the real sky is dry. Does not change the visual weather. Admin-only world setting in multiplayer." eh="e2f5fab8" />
@@ -23,40 +23,40 @@
     <e k="sf_ws_blurb_1" v="[EN] Real sky only: soil follows the forecast with no fill. Short months can feel sparse." eh="e36f0769" />
     <e k="sf_ws_world_note" v="[EN] World setting - admin only in multiplayer; changes soil for everyone." eh="9f78a319" />
     <e k="sf_plowing_bonus_short" v="Pflugbonus" eh="541ec752" />
-    <e k="sf_plowing_bonus_long" v="Pflugvorteile f├╝r Bodenfruchtbarkeit ein-/ausschalten (verbesserter Stickstoff und organische Substanz)" eh="fe701c1c" />
-    <e k="sf_residue_incorporation_short" v="Ernter├╝ckst├ñnde" eh="f4352cb5" />
-    <e k="sf_residue_incorporation_long" v="Aktiviert die N├ñhrstofffreisetzung aus Ernter├╝ckst├ñnden, welche in den Boden eingearbeitet wurden" eh="2e43448f" />
+    <e k="sf_plowing_bonus_long" v="Pflugvorteile für Bodenfruchtbarkeit ein-/ausschalten (verbesserter Stickstoff und organische Substanz)" eh="fe701c1c" />
+    <e k="sf_residue_incorporation_short" v="Ernterückstände" eh="f4352cb5" />
+    <e k="sf_residue_incorporation_long" v="Aktiviert die Nährstofffreisetzung aus Ernterückständen, welche in den Boden eingearbeitet wurden" eh="2e43448f" />
     <e k="sf_weed_pressure_short" v="Unkraut" eh="53f8b936" />
-    <e k="sf_weed_pressure_long" v="Unkraut konkurriert mit den Kulturpflanzen um Wasser und N├ñhrstoffe und kann den Ertrag verringern" eh="ac99a865" />
-    <e k="sf_pest_pressure_short" v="Sch├ñdlinge" eh="18a7c2be" />
-    <e k="sf_pest_pressure_long" v="Sch├ñdlinge k├Ânnen Pflanzen sch├ñdigen und bei starkem Befall den Ertrag reduzieren" eh="2ba11abc" />
+    <e k="sf_weed_pressure_long" v="Unkraut konkurriert mit den Kulturpflanzen um Wasser und Nährstoffe und kann den Ertrag verringern" eh="ac99a865" />
+    <e k="sf_pest_pressure_short" v="Schädlinge" eh="18a7c2be" />
+    <e k="sf_pest_pressure_long" v="Schädlinge können Pflanzen schädigen und bei starkem Befall den Ertrag reduzieren" eh="2ba11abc" />
     <e k="sf_disease_pressure_short" v="Krankheiten" eh="2b805cc9" />
-    <e k="sf_disease_pressure_long" v="Ein Befall mit Krankheiten kann das Pflanzenwachstum beeintr├ñchtigen und zu Ertragsverlusten f├╝hren" eh="9080edbc" />
+    <e k="sf_disease_pressure_long" v="Ein Befall mit Krankheiten kann das Pflanzenwachstum beeinträchtigen und zu Ertragsverlusten führen" eh="9080edbc" />
     <e k="sf_compaction_short" v="Bodenverdichtung" eh="68734a56" />
     <e k="sf_compaction_long" v="Bodenverdichtungssystem durch schwere Fahrzeuge aktivieren/deaktivieren" eh="a0995ec5" />
     <e k="sf_fertility_short" v="Fruchtbarkeitssystem" eh="f7e27d58" />
     <e k="sf_fertility_long" v="Dynamisches Bodenfruchtbarkeitssystem ein-/ausschalten" eh="ea074366" />
-    <e k="sf_nutrients_short" v="N├ñhrstoffkreisl├ñufe" eh="ffab595d" />
-    <e k="sf_nutrients_long" v="Realistische N├ñhrstoffverarmung und -auff├╝llung ein-/ausschalten" eh="dbe9c8ff" />
+    <e k="sf_nutrients_short" v="Nährstoffkreisläufe" eh="ffab595d" />
+    <e k="sf_nutrients_long" v="Realistische Nährstoffverarmung und -auffüllung ein-/ausschalten" eh="dbe9c8ff" />
     <e k="sf_difficulty_short" v="Schwierigkeitsgrad" eh="7b29ca96" />
     <e k="sf_difficulty_long" v="Schwierigkeitsgrad festlegen: Einfach, Realistisch, Hardcore" eh="cfb758a4" />
     <e k="sf_diff_1" v="Einfach" eh="1fbb1e39" />
     <e k="sf_diff_2" v="Realistisch" eh="408c999f" />
     <e k="sf_diff_3" v="Hardcore" eh="1c800aa9" />
-    <e k="sf_fertilizer_cost_short" v="D├╝ngerkosten" eh="6870d88b" />
-    <e k="sf_fertilizer_cost_long" v="Realistische D├╝ngerkosten ein-/ausschalten" eh="12b03fbb" />
+    <e k="sf_fertilizer_cost_short" v="Düngerkosten" eh="6870d88b" />
+    <e k="sf_fertilizer_cost_long" v="Realistische Düngerkosten ein-/ausschalten" eh="12b03fbb" />
     <e k="sf_notifications_short" v="Benachrichtigungen" eh="a274f4d4" />
     <e k="sf_notifications_long" v="Benachrichtigungen ein-/ausschalten" eh="9a872f8f" />
     <e k="sf_show_hud_short" v="HUD anzeigen" eh="c94fd4d7" />
-    <e k="sf_show_hud_long" v="Info-HUD ein-/ausblenden (F8 zum tempor├ñren Umschalten)" eh="4e2e11b6" />
-    <e k="sf_show_work_trail_short" v="├£berfahrtsmarkierungen" eh="12a93dfa" />
-    <e k="sf_show_work_trail_long" v="├£berfahrtsmarkierungen von Erntemaschinen und Feldspritzen anzeigen" eh="25c58f0e" />
-    <e k="sf_show_sprayer_panel_short" v="├£bersicht Pflanzenschutzspritze" eh="0e8b3487" />
-    <e k="sf_show_sprayer_panel_long" v="Zeigt w├ñhrend der Nutzung einer Pflanzenschutzspritze eine detalierte ├£bersicht." eh="125a6e27" />
-    <e k="sf_show_harvester_panel_short" v="├£bersicht M├ñhdrescher" eh="e4fd0c77" />
-    <e k="sf_show_harvester_panel_long" v="Zeigt w├ñhrend der Ernte eine ├£bersicht f├╝r Bunker des M├ñhdreschers." eh="977f32e8" />
+    <e k="sf_show_hud_long" v="Info-HUD ein-/ausblenden (F8 zum temporären Umschalten)" eh="4e2e11b6" />
+    <e k="sf_show_work_trail_short" v="Überfahrtsmarkierungen" eh="12a93dfa" />
+    <e k="sf_show_work_trail_long" v="Überfahrtsmarkierungen von Erntemaschinen und Feldspritzen anzeigen" eh="25c58f0e" />
+    <e k="sf_show_sprayer_panel_short" v="Übersicht Pflanzenschutzspritze" eh="0e8b3487" />
+    <e k="sf_show_sprayer_panel_long" v="Zeigt während der Nutzung einer Pflanzenschutzspritze eine detalierte Übersicht." eh="125a6e27" />
+    <e k="sf_show_harvester_panel_short" v="Übersicht Mähdrescher" eh="e4fd0c77" />
+    <e k="sf_show_harvester_panel_long" v="Zeigt während der Ernte eine Übersicht für Bunker des Mähdreschers." eh="977f32e8" />
     <e k="sf_hud_position_short" v="HUD-Position" eh="5ac371f2" />
-    <e k="sf_hud_position_long" v="W├ñhle wo das Info-HUD angezeigt wird" eh="d7b9c109" />
+    <e k="sf_hud_position_long" v="Wähle wo das Info-HUD angezeigt wird" eh="d7b9c109" />
     <e k="sf_hud_pos_1" v="Oben rechts" eh="5f9f6784" />
     <e k="sf_hud_pos_2" v="Oben links" eh="ac71274a" />
     <e k="sf_hud_pos_3" v="Unten rechts" eh="4d297f5d" />
@@ -64,32 +64,32 @@
     <e k="sf_hud_pos_5" v="Mitte rechts" eh="d7afdc5a" />
     <e k="sf_hud_pos_6" v="Benutzerdefiniert" eh="90589c47" />
     <e k="sf_hud_color_theme_short" v="HUD-Farbschema" eh="4a73f95b" />
-    <e k="sf_hud_color_theme_long" v="W├ñhle das Farbschema f├╝r die Info-HUD" eh="3218bca6" />
-    <e k="sf_hud_color_1" v="Gr├╝n" eh="d382816a" />
+    <e k="sf_hud_color_theme_long" v="Wähle das Farbschema für die Info-HUD" eh="3218bca6" />
+    <e k="sf_hud_color_1" v="Grün" eh="d382816a" />
     <e k="sf_hud_color_2" v="Blau" eh="9594eec9" />
     <e k="sf_hud_color_3" v="Bernstein" eh="88068e33" />
     <e k="sf_hud_color_4" v="Monochrome" eh="5d9b47bd" />
     <e k="sf_diff_short" v="Schwierigkeit" eh="7b29ca96" />
     <e k="sf_diff_long" v="Schwierigkeitsgrad der Bodenverwaltung" eh="d6f4560c" />
-    <e k="sf_rr_short" v="D├╝ngereffizienz" eh="b363b336" />
-    <e k="sf_rr_long" v="Wie schnell D├╝nger die N├ñhrstoffe im Boden wiederherstellt (0,25x sehr langsam bis 2,0x sehr schnell)" eh="afe78a6d" />
+    <e k="sf_rr_short" v="Düngereffizienz" eh="b363b336" />
+    <e k="sf_rr_long" v="Wie schnell Dünger die Nährstoffe im Boden wiederherstellt (0,25x sehr langsam bis 2,0x sehr schnell)" eh="afe78a6d" />
     <e k="sf_dm_short" v="Klimazone" eh="86eac820" />
     <e k="sf_dm_long" v="[EN] Climate moisture level - controls how quickly fungal diseases build up and how long fungicide protection lasts" eh="23424d05" />
     <e k="sf_dm_1" v="Trocken" eh="cf9aa4a8" />
-    <e k="sf_dm_2" v="Gem├ñ├ƒigt" eh="e8328062" />
+    <e k="sf_dm_2" v="Gemäßigt" eh="e8328062" />
     <e k="sf_dm_3" v="Feucht" eh="ccb2fc34" />
     <e k="sf_dm_4" v="Nass" eh="ae789b86" />
     <e k="sf_auto_rate_short" v="DoseControl" eh="6f99137d" />
-    <e k="sf_auto_rate_long" v="Passt die ausgebrachte D├╝ngermenge automatisch an den aktuellen N├ñhrstoffbedarf des Feldes an." eh="a9ca9f6b" />
-    <e k="sf_hud_theme_1" v="Gr├╝n" eh="d382816a" />
+    <e k="sf_auto_rate_long" v="Passt die ausgebrachte Düngermenge automatisch an den aktuellen Nährstoffbedarf des Feldes an." eh="a9ca9f6b" />
+    <e k="sf_hud_theme_1" v="Grün" eh="d382816a" />
     <e k="sf_hud_theme_2" v="Blau" eh="9594eec9" />
     <e k="sf_hud_theme_3" v="Bernstein" eh="88068e33" />
     <e k="sf_hud_theme_4" v="Monochrome" eh="5d9b47bd" />
-    <e k="sf_hud_font_size_short" v="HUD-Schriftgr├Â├ƒe" eh="fd6ca64a" />
-    <e k="sf_hud_font_size_long" v="HUD-Schriftgr├Â├ƒe f├╝r eine bessere Lesbarkeit anpassen" eh="c338854f" />
+    <e k="sf_hud_font_size_short" v="HUD-Schriftgröße" eh="fd6ca64a" />
+    <e k="sf_hud_font_size_long" v="HUD-Schriftgröße für eine bessere Lesbarkeit anpassen" eh="c338854f" />
     <e k="sf_hud_font_1" v="Klein" eh="2660064e" />
     <e k="sf_hud_font_2" v="Mittel" eh="87f8a6ab" />
-    <e k="sf_hud_font_3" v="Gro├ƒ" eh="3a69b34c" />
+    <e k="sf_hud_font_3" v="Groß" eh="3a69b34c" />
     <e k="sf_hud_transparency_short" v="HUD-Transparenz" eh="e8a009e4" />
     <e k="sf_hud_transparency_long" v="Hintergrundtransparenz der HUD festlegen" eh="152e390a" />
     <e k="sf_hud_trans_1" v="Durchsichtig" eh="dc30bc0c" />
@@ -100,28 +100,28 @@
     <e k="sf_use_imperial_short" v="Imperiale Einheiten" eh="ff2701ad" />
     <e k="sf_use_imperial_long" v="Einheiten werden in gal/ac und lb/ac dargestellt." eh="17efa489" />
     <e k="sf_active_map_layer_short" v="Aktive Kartenebene" eh="1861765f" />
-    <e k="sf_active_map_layer_long" v="N├ñhrstoffebene, die als Overlay in der PDA-Karte angezeigt wird" eh="d7755cc8" />
+    <e k="sf_active_map_layer_long" v="Nährstoffebene, die als Overlay in der PDA-Karte angezeigt wird" eh="d7755cc8" />
     <e k="sf_overlay_density_short" v="Kartendetails" eh="a525859a" />
-    <e k="sf_overlay_density_long" v="Abtastpunktbudget f├╝r das PDA-Bodenoverlay. Niedrig = bessere FPS, Hoch = vollst├ñndigere Abdeckung auf gro├ƒen Karten." eh="89215ce5" />
-    <e k="sf_colorblind_mode_short" v="Modus f├╝r Farbenblinde" eh="d5a644f4" />
-    <e k="sf_colorblind_mode_long" v="Ersetzt Rot und Gr├╝n durch Orange und Blau (Okabe-Ito-Palette), um die Barrierefreiheit f├╝r Personen mit Deuteranopie und Protanopie zu gew├ñhrleisten." eh="4de2f9fb" />
+    <e k="sf_overlay_density_long" v="Abtastpunktbudget für das PDA-Bodenoverlay. Niedrig = bessere FPS, Hoch = vollständigere Abdeckung auf großen Karten." eh="89215ce5" />
+    <e k="sf_colorblind_mode_short" v="Modus für Farbenblinde" eh="d5a644f4" />
+    <e k="sf_colorblind_mode_long" v="Ersetzt Rot und Grün durch Orange und Blau (Okabe-Ito-Palette), um die Barrierefreiheit für Personen mit Deuteranopie und Protanopie zu gewährleisten." eh="4de2f9fb" />
     <e k="sf_show_field_info_box_short" v="Feldinfo" eh="bf8bc5c7" />
-    <e k="sf_show_field_info_box_long" v="Zeige die N├ñhrstoffe in der Standard-Feldinfo w├ñhrend du auf einem Feld stehst." eh="f7cd7156" />
-    <e k="input_SF_OPEN_SETTINGS" v="Einstellungen ├Âffnen" eh="2e31c0dd" />
-    <e k="sf_reset" v="Einstellungen zur├╝cksetzen" eh="467bc2f5" />
+    <e k="sf_show_field_info_box_long" v="Zeige die Nährstoffe in der Standard-Feldinfo während du auf einem Feld stehst." eh="f7cd7156" />
+    <e k="input_SF_OPEN_SETTINGS" v="Einstellungen öffnen" eh="2e31c0dd" />
+    <e k="sf_reset" v="Einstellungen zurücksetzen" eh="467bc2f5" />
     <e k="input_SF_TOGGLE_HUD" v="HUD umschalten" eh="f0224a10" />
     <e k="input_SF_HUD_DRAG" v="HUD-Ziehmodus" eh="cb2eb762" />
     <e k="input_SF_SOIL_REPORT" v="Bodenbericht" eh="c33180ef" />
     <e k="input_SF_TOGGLE_CELL_MAP" v="Boden-Zellenkarte umschalten" eh="3a7e9b9d" />
-    <e k="input_SF_RATE_UP" v="Ausbringmenge erh├Âhen" eh="6e601ef5" />
+    <e k="input_SF_RATE_UP" v="Ausbringmenge erhöhen" eh="6e601ef5" />
     <e k="input_SF_RATE_DOWN" v="Ausbringmenge verringern" eh="30712026" />
     <e k="input_SF_TOGGLE_AUTO" v="DoseControl umschalten" eh="a8642cf0" />
     <e k="input_SF_CYCLE_MAP_LAYER" v="Bodenebene wechseln" eh="8e4a716c" />
-    <e k="input_SF_SOIL_PDA" v="Boden-PDA ├Âffnen" eh="7d70f7b4" />
-    <e k="input_SF_SENSOR_PEST"       v="Sch├ñdlingssensor umschalten" />
+    <e k="input_SF_SOIL_PDA" v="Boden-PDA öffnen" eh="7d70f7b4" />
+    <e k="input_SF_SENSOR_PEST"       v="Schädlingssensor umschalten" />
     <e k="input_SF_SENSOR_DISEASE"    v="Krankheitssensor umschalten" />
-    <e k="input_SF_SENSOR_NUTRIENT"   v="N├ñhrstoffsensor umschalten" />
-    <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Sch├ñdlinge" />
+    <e k="input_SF_SENSOR_NUTRIENT"   v="Nährstoffsensor umschalten" />
+    <e k="input_SF_SEE_SPRAY_PEST"    v="See &amp; Spray: Schädlinge" />
     <e k="input_SF_SEE_SPRAY_DISEASE" v="See &amp; Spray: Krankheit" eh="a5e476a8" />
     <e k="input_SF_SEE_SPRAY_WEED"    v="See &amp; Spray: Unkraut" />
     <e k="input_SF_VARIABLE_RATE"     v="Variable Ausbringmenge umschalten" />
@@ -131,14 +131,14 @@
     <e k="sf_uan32_title" v="AHL-32" eh="90913bb8" />
     <e k="sf_uan28_title" v="AHL-28" eh="9d902cd7" />
     <e k="sf_anhydrous_title" v="Wasserfreies Ammoniak" eh="3fc85c02" />
-    <e k="sf_starter_title" v="Starterd├╝nger" eh="8c1a1ddc" />
+    <e k="sf_starter_title" v="Starterdünger" eh="8c1a1ddc" />
     <e k="sf_urea_title" v="Harnstoff" eh="659b3097" />
     <e k="sf_an_title" v="KAS" eh="29f6ee93" />
     <e k="sf_ams_title" v="Ammoniumsulfat" eh="033d1845" />
     <e k="sf_map_title" v="MAP" eh="31aa2534" />
     <e k="sf_dap_title" v="DAP" eh="5030a80a" />
     <e k="sf_potash_title" v="Kaliumchlorid" eh="8db6c54c" />
-    <e k="sf_polifoska_title" v="NPK-Mehrn├ñhrstoffd├╝nger" eh="6c3cba26" />
+    <e k="sf_polifoska_title" v="NPK-Mehrnährstoffdünger" eh="6c3cba26" />
     <e k="sf_liquid_urea_title" v="Harnstoff" eh="7fee4f12" />
     <e k="sf_liquid_ams_title" v="Ammoniumsulfat" eh="0daf3a6f" />
     <e k="sf_liquid_map_title" v="MAP" eh="3ce7c8c9" />
@@ -148,198 +148,198 @@
     <e k="sf_fungicide_title" v="Fungizid" eh="e8512698" />
     <!-- liquid fertilizer -->
     <e k="sf_bigBag_uan32_name" v="AHL-32 32-0-0" eh="574747ce" />
-    <e k="sf_bigBag_uan32_function" v="Fl├╝ssiger D├╝nger mit 32 % N. Aufwandmenge: 60,8 l/ha (entspricht ca. 49 kg N/ha)." eh="8ab6b497" />
+    <e k="sf_bigBag_uan32_function" v="Flüssiger Dünger mit 32 % N. Aufwandmenge: 60,8 l/ha (entspricht ca. 49 kg N/ha)." eh="8ab6b497" />
     <e k="sf_bigBag_uan28_name" v="AHL-28 28-0-0" eh="7eeec815" />
-    <e k="sf_bigBag_uan28_function" v="Fl├╝ssiger D├╝nger mit 28 % N. Aufwandmenge: 60,8 l/ha (entspricht ca. 43 kg N/ha)" eh="1936bc46" />
+    <e k="sf_bigBag_uan28_function" v="Flüssiger Dünger mit 28 % N. Aufwandmenge: 60,8 l/ha (entspricht ca. 43 kg N/ha)" eh="1936bc46" />
     <e k="sf_bigBag_anhydrous_name" v="Wasserfreies Ammoniak 82-0-0" eh="fb09e6ce" />
-    <e k="sf_bigBag_anhydrous_function" v="Fl├╝ssiger D├╝nger mit 82 % N. Aufwandmenge: 28 l/ha (entspricht ca. 75 kg N/ha)." eh="3b8abc2e" />
-    <e k="sf_bigBag_liquid_urea_name" v="Fl├╝ssigharnstoff" eh="c40b906f" />
-    <e k="sf_bigBag_liquid_urea_function" v="Fl├╝ssiger D├╝nger mit 46 % N. Aufwandmenge: 168 l/ha (entspricht ca. 87 kg N/ha)." eh="5cc8784e" />
+    <e k="sf_bigBag_anhydrous_function" v="Flüssiger Dünger mit 82 % N. Aufwandmenge: 28 l/ha (entspricht ca. 75 kg N/ha)." eh="3b8abc2e" />
+    <e k="sf_bigBag_liquid_urea_name" v="Flüssigharnstoff" eh="c40b906f" />
+    <e k="sf_bigBag_liquid_urea_function" v="Flüssiger Dünger mit 46 % N. Aufwandmenge: 168 l/ha (entspricht ca. 87 kg N/ha)." eh="5cc8784e" />
     <e k="sf_bigBag_liquid_ams_name" v="Ammoniumsulfat" eh="32e6c8bb" />
-    <e k="sf_bigBag_liquid_ams_function" v="Fl├╝ssiger D├╝nger (SSA/AMS 21-0-0-24) mit 21 % N und 24 % S. Aufwandmenge: 168 l/ha (entspricht ca. 37 kg N/ha)." eh="1ac16a61" />
+    <e k="sf_bigBag_liquid_ams_function" v="Flüssiger Dünger (SSA/AMS 21-0-0-24) mit 21 % N und 24 % S. Aufwandmenge: 168 l/ha (entspricht ca. 37 kg N/ha)." eh="1ac16a61" />
     <e k="sf_bigBag_liquid_map_name" v="MAP (Monoammonphosphat)" eh="4628addb" />
-    <e k="sf_bigBag_liquid_map_function" v="Fl├╝ssiger D├╝nger mit 11 % N und 52 % PÔééOÔéà. Aufwandmenge: 225 l/ha (entspricht ca. 9 kg N/ha und 63 kg PÔééOÔéà/ha)." eh="5003a806" />
+    <e k="sf_bigBag_liquid_map_function" v="Flüssiger Dünger mit 11 % N und 52 % P2O5. Aufwandmenge: 225 l/ha (entspricht ca. 9 kg N/ha und 63 kg P2O5/ha)." eh="5003a806" />
     <e k="sf_bigBag_liquid_dap_name" v="DAP (Diammonphosphat)" eh="82fb3c06" />
-    <e k="sf_bigBag_liquid_dap_function" v="Fl├╝ssiger NP-D├╝nger (DAP 18-46-0) mit 18 % N und 46 % PÔééOÔéà. Aufwandmenge: 225 l/ha (entspricht ca. 12 kg N/ha und 49 kg PÔééOÔéà/ha)." eh="5aad6141" />
+    <e k="sf_bigBag_liquid_dap_function" v="Flüssiger NP-Dünger (DAP 18-46-0) mit 18 % N und 46 % P2O5. Aufwandmenge: 225 l/ha (entspricht ca. 12 kg N/ha und 49 kg P2O5/ha)." eh="5aad6141" />
     <e k="sf_bigBag_liquid_potash_name" v="Kaliumchlorid" eh="7176856d" />
-    <e k="sf_bigBag_liquid_potash_function" v="Fl├╝ssiger D├╝nger mit 60 % KÔééO. Aufwandmenge: 225 l/ha (entspricht ca. 90 kg KÔééO/ha)." eh="9fd649bb" />  
-    <e k="sf_bigBag_starter_name" v="Starterd├╝nger 10-34-0" eh="62b13bd1" />
-    <e k="sf_bigBag_starter_function" v="Fl├╝ssiger D├╝nger mit 10 % N und 34 % PÔééOÔéà. Aufwandmenge: 46,8 l/ha (entspricht ca. 10 kg N/ha und 19 kg P/ha)." eh="0b63e473" />
+    <e k="sf_bigBag_liquid_potash_function" v="Flüssiger Dünger mit 60 % K2O. Aufwandmenge: 225 l/ha (entspricht ca. 90 kg K2O/ha)." eh="9fd649bb" />  
+    <e k="sf_bigBag_starter_name" v="Starterdünger 10-34-0" eh="62b13bd1" />
+    <e k="sf_bigBag_starter_function" v="Flüssiger Dünger mit 10 % N und 34 % P2O5. Aufwandmenge: 46,8 l/ha (entspricht ca. 10 kg N/ha und 19 kg P/ha)." eh="0b63e473" />
     <!-- solid fertilizer -->
     <e k="sf_bigBag_urea_name" v="Harnstoff 46-0-0" eh="8e8cbaae" />
-    <e k="sf_bigBag_urea_function" v="Fester D├╝nger mit 46 % N. Aufwandmenge: 168 kg/ha (entspricht ca. 78 kg N/ha)." eh="c62ae97e" />
+    <e k="sf_bigBag_urea_function" v="Fester Dünger mit 46 % N. Aufwandmenge: 168 kg/ha (entspricht ca. 78 kg N/ha)." eh="c62ae97e" />
     <e k="sf_bigBag_an_name" v="KAS (Kalkammonsalpeter) 34,5-0-0" eh="45f56f60" />
-    <e k="sf_bigBag_an_function" v="Fester D├╝nger mit 34,5 % N. Aufwandmenge: 200 kg/ha (entspricht ca. 68 kg N/ha)." eh="d5f6bb4d" />
+    <e k="sf_bigBag_an_function" v="Fester Dünger mit 34,5 % N. Aufwandmenge: 200 kg/ha (entspricht ca. 68 kg N/ha)." eh="d5f6bb4d" />
     <e k="sf_bigBag_ams_name" v="Ammoniumsulfat 21-0-0-24S" eh="7f71ee68" />
-    <e k="sf_bigBag_ams_function" v="Fester D├╝nger mit 21 % N und 24 % S. Aufwandmenge: 168 kg/ha (entspricht ca. 33 kg N/ha)." eh="17e21469" />
+    <e k="sf_bigBag_ams_function" v="Fester Dünger mit 21 % N und 24 % S. Aufwandmenge: 168 kg/ha (entspricht ca. 33 kg N/ha)." eh="17e21469" />
     <e k="sf_bigBag_map_name" v="MAP (Monoammonphosphat) 11-52-0" eh="8a5a059b" />
-    <e k="sf_bigBag_map_function" v="Fester D├╝nger mit 11 % N und 52 % PÔééOÔéà. Aufwandmenge: 225 kg/ha (entspricht ca. 8 kg N/ha und 56 kg PÔééOÔéà/ha)." eh="30ce16a7" />
+    <e k="sf_bigBag_map_function" v="Fester Dünger mit 11 % N und 52 % P2O5. Aufwandmenge: 225 kg/ha (entspricht ca. 8 kg N/ha und 56 kg P2O5/ha)." eh="30ce16a7" />
     <e k="sf_bigBag_dap_name" v="DAP (Diammonphosphat) 18-46-0" eh="fb4e9987" />
-    <e k="sf_bigBag_dap_function" v="Fester D├╝nger mit 18 % N und 46 % PÔééOÔéà. Aufwandmenge: 225 kg/ha (entspricht ca. 11 kg N/ha und 44 kg PÔééOÔéà/ha)." eh="bb645b95" />    
+    <e k="sf_bigBag_dap_function" v="Fester Dünger mit 18 % N und 46 % P2O5. Aufwandmenge: 225 kg/ha (entspricht ca. 11 kg N/ha und 44 kg P2O5/ha)." eh="bb645b95" />    
     <e k="sf_bigBag_potash_name" v="Kaliumchlorid 0-0-60" eh="eb771556" />
-    <e k="sf_bigBag_potash_function" v="Fester D├╝nger 60 % KÔééO. Aufwandmenge: 225 kg/ha (entspricht ca. 90 kg KÔééO/ha)." eh="4f9d6019" />
-    <e k="sf_bigBag_polifoska_name" v="NPK-Mehrn├ñhrstoffd├╝nger 6-20-30" eh="33366162" />
-    <e k="sf_bigBag_polifoska_function" v="Fester D├╝nger mit 6 % N, 20 % PÔééOÔéà und 30 % KÔééO. Aufwandmenge: 250 kg/ha (entspricht ca. 4 kg N/ha, 21 kg PÔééOÔéà/ha und 50 kg KÔééO/ha)." eh="be40f0f6" />
+    <e k="sf_bigBag_potash_function" v="Fester Dünger 60 % K2O. Aufwandmenge: 225 kg/ha (entspricht ca. 90 kg K2O/ha)." eh="4f9d6019" />
+    <e k="sf_bigBag_polifoska_name" v="NPK-Mehrnährstoffdünger 6-20-30" eh="33366162" />
+    <e k="sf_bigBag_polifoska_function" v="Fester Dünger mit 6 % N, 20 % P2O5 und 30 % K2O. Aufwandmenge: 250 kg/ha (entspricht ca. 4 kg N/ha, 21 kg P2O5/ha und 50 kg K2O/ha)." eh="be40f0f6" />
     <!-- misc -->
     <e k="sf_bigBag_insecticide_name" v="Insektizid" eh="c8f0aabb" />
-    <e k="sf_bigBag_insecticide_function" v="Breitbandinsektizid Fertigmischung. Pflanzenschutzmittel zur Anwendung gegen Unkr├ñuter und -gr├ñser." eh="09580f6b" />
+    <e k="sf_bigBag_insecticide_function" v="Breitbandinsektizid Fertigmischung. Pflanzenschutzmittel zur Anwendung gegen Unkräuter und -gräser." eh="09580f6b" />
     
     <e k="sf_bigBag_fungicide_name" v="Fungizid" eh="2a1c78d4" />
     <e k="sf_bigBag_fungicide_function" v="Breitbandfungizid Fertigmischung. Pflanzenschutzmittel zur Anwendung gegen Pilzerkrankungen." eh="745c34cb" />
     
     <e k="sf_bigBag_gypsum_name" v="Gips" eh="40fc8169" />
-    <e k="sf_bigBag_gypsum_function" v="Fester D├╝nger mit pH-Wert -0,15 pro Gabe bei 1500 kg/ha Aufwandmenge" eh="c33d39bf" />
+    <e k="sf_bigBag_gypsum_function" v="Fester Dünger mit pH-Wert -0,15 pro Gabe bei 1500 kg/ha Aufwandmenge" eh="c33d39bf" />
     
     <e k="sf_bigBag_compost_name" v="Kompost" eh="14322c5d" />
     <e k="sf_bigBag_compost_10k_name" v="Kompost XXL" eh="760ccc30" />
-    <e k="sf_bigBag_compost_function" v="Fester D├╝nger mit +11 kg N/ha, +2 kg P/ha, +11 kg K/ha, +3,0 % organische Substanz bei 5 t/ha Aufwandmenge" eh="114f28ca" />
+    <e k="sf_bigBag_compost_function" v="Fester Dünger mit +11 kg N/ha, +2 kg P/ha, +11 kg K/ha, +3,0 % organische Substanz bei 5 t/ha Aufwandmenge" eh="114f28ca" />
     
-    <e k="sf_bigBag_biosolids_name" v="Kl├ñrschlammpellets" eh="61a60ff3" />
-    <e k="sf_bigBag_biosolids_10k_name" v="Kl├ñrschlammpellets XXL" eh="53b60563" />
-    <e k="sf_bigBag_biosolids_function" v="Fester D├╝nger mit +28 kg N/ha, +3 kg P/ha, +22 kg K/ha, +2,0 % organische Substanz bei 4,5 t/ha Aufwandmenge" eh="421466e9" />
+    <e k="sf_bigBag_biosolids_name" v="Klärschlammpellets" eh="61a60ff3" />
+    <e k="sf_bigBag_biosolids_10k_name" v="Klärschlammpellets XXL" eh="53b60563" />
+    <e k="sf_bigBag_biosolids_function" v="Fester Dünger mit +28 kg N/ha, +3 kg P/ha, +22 kg K/ha, +2,0 % organische Substanz bei 4,5 t/ha Aufwandmenge" eh="421466e9" />
     
-    <e k="sf_bigBag_chicken_manure_name" v="H├╝hnermist" eh="cb60fddc" />
-    <e k="sf_bigBag_chicken_manure_10k_name" v="H├╝hnermist XXL" eh="dd621023" />
-    <e k="sf_bigBag_chicken_manure_function" v="Fester D├╝nger mit - +22 kg N/ha, +3 kg P/ha, +22 kg K/ha, +1,1 % organische Substanz bei 2 t/ha Aufwandemenge" eh="ad6e0186" />
+    <e k="sf_bigBag_chicken_manure_name" v="Hühnermist" eh="cb60fddc" />
+    <e k="sf_bigBag_chicken_manure_10k_name" v="Hühnermist XXL" eh="dd621023" />
+    <e k="sf_bigBag_chicken_manure_function" v="Fester Dünger mit - +22 kg N/ha, +3 kg P/ha, +22 kg K/ha, +1,1 % organische Substanz bei 2 t/ha Aufwandemenge" eh="ad6e0186" />
 
     <e k="sf_bigBag_pelletized_manure_name" v="Mistpellets" eh="064be7fa" />
     <e k="sf_bigBag_pelletized_manure_10k_name" v="Mistpellets XXL" eh="261ca096" />
-    <e k="sf_bigBag_pelletized_manure_function" v="Fester D├╝nger mit - +22 kg N/ha, +2 kg P/ha, +33 kg K/ha bei 450 kg/ha Aufwandemenge" eh="ef34da4c" />
+    <e k="sf_bigBag_pelletized_manure_function" v="Fester Dünger mit - +22 kg N/ha, +2 kg P/ha, +33 kg K/ha bei 450 kg/ha Aufwandemenge" eh="ef34da4c" />
 
     <e k="sf_bigBag_liquidlime_name" v="Kalk" eh="4f8caca1" />
-    <e k="sf_bigBag_liquidlime_function" v="Fl├╝ssiger D├╝nger mit pH-Wert +0,40 pro Gabe bei 374 l/ha Aufwandemenge" eh="352515b3" />
+    <e k="sf_bigBag_liquidlime_function" v="Flüssiger Dünger mit pH-Wert +0,40 pro Gabe bei 374 l/ha Aufwandemenge" eh="352515b3" />
     
     <e k="sf_hud_title" v="BODENMONITOR" eh="f8cda642" />
     <e k="sf_hud_field" v="Feld %d" eh="08988997" />
     <e k="sf_hud_noField" v="Gehe auf ein Feld" eh="62c55e9e" />
     <e k="sf_sprayer_no_field" v="Fahre auf ein Feld." eh="f238e4b8" />
     <e k="sf_hud_fallow" v="Brachland" eh="eafe5913" />
-		<e k="sf_hud_meadow" v="Gr├╝nland" eh="f34c07d8" />
+		<e k="sf_hud_meadow" v="Grünland" eh="f34c07d8" />
 		<e k="sf_hud_asleep" v="Stilllegung" eh="0af05a4e" />
     <e k="sf_hud_weeds" v="Unkraut" eh="0ec7e90d" />
-    <e k="sf_hud_pests" v="Sch├ñdling" eh="2fed5101" />
+    <e k="sf_hud_pests" v="Schädling" eh="2fed5101" />
     <e k="sf_hud_disease" v="Krankheit" eh="e7067a8c" />
-    <e k="sf_hud_disease_unknown" v="Bestimme die Erkrankung zun├ñchst." eh="a6fe3f43" />
-    <e k="sf_hud_protected" v="(gesch├╝tzt)" eh="8273211e" />
+    <e k="sf_hud_disease_unknown" v="Bestimme die Erkrankung zunächst." eh="a6fe3f43" />
+    <e k="sf_hud_protected" v="(geschützt)" eh="8273211e" />
     <e k="sf_hud_yield" v="Ertrag" eh="97345487" />
-    <e k="sf_hud_estYield" v="gesch├ñtzter Ertrag" eh="32a4135e" />
+    <e k="sf_hud_estYield" v="geschätzter Ertrag" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
-    <e k="sf_hud_hint_edit" v="Ziehen: Bewegen   Ecke: Gr├Â├ƒe   Rechtsklick oder Umschalt+H: Beenden" eh="c3f1820c" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
+    <e k="sf_hud_hint_edit" v="Ziehen: Bewegen   Ecke: Größe   Rechtsklick oder Umschalt+H: Beenden" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Umschalt+H: Bearbeitungsmodus" eh="f1d565b1" />
-    <e k="sf_incompatibility_pf_title" v="Inkompatibilit├ñt erkannt" eh="89dbfc90" />
-    <e k="sf_incompatibility_pf_text" v="Die Realistische B├Âden &amp; D├╝ngung-Mod wurde f├╝r diesen Spielstand deaktiviert, weil das Precision Farming DLC aktiv ist. Beide Mods verwalten Bodenn├ñhrstoffe und k├Ânnen nicht gleichzeitig genutzt werden. Um die Realistische B├Âden &amp; D├╝ngung-Mod zu nutzen, deaktiviere einfach Precision Farming f├╝r diesen Spielstand im Mod-Auswahlbildschirm." eh="91dbcf1b" />
+    <e k="sf_incompatibility_pf_title" v="Inkompatibilität erkannt" eh="89dbfc90" />
+    <e k="sf_incompatibility_pf_text" v="Die Realistische Böden &amp; Düngung-Mod wurde für diesen Spielstand deaktiviert, weil das Precision Farming DLC aktiv ist. Beide Mods verwalten Bodennährstoffe und können nicht gleichzeitig genutzt werden. Um die Realistische Böden &amp; Düngung-Mod zu nutzen, deaktiviere einfach Precision Farming für diesen Spielstand im Mod-Auswahlbildschirm." eh="91dbcf1b" />
 
-    <e k="helpLine_sf_cat_overview" v="├£bersicht" eh="3b878279" />
-    <e k="helpLine_sf_cat_started" v="F├╝r Einsteiger" eh="bf647454" />
+    <e k="helpLine_sf_cat_overview" v="Übersicht" eh="3b878279" />
+    <e k="helpLine_sf_cat_started" v="Für Einsteiger" eh="bf647454" />
     <e k="helpLine_sf_cat_nutrients" v="Bodeneigenschaften" eh="64377acf" />
-    <e k="helpLine_sf_cat_fertilizers" v="D├╝ngemittel" eh="754d59bd" />
+    <e k="helpLine_sf_cat_fertilizers" v="Düngemittel" eh="754d59bd" />
     <e k="helpLine_sf_cat_hud" v="HUD, Bodenproben und Feldbonitur" eh="655b1b40" />
     <e k="helpLine_sf_cat_settings" v="Einstellungen" eh="f4f70727" />
     <e k="helpLine_sf_cat_multiplayer" v="Multiplayer" eh="901a7320" />
 
     <e k="helpLine_sf_ov_p1_title" v="Funktionsweise" eh="46cbb25b" />
     <e k="helpLine_sf_ov_p1_intro_title" v="Feldspezifischer Boden" eh="8fe3248d" />
-    <e k="helpLine_sf_ov_p1_intro_text" v="Jedes Feld verf├╝gt ├╝ber eine eigene Bodenbilanz, die f├╝nf wichtige Bodeneigenschaften beachtet: Stickstoff (N), Phosphor (P), Kalium (K), organische Substanz (OS) und den pH-Wert. Diese Werte werden dauerhaft im Spielstand gespeichert und bleiben auch nach dem Beenden und erneuten Laden des Spiels erhalten." eh="c30216e6" />
+    <e k="helpLine_sf_ov_p1_intro_text" v="Jedes Feld verfügt über eine eigene Bodenbilanz, die fünf wichtige Bodeneigenschaften beachtet: Stickstoff (N), Phosphor (P), Kalium (K), organische Substanz (OS) und den pH-Wert. Diese Werte werden dauerhaft im Spielstand gespeichert und bleiben auch nach dem Beenden und erneuten Laden des Spiels erhalten." eh="c30216e6" />
 
-    <e k="helpLine_sf_ov_p1_flow_title" v="Der N├ñhrstoffkreislauf" eh="15b0d408" />
-    <e k="helpLine_sf_ov_p1_flow_text" v="Durch das Pflanzenwachstum und die Ernte werden dem Boden N├ñhrstoffe entzogen. Mineralische D├╝nger, Wirtschaftsd├╝nger wie Mist und G├╝lle sowie Kalkungsma├ƒnahmen gleichen diese Verluste wieder aus. Die Mod simuliert eine realistische N├ñhrstoffbilanz: Was die Kultur dem Boden entzieht, muss ├╝ber die D├╝ngung wieder zugef├╝hrt werden, um die Bodenfruchtbarkeit langfristig zu erhalten." eh="418041f0" />
+    <e k="helpLine_sf_ov_p1_flow_title" v="Der Nährstoffkreislauf" eh="15b0d408" />
+    <e k="helpLine_sf_ov_p1_flow_text" v="Durch das Pflanzenwachstum und die Ernte werden dem Boden Nährstoffe entzogen. Mineralische Dünger, Wirtschaftsdünger wie Mist und Gülle sowie Kalkungsmaßnahmen gleichen diese Verluste wieder aus. Die Mod simuliert eine realistische Nährstoffbilanz: Was die Kultur dem Boden entzieht, muss über die Düngung wieder zugeführt werden, um die Bodenfruchtbarkeit langfristig zu erhalten." eh="418041f0" />
 
     <e k="helpLine_sf_ov_p2_title" v="Umwelteffekte" eh="e139e84f" />
     <e k="helpLine_sf_ov_p2_rain_title" v="Regen" eh="33e0d8ea" />
-    <e k="helpLine_sf_ov_p2_rain_text" v="Starker Regen kann N├ñhrstoffe auswaschen. Stickstoff wird dabei am st├ñrksten ausgewaschen, gefolgt von Kalium und Phosphor. Er s├ñuert den Boden dadurch ├╝ber die Zeit auch langsam an. Dieser Effekt kann in den Einstellungen deaktiviert werden." eh="91e39cc6" />
-    <e k="helpLine_sf_ov_p2_season_title" v="Jahreszeiten und Brachfl├ñchen" eh="ad2009c8" />
-    <e k="helpLine_sf_ov_p2_season_text" v="Im Fr├╝hjahr werden durch biologische Aktivit├ñt t├ñglich geringe Mengen Stickstoff (+0,03 N/Tag) im Boden mineralisiert und pflanzenverf├╝gbar. Im Herbst nimmt der verf├╝gbare Stickstoffvorrat leicht ab (-0,02 N/Tag). Felder, die l├ñnger als 7 Spieltage unbewirtschaftet bleiben, regenerieren ihre N├ñhrstoffvorr├ñte langsam durch nat├╝rliche Bodenprozesse." eh="e5ebb3b2" />
+    <e k="helpLine_sf_ov_p2_rain_text" v="Starker Regen kann Nährstoffe auswaschen. Stickstoff wird dabei am stärksten ausgewaschen, gefolgt von Kalium und Phosphor. Er säuert den Boden dadurch über die Zeit auch langsam an. Dieser Effekt kann in den Einstellungen deaktiviert werden." eh="91e39cc6" />
+    <e k="helpLine_sf_ov_p2_season_title" v="Jahreszeiten und Brachflächen" eh="ad2009c8" />
+    <e k="helpLine_sf_ov_p2_season_text" v="Im Frühjahr werden durch biologische Aktivität täglich geringe Mengen Stickstoff (+0,03 N/Tag) im Boden mineralisiert und pflanzenverfügbar. Im Herbst nimmt der verfügbare Stickstoffvorrat leicht ab (-0,02 N/Tag). Felder, die länger als 7 Spieltage unbewirtschaftet bleiben, regenerieren ihre Nährstoffvorräte langsam durch natürliche Bodenprozesse." eh="e5ebb3b2" />
 
     <e k="helpLine_sf_gs_p1_title" v="Was mache ich zuerst?" eh="bdd0e0a7" />
-    <e k="helpLine_sf_gs_p1_hud_title" v="HUD ├ûffnen" eh="e1bdea72" />
-    <e k="helpLine_sf_gs_p1_hud_text" v="Dr├╝cke die Taste J, um eine Auswertung in Echtzeit ├╝ber den Boden deines Feldes zu erhalten. Du siehst die Verf├╝gbarkeit von N, P, K, pH und organischer Substanz (OS) f├╝r das jeweilige Feld, auf dem du stehst. Es werden Bewertungen wie Gut, Mittel oder Schlecht vergeben. Damit siehst du auf einen Blick worauf du deine Aufmerksamkeit als erste legen solltest." eh="53cef520" />
-    <e k="helpLine_sf_gs_p1_report_title" v="Bodenbericht ├ûffnen" eh="e71446cd" />
-    <e k="helpLine_sf_gs_p1_report_text" v="Dr├╝cke die Taste K, um eine vollst├ñndige Analyse des Bodens deines Hofes zu ├Âffnen. Jedes Feld ist mit einem N├ñhrstoffstatus aufgelistet, farblich markiert und nach Handlungsbedarf sortiert. Klicke auf den Pfeil in einer Zeile um eine Detailansicht mit Empfehlungen zu ├Âffnen." eh="9a0d32a6" />
+    <e k="helpLine_sf_gs_p1_hud_title" v="HUD Öffnen" eh="e1bdea72" />
+    <e k="helpLine_sf_gs_p1_hud_text" v="Drücke die Taste J, um eine Auswertung in Echtzeit über den Boden deines Feldes zu erhalten. Du siehst die Verfügbarkeit von N, P, K, pH und organischer Substanz (OS) für das jeweilige Feld, auf dem du stehst. Es werden Bewertungen wie Gut, Mittel oder Schlecht vergeben. Damit siehst du auf einen Blick worauf du deine Aufmerksamkeit als erste legen solltest." eh="53cef520" />
+    <e k="helpLine_sf_gs_p1_report_title" v="Bodenbericht Öffnen" eh="e71446cd" />
+    <e k="helpLine_sf_gs_p1_report_text" v="Drücke die Taste K, um eine vollständige Analyse des Bodens deines Hofes zu öffnen. Jedes Feld ist mit einem Nährstoffstatus aufgelistet, farblich markiert und nach Handlungsbedarf sortiert. Klicke auf den Pfeil in einer Zeile um eine Detailansicht mit Empfehlungen zu öffnen." eh="9a0d32a6" />
 
-    <e k="helpLine_sf_gs_p2_title" v="D├╝ngung und Ernte" eh="1a52ac04" />
-    <e k="helpLine_sf_gs_p2_fert_title" v="Felder d├╝ngen" eh="ea52ec26" />
-    <e k="helpLine_sf_gs_p2_fert_text" v="Bringe D├╝nger mit jeder Standard-Spritze oder jedem Streuer aus. Die Mod erkennt alle D├╝ngertypen des Basisspiels sowie 9 zus├ñtzliche Speziald├╝nger wie AHL 32, Monoammonphosphat oder Kaliumchlorid. Jeder D├╝nger liefert unterschiedliche N├ñhrstoffe und beeinflusst dadurch gezielt die Bodenbilanz. Eine vollst├ñndige ├£bersicht aller D├╝nger und ihrer Eigenschaften findest du in der Kategorie D├╝ngemittel." eh="fe906e29" />
-    <e k="helpLine_sf_gs_p2_harvest_title" v="N├ñhrstoffentzug" eh="a67b6cb5" />
-    <e k="helpLine_sf_gs_p2_harvest_text" v="Mit jeder Ernte werden dem Boden N├ñhrstoffe entzogen. Stark zehrende Kulturen wie Kartoffeln, Zuckerr├╝ben oder Sojabohnen ben├Âtigen deutlich mehr N├ñhrstoffe als schwach zehrende Kulturen wie Gerste oder Hafer. ├£berpr├╝fe nach jeder Ernte den Bodenstatus im HUD oder im Bodenbericht, um den N├ñhrstoffbedarf deines Feldes im Blick zu behalten." eh="63f90ed4" />
+    <e k="helpLine_sf_gs_p2_title" v="Düngung und Ernte" eh="1a52ac04" />
+    <e k="helpLine_sf_gs_p2_fert_title" v="Felder düngen" eh="ea52ec26" />
+    <e k="helpLine_sf_gs_p2_fert_text" v="Bringe Dünger mit jeder Standard-Spritze oder jedem Streuer aus. Die Mod erkennt alle Düngertypen des Basisspiels sowie 9 zusätzliche Spezialdünger wie AHL 32, Monoammonphosphat oder Kaliumchlorid. Jeder Dünger liefert unterschiedliche Nährstoffe und beeinflusst dadurch gezielt die Bodenbilanz. Eine vollständige Übersicht aller Dünger und ihrer Eigenschaften findest du in der Kategorie Düngemittel." eh="fe906e29" />
+    <e k="helpLine_sf_gs_p2_harvest_title" v="Nährstoffentzug" eh="a67b6cb5" />
+    <e k="helpLine_sf_gs_p2_harvest_text" v="Mit jeder Ernte werden dem Boden Nährstoffe entzogen. Stark zehrende Kulturen wie Kartoffeln, Zuckerrüben oder Sojabohnen benötigen deutlich mehr Nährstoffe als schwach zehrende Kulturen wie Gerste oder Hafer. Überprüfe nach jeder Ernte den Bodenstatus im HUD oder im Bodenbericht, um den Nährstoffbedarf deines Feldes im Blick zu behalten." eh="63f90ed4" />
 
     <e k="helpLine_sf_gs_p3_title" v="Schwierigkeit" eh="7b29ca96" />
     <e k="helpLine_sf_gs_p3_levels_title" v="Drei Schwierigkeitsstufen" eh="52611188" />
-    <e k="helpLine_sf_gs_p3_levels_text" v="Einfach (0,7x): 30% weniger N├ñhrstoffentzug - gut f├╝r neue Spieler. Realistisch (1,0x): ausgewogen, kalibriert auf reale landwirtschaftliche Raten. Hardcore (1,5x): 50% mehr N├ñhrstoffentzug - intensives Bodenmanagement erforderlich." eh="f4f1ea30" />
-    <e k="helpLine_sf_gs_p3_access_title" v="Einstellungen ├ñndern" eh="b421c88f" />
-    <e k="helpLine_sf_gs_p3_access_text" v="├ûffne die Einstellungen mit der ESC-Taste &gt; Einstellungen &gt; Boden &amp; D├╝nger. Im Mehrspielermodus kann nur der Server-Admin die Simulationseinstellungen ├ñndern. Alle HUD-Anzeigeoptionen gelten pro Spieler und werden nicht geteilt." eh="4ba9d860" />
+    <e k="helpLine_sf_gs_p3_levels_text" v="Einfach (0,7x): 30% weniger Nährstoffentzug - gut für neue Spieler. Realistisch (1,0x): ausgewogen, kalibriert auf reale landwirtschaftliche Raten. Hardcore (1,5x): 50% mehr Nährstoffentzug - intensives Bodenmanagement erforderlich." eh="f4f1ea30" />
+    <e k="helpLine_sf_gs_p3_access_title" v="Einstellungen ändern" eh="b421c88f" />
+    <e k="helpLine_sf_gs_p3_access_text" v="Öffne die Einstellungen mit der ESC-Taste &gt; Einstellungen &gt; Boden &amp; Dünger. Im Mehrspielermodus kann nur der Server-Admin die Simulationseinstellungen ändern. Alle HUD-Anzeigeoptionen gelten pro Spieler und werden nicht geteilt." eh="4ba9d860" />
 
     <e k="helpLine_sf_nu_p1_title" v="Stickstoff und Phosphor" eh="27d37372" />
     <e k="helpLine_sf_nu_p1_n_title" v="Stickstoff (N) - Skala 0 bis 100" eh="10a358f4" />
-    <e k="helpLine_sf_nu_p1_n_text" v="Stickstoff ist der beweglichste N├ñhrstoff und unterliegt starken Ver├ñnderungen im Boden. Pflanzen entziehen ihn schnell, gleichzeitig kann er durch Niederschl├ñge ausgewaschen oder durch andere Prozesse verloren gehen. Schlecht: unter 30. Gut: ├╝ber 50. Du kannst ihn mit Fl├╝ssigd├╝nger, AHL 32, AHL 28, wasserfreiem Ammoniak, Harnstoff, Ammoniumsulfat, Mist oder G├╝lle erh├Âhen." eh="58d62253" />
+    <e k="helpLine_sf_nu_p1_n_text" v="Stickstoff ist der beweglichste Nährstoff und unterliegt starken Veränderungen im Boden. Pflanzen entziehen ihn schnell, gleichzeitig kann er durch Niederschläge ausgewaschen oder durch andere Prozesse verloren gehen. Schlecht: unter 30. Gut: über 50. Du kannst ihn mit Flüssigdünger, AHL 32, AHL 28, wasserfreiem Ammoniak, Harnstoff, Ammoniumsulfat, Mist oder Gülle erhöhen." eh="58d62253" />
     <e k="helpLine_sf_nu_p1_p_title" v="Phosphor (P) - Skala 0 bis 100" eh="979bba64" />
-    <e k="helpLine_sf_nu_p1_p_text" v="Phosphor wird haupts├ñchlich durch die Ernte entzogen und bleibt lange im Boden gebunden. Kulturen mit hohem Ertragspotenzial wie Raps, Kartoffeln oder Mais besitzen einen besonders hohen Phosphorbedarf." eh="92c5ac66" />
+    <e k="helpLine_sf_nu_p1_p_text" v="Phosphor wird hauptsächlich durch die Ernte entzogen und bleibt lange im Boden gebunden. Kulturen mit hohem Ertragspotenzial wie Raps, Kartoffeln oder Mais besitzen einen besonders hohen Phosphorbedarf." eh="92c5ac66" />
 
     <e k="helpLine_sf_nu_p2_title" v="Kalium und pH-Wert" eh="6bd92f25" />
     <e k="helpLine_sf_nu_p2_k_title" v="Kalium (K) - Skala 0 bis 100" eh="2a16e8bc" />
-    <e k="helpLine_sf_nu_p2_k_text" v="Kalium ist besonders wichtig f├╝r Wurzelbildung, Wasserhaushalt und die Qualit├ñt von Knollenfr├╝chten. Kulturen wie Kartoffeln und Zuckerr├╝ben entziehen dem Boden bei jeder Ernte gro├ƒe Mengen Kalium. Durch Niederschl├ñge kann Kalium mit der Zeit ausgewaschen werden. Unter 20 gilt die Versorgung als schlecht, ├╝ber 40 als gut. Erh├Âhe den Kaliumgehalt mit Kalid├╝ngern (0-0-60), G├╝lle, G├ñrresten oder geeigneten Fl├╝ssigd├╝ngern." eh="7230fee4" />
+    <e k="helpLine_sf_nu_p2_k_text" v="Kalium ist besonders wichtig für Wurzelbildung, Wasserhaushalt und die Qualität von Knollenfrüchten. Kulturen wie Kartoffeln und Zuckerrüben entziehen dem Boden bei jeder Ernte große Mengen Kalium. Durch Niederschläge kann Kalium mit der Zeit ausgewaschen werden. Unter 20 gilt die Versorgung als schlecht, über 40 als gut. Erhöhe den Kaliumgehalt mit Kalidüngern (0-0-60), Gülle, Gärresten oder geeigneten Flüssigdüngern." eh="7230fee4" />
     <e k="helpLine_sf_nu_p2_ph_title" v="pH-Wert - Skala 5,0 bis 7,5" eh="944beca2" />
-    <e k="helpLine_sf_nu_p2_ph_text" v="Der optimale pH-Wert liegt f├╝r die meisten Kulturen zwischen 6,5 und 7,0. Niederschl├ñge k├Ânnen den Boden langfristig versauern und den pH-Wert senken. Eine Erh├Âhung des pH-Werts erfolgt nicht durch nat├╝rliche Prozesse, sondern nur durch Kalkung. Unter 5,5 gilt der pH-Wert als schlecht. Bringe Kalk oder Fl├╝ssigkalk aus, wenn der pH-Wert vor der n├ñchsten Aussaat zu niedrig ist." eh="08e0aefd" />
+    <e k="helpLine_sf_nu_p2_ph_text" v="Der optimale pH-Wert liegt für die meisten Kulturen zwischen 6,5 und 7,0. Niederschläge können den Boden langfristig versauern und den pH-Wert senken. Eine Erhöhung des pH-Werts erfolgt nicht durch natürliche Prozesse, sondern nur durch Kalkung. Unter 5,5 gilt der pH-Wert als schlecht. Bringe Kalk oder Flüssigkalk aus, wenn der pH-Wert vor der nächsten Aussaat zu niedrig ist." eh="08e0aefd" />
     
     <e k="helpLine_sf_nu_p3_title" v="Organische Substanz" eh="6305f4bb" />
     <e k="helpLine_sf_nu_p3_om_title" v="Organische Substanz (OS) - Skala 0 bis 10" eh="58f490f3" />
-    <e k="helpLine_sf_nu_p3_om_text" v="Die organische Substanz bildet sich nur sehr langsam und wird nicht direkt durch die Ernte entzogen. Sie verbessert die Bodenstruktur und unterst├╝tzt die langfristige Bodenfruchtbarkeit. Unter 2,5 gilt der Gehalt als schlecht, ├╝ber 4,0 als gut. Erh├Âhe die organische Substanz durch Mist, G├╝lle, G├ñrreste, Kompost, Biosolids, H├╝hnermist, pelletierten Mist oder durch das Einarbeiten von Ernter├╝ckst├ñnden wie Stroh." eh="f9a02359" />
-    <e k="helpLine_sf_nu_p3_fallow_title" v="Regeneration von Brachfl├ñchen" eh="14133b0b" />
-    <e k="helpLine_sf_nu_p3_fallow_text" v="Bleibt ein Feld l├ñnger als 7 Tage unbewirtschaftet, k├Ânnen sich die N├ñhrstoffvorr├ñte durch nat├╝rliche Bodenprozesse langsam regenerieren. Pro Tag: N +0,07, P +0,03, K +0,05, OS +0,01. Fruchtfolgen und gezielte Ruhezeiten k├Ânnen dadurch einen wichtigen Beitrag zur langfristigen Bodenbewirtschaftung leisten." eh="81fa82b3" />
+    <e k="helpLine_sf_nu_p3_om_text" v="Die organische Substanz bildet sich nur sehr langsam und wird nicht direkt durch die Ernte entzogen. Sie verbessert die Bodenstruktur und unterstützt die langfristige Bodenfruchtbarkeit. Unter 2,5 gilt der Gehalt als schlecht, über 4,0 als gut. Erhöhe die organische Substanz durch Mist, Gülle, Gärreste, Kompost, Biosolids, Hühnermist, pelletierten Mist oder durch das Einarbeiten von Ernterückständen wie Stroh." eh="f9a02359" />
+    <e k="helpLine_sf_nu_p3_fallow_title" v="Regeneration von Brachflächen" eh="14133b0b" />
+    <e k="helpLine_sf_nu_p3_fallow_text" v="Bleibt ein Feld länger als 7 Tage unbewirtschaftet, können sich die Nährstoffvorräte durch natürliche Bodenprozesse langsam regenerieren. Pro Tag: N +0,07, P +0,03, K +0,05, OS +0,01. Fruchtfolgen und gezielte Ruhezeiten können dadurch einen wichtigen Beitrag zur langfristigen Bodenbewirtschaftung leisten." eh="81fa82b3" />
 
-    <e k="helpLine_sf_fe_p1_title" v="D├╝ngertypen des Basisspiels" eh="fd941c0d" />
-    <e k="helpLine_sf_fe_p1_base_title" v="Fl├╝ssigd├╝nger, Minerald├╝nger, Mist und G├╝lle" eh="4668dca7" />
-    <e k="helpLine_sf_fe_p1_base_text" v="Fl├╝ssigd├╝nger k├Ânnen je nach Zusammensetzung einzelne oder mehrere N├ñhrstoffe liefern. Feste Minerald├╝nger liefern vor allem Stickstoff und Phosphor. Mist und G├╝lle f├╝hren dem Boden Stickstoff, Phosphor, Kalium und organische Substanz zu. G├ñrreste aus Biogasanlagen enthalten besonders viel Kalium und tragen ebenfalls zur Erh├Âhung der organischen Substanz bei. Alle Varianten k├Ânnen mit Standardger├ñten ausgebracht werden." eh="64069a56" />
+    <e k="helpLine_sf_fe_p1_title" v="Düngertypen des Basisspiels" eh="fd941c0d" />
+    <e k="helpLine_sf_fe_p1_base_title" v="Flüssigdünger, Mineraldünger, Mist und Gülle" eh="4668dca7" />
+    <e k="helpLine_sf_fe_p1_base_text" v="Flüssigdünger können je nach Zusammensetzung einzelne oder mehrere Nährstoffe liefern. Feste Mineraldünger liefern vor allem Stickstoff und Phosphor. Mist und Gülle führen dem Boden Stickstoff, Phosphor, Kalium und organische Substanz zu. Gärreste aus Biogasanlagen enthalten besonders viel Kalium und tragen ebenfalls zur Erhöhung der organischen Substanz bei. Alle Varianten können mit Standardgeräten ausgebracht werden." eh="64069a56" />
     <e k="helpLine_sf_fe_p1_lime_title" v="Kalk und pH-Wert" eh="8933cce1" />
-    <e k="helpLine_sf_fe_p1_lime_text" v="Kalk ist im Basisspiel die einzige M├Âglichkeit zur Erh├Âhung des pH-Wert und liefert keine anderen N├ñhrstoffe. Mit der Mod werden Kalk in fl├╝ssiger Form (Ideal f├╝r deine Feldspritze) und Gips eingef├╝hrt. Gips tr├ñgt zus├ñtzlich geringf├╝gig zur organischen Substanz bei. Bringe Kalk aus, wenn der pH-Wert unter 6,0 sinkt, um optimale Wachstumsbedingungen f├╝r deine Kulturen sicherzustellen." eh="833a967f" />
+    <e k="helpLine_sf_fe_p1_lime_text" v="Kalk ist im Basisspiel die einzige Möglichkeit zur Erhöhung des pH-Wert und liefert keine anderen Nährstoffe. Mit der Mod werden Kalk in flüssiger Form (Ideal für deine Feldspritze) und Gips eingeführt. Gips trägt zusätzlich geringfügig zur organischen Substanz bei. Bringe Kalk aus, wenn der pH-Wert unter 6,0 sinkt, um optimale Wachstumsbedingungen für deine Kulturen sicherzustellen." eh="833a967f" />
 
-    <e k="helpLine_sf_fe_p2_title" v="D├╝ngemittel" eh="1021f8c9" />
+    <e k="helpLine_sf_fe_p2_title" v="Düngemittel" eh="1021f8c9" />
     <e k="helpLine_sf_fe_p2_n_title" v="Stickstoff" eh="9dfe5a5a" />
-    <e k="helpLine_sf_fe_p2_n_text" v="AHL 32 (32-0-0) und AHL 28 (28-0-0) sind fl├╝ssige Stickstoffd├╝nger. Wasserfreies Ammoniak (82-0-0) liefert die h├Âchste Stickstoffmenge pro Liter. Harnstoff (46-0-0) und Ammoniumsulfat (21-0-0-24S) werden als feste Granulate ausgebracht. Alle diese D├╝nger liefern ausschlie├ƒlich Stickstoff und beeinflussen weder Phosphor, Kalium noch den pH-Wert." eh="6a100c25" />
+    <e k="helpLine_sf_fe_p2_n_text" v="AHL 32 (32-0-0) und AHL 28 (28-0-0) sind flüssige Stickstoffdünger. Wasserfreies Ammoniak (82-0-0) liefert die höchste Stickstoffmenge pro Liter. Harnstoff (46-0-0) und Ammoniumsulfat (21-0-0-24S) werden als feste Granulate ausgebracht. Alle diese Dünger liefern ausschließlich Stickstoff und beeinflussen weder Phosphor, Kalium noch den pH-Wert." eh="6a100c25" />
     <e k="helpLine_sf_fe_p2_pk_title" v="Phosphor und Kalium" eh="a2d4091b" />
-    <e k="helpLine_sf_fe_p2_pk_text" v="MAP (11-52-0) besitzt den h├Âchsten Phosphorgehalt unter den verf├╝gbaren Produkten. DAP (18-46-0) kombiniert einen hohen Phosphorgehalt mit zus├ñtzlichem Stickstoff. Kali (0-0-60) dient als reine Kaliumquelle. Starterd├╝nger (10-34-0) ist ein phosphorreicher Unterfu├ƒd├╝nger mit zus├ñtzlichem Stickstoff. Alle Produkte sind als Big Bags im Shop erh├ñltlich." eh="75a86964" />
+    <e k="helpLine_sf_fe_p2_pk_text" v="MAP (11-52-0) besitzt den höchsten Phosphorgehalt unter den verfügbaren Produkten. DAP (18-46-0) kombiniert einen hohen Phosphorgehalt mit zusätzlichem Stickstoff. Kali (0-0-60) dient als reine Kaliumquelle. Starterdünger (10-34-0) ist ein phosphorreicher Unterfußdünger mit zusätzlichem Stickstoff. Alle Produkte sind als Big Bags im Shop erhältlich." eh="75a86964" />
 
-    <e k="helpLine_sf_fe_p3_title" v="Organische D├╝ngung und Ver├ñtzung" eh="7ab807d1" />
-    <e k="helpLine_sf_fe_p3_organic_title" v="Organische D├╝nger und Langzeitwirkung" eh="0199e6be" />
-    <e k="helpLine_sf_fe_p3_organic_text" v="Kompost besitzt die st├ñrkste Wirkung auf den Aufbau organischer Substanz (+0,12 pro 1.000 l). Kl├ñrschlammpellets und H├╝hnermistpellets liefern Stickstoff, Phosphor und organische Substanz. Pelletierter Mist ist ein konzentrierter organischer D├╝nger mit ausgewogener N├ñhrstoffzusammensetzung." eh="3d16e4ee" />
-    <e k="helpLine_sf_fe_p3_burn_title" v="Ver├ñtzungen bei ├£berd├╝ngung" eh="e986cc54" />
-    <e k="helpLine_sf_fe_p3_burn_text" v="Eine Ausbringmenge ├╝ber dem 1,25-fachen der empfohlenen Ausbringmenge kann zu Ver├ñtzungen deiner Pflanzen f├╝hren. Das hat einen Effekt von -0,15 pH und -5 N zur Folge. Ab einer 1,50-fachen ├£berdosierung oder h├Âher tritt bei jeder Anwendung eine Ver├ñtzung auf und -0,30 pH und -12 N. Nutze die Tasten SF Rate Up / Rate Down im Fahrzeug, um die Ausbringmenge anzupassen." eh="7bccc46a" />
+    <e k="helpLine_sf_fe_p3_title" v="Organische Düngung und Verätzung" eh="7ab807d1" />
+    <e k="helpLine_sf_fe_p3_organic_title" v="Organische Dünger und Langzeitwirkung" eh="0199e6be" />
+    <e k="helpLine_sf_fe_p3_organic_text" v="Kompost besitzt die stärkste Wirkung auf den Aufbau organischer Substanz (+0,12 pro 1.000 l). Klärschlammpellets und Hühnermistpellets liefern Stickstoff, Phosphor und organische Substanz. Pelletierter Mist ist ein konzentrierter organischer Dünger mit ausgewogener Nährstoffzusammensetzung." eh="3d16e4ee" />
+    <e k="helpLine_sf_fe_p3_burn_title" v="Verätzungen bei Überdüngung" eh="e986cc54" />
+    <e k="helpLine_sf_fe_p3_burn_text" v="Eine Ausbringmenge über dem 1,25-fachen der empfohlenen Ausbringmenge kann zu Verätzungen deiner Pflanzen führen. Das hat einen Effekt von -0,15 pH und -5 N zur Folge. Ab einer 1,50-fachen Überdosierung oder höher tritt bei jeder Anwendung eine Verätzung auf und -0,30 pH und -12 N. Nutze die Tasten SF Rate Up / Rate Down im Fahrzeug, um die Ausbringmenge anzupassen." eh="7bccc46a" />
 
     <e k="helpLine_sf_hu_p1_title" v="Das Boden-HUD" eh="6522879b" />
     <e k="helpLine_sf_hu_p1_toggle_title" v="HUD umschalten" eh="402283ba" />
-    <e k="helpLine_sf_hu_p1_toggle_text" v="Dr├╝cke J, um die Live-Bodenanzeige ein- oder auszublenden. Das HUD erkennt automatisch das Feld, auf dem du dich befindest, und zeigt die aktuellen Werte f├╝r N, P, K, pH-Wert und organische Substanz (OS) an. Sind Unkraut-, Sch├ñdlings- oder Krankheitssysteme aktiviert, werden diese Informationen zus├ñtzlich am unteren Rand angezeigt." eh="3dcb9bfe" />
+    <e k="helpLine_sf_hu_p1_toggle_text" v="Drücke J, um die Live-Bodenanzeige ein- oder auszublenden. Das HUD erkennt automatisch das Feld, auf dem du dich befindest, und zeigt die aktuellen Werte für N, P, K, pH-Wert und organische Substanz (OS) an. Sind Unkraut-, Schädlings- oder Krankheitssysteme aktiviert, werden diese Informationen zusätzlich am unteren Rand angezeigt." eh="3dcb9bfe" />
     <e k="helpLine_sf_hu_p1_status_title" v="Statuswerte verstehen" eh="291c3aac" />
-    <e k="helpLine_sf_hu_p1_status_text" v="Jeder Wert wird mit Gut (keine Ma├ƒnahme erforderlich), Mittel (├£berpr├╝fung oder Behandlung empfohlen) oder Schlecht (Handlungsbedarf - Ertrag kann beeintr├ñchtigt werden) bewertet. Die Anzeige in der Titelleiste orientiert sich am schlechtesten Wert aller erfassten Bereiche, einschlie├ƒlich N├ñhrstoffen, Unkraut, Sch├ñdlingen und Krankheiten." eh="3b8c2c6e" />
+    <e k="helpLine_sf_hu_p1_status_text" v="Jeder Wert wird mit Gut (keine Maßnahme erforderlich), Mittel (Überprüfung oder Behandlung empfohlen) oder Schlecht (Handlungsbedarf - Ertrag kann beeinträchtigt werden) bewertet. Die Anzeige in der Titelleiste orientiert sich am schlechtesten Wert aller erfassten Bereiche, einschließlich Nährstoffen, Unkraut, Schädlingen und Krankheiten." eh="3b8c2c6e" />
 
     <e k="helpLine_sf_hu_p2_title" v="Feldgesundheit" eh="b4d35b30" />
-    <e k="helpLine_sf_hu_p2_press_title" v="Unkraut, Sch├ñdlinge und Krankheiten" eh="0a3fae00" />
-    <e k="helpLine_sf_hu_p2_press_text" v="Drei Belastungswerte von 0 bis 100 erfassen den aktuellen Befallsdruck durch Schadorganismen und Unkrautdruck auf jedem Feld. Bleiben diese unbehandelt, k├Ânnen sie den Ertrag bei der Ernte deutlich verringern: Unkraut bis zu -30 %, Sch├ñdlinge bis zu -20 % und Krankheiten bis zu -25 %. Die HUD-Anzeigen zeigen den jeweiligen Schweregrad farblich an: Gr├╝n (gering), Gelb (mittel) und Rot (hoch)." eh="3fc3c400" />
+    <e k="helpLine_sf_hu_p2_press_title" v="Unkraut, Schädlinge und Krankheiten" eh="0a3fae00" />
+    <e k="helpLine_sf_hu_p2_press_text" v="Drei Belastungswerte von 0 bis 100 erfassen den aktuellen Befallsdruck durch Schadorganismen und Unkrautdruck auf jedem Feld. Bleiben diese unbehandelt, können sie den Ertrag bei der Ernte deutlich verringern: Unkraut bis zu -30 %, Schädlinge bis zu -20 % und Krankheiten bis zu -25 %. Die HUD-Anzeigen zeigen den jeweiligen Schweregrad farblich an: Grün (gering), Gelb (mittel) und Rot (hoch)." eh="3fc3c400" />
     <e k="helpLine_sf_hu_p2_treat_title" v="Befallsdruck behandeln" eh="cb24bf50" />
-    <e k="helpLine_sf_hu_p2_treat_text" v="Herbizide reduzieren den Unkrautdruck. Auch Bodenbearbeitung entfernt den Unkrautdruck vollst├ñndig. Insektizide senken den Sch├ñdlingsdruck um 25 Punkte und verhindern f├╝r 10 Tage eine erneute Ausbreitung. Fungizide reduzieren den Krankheitsdruck um 20 Punkte und wirken f├╝r 12 Tage vorbeugend. Jedes dieser Systeme kann in den Einstellungen deaktiviert werden." eh="4d65bdec" />
+    <e k="helpLine_sf_hu_p2_treat_text" v="Herbizide reduzieren den Unkrautdruck. Auch Bodenbearbeitung entfernt den Unkrautdruck vollständig. Insektizide senken den Schädlingsdruck um 25 Punkte und verhindern für 10 Tage eine erneute Ausbreitung. Fungizide reduzieren den Krankheitsdruck um 20 Punkte und wirken für 12 Tage vorbeugend. Jedes dieser Systeme kann in den Einstellungen deaktiviert werden." eh="4d65bdec" />
 
     <e k="helpLine_sf_hu_p3_title" v="Bodenprobe" eh="35fcce6c" />
     <e k="helpLine_sf_hu_p3_open_title" v="Bodenproben auswerten" eh="62e3f629" />
-    <e k="helpLine_sf_hu_p3_open_text" v="├ûffne den Bodenbericht deines Hofes (Standardm├ñ0ig Taste K), deine Felder werden automatisch beprobt und dir werden die Daten angezeigt. Die ├£bersicht umfasst alle Felder, den aktuellen D├╝ngebedarf sowie einen gewichteten Gesundheitswert des gesamten Hofes. Die Felder sind nach Handlungsbedarf sortiert - die kritischsten Zust├ñnde werden zuerst angezeigt." eh="38a5bd2e" />
+    <e k="helpLine_sf_hu_p3_open_text" v="Öffne den Bodenbericht deines Hofes (Standardmä0ig Taste K), deine Felder werden automatisch beprobt und dir werden die Daten angezeigt. Die Übersicht umfasst alle Felder, den aktuellen Düngebedarf sowie einen gewichteten Gesundheitswert des gesamten Hofes. Die Felder sind nach Handlungsbedarf sortiert - die kritischsten Zustände werden zuerst angezeigt." eh="38a5bd2e" />
     <e k="helpLine_sf_hu_p3_detail_title" v="Empfehlungen" eh="c99d2b89" />
-    <e k="helpLine_sf_hu_p3_detail_text" v="├ûffne mit dem Pfeil einer beliebigen Zeile die Detailansicht eines Feldes. Dort findest du die aktuellen N├ñhrstoffwerte, Befallsstufen, eine Prognose m├Âglicher Ertragseinbu├ƒen sowie konkrete Empfehlungen, welche Ma├ƒnahmen durchgef├╝hrt werden sollten. Dr├╝cke Zur├╝ck oder Esc, um zur ├£bersicht zur├╝ckzukehren." eh="38dd2c6d" />
+    <e k="helpLine_sf_hu_p3_detail_text" v="Öffne mit dem Pfeil einer beliebigen Zeile die Detailansicht eines Feldes. Dort findest du die aktuellen Nährstoffwerte, Befallsstufen, eine Prognose möglicher Ertragseinbußen sowie konkrete Empfehlungen, welche Maßnahmen durchgeführt werden sollten. Drücke Zurück oder Esc, um zur Übersicht zurückzukehren." eh="38dd2c6d" />
 
     <e k="helpLine_sf_se_p1_title" v="Simulationseinstellungen" eh="cbf13e3c" />
     <e k="helpLine_sf_se_p1_server_title" v="Servereinstellungen (nur Admin im Mehrspielermodus)" eh="49f37ed7" />
-    <e k="helpLine_sf_se_p1_server_text" v="Fruchtbarkeitssystem, N├ñhrstoffkreisl├ñufe, Saisoneffekte, Regeneffekte, Pflugbonus, Unkraut-/Sch├ñdlings-/Krankheitsdruck, D├╝ngerkosten, Benachrichtigungen, Fruchtfolge und Auto-Ratensteuerung. Im Mehrspielermodus kann nur der Server-Admin diese ├ñndern. ├änderungen werden sofort mit allen Clients synchronisiert." eh="abca5e43" />
+    <e k="helpLine_sf_se_p1_server_text" v="Fruchtbarkeitssystem, Nährstoffkreisläufe, Saisoneffekte, Regeneffekte, Pflugbonus, Unkraut-/Schädlings-/Krankheitsdruck, Düngerkosten, Benachrichtigungen, Fruchtfolge und Auto-Ratensteuerung. Im Mehrspielermodus kann nur der Server-Admin diese ändern. Änderungen werden sofort mit allen Clients synchronisiert." eh="abca5e43" />
     <e k="helpLine_sf_se_p1_diff_title" v="Schwierigkeit" eh="7b29ca96" />
-    <e k="helpLine_sf_se_p1_diff_text" v="Einfach (0,7x) reduziert den N├ñhrstoffentzug um 30% f├╝r ein entspanntes Erlebnis. Realistisch (1,0x) ist der ausgewogene Standard. Hardcore (1,5x) erh├Âht den N├ñhrstoffentzug um 50% f├╝r intensives Bodenmanagement. Zugriff ├╝ber ESC &gt; Einstellungen &gt; Boden &amp; D├╝nger." eh="ca93ca3e" />
+    <e k="helpLine_sf_se_p1_diff_text" v="Einfach (0,7x) reduziert den Nährstoffentzug um 30% für ein entspanntes Erlebnis. Realistisch (1,0x) ist der ausgewogene Standard. Hardcore (1,5x) erhöht den Nährstoffentzug um 50% für intensives Bodenmanagement. Zugriff über ESC &gt; Einstellungen &gt; Boden &amp; Dünger." eh="ca93ca3e" />
 
     <e k="helpLine_sf_se_p2_title" v="HUD und SmartSpray" eh="399f4910" />
     <e k="helpLine_sf_se_p2_hud_title" v="HUD-Optionen pro Spieler" eh="0df76500" />
-    <e k="helpLine_sf_se_p2_hud_text" v="Jeder Spieler steuert sein eigenes HUD, es wird nicht mit dem Server synchronisiert. Optionen: HUD anzeigen (ein/aus), Position (5 Voreinstellungen + Ziehen), Farbthema (Gr├╝n / Blau / Bernstein / Monochrome), Schriftgr├Â├ƒe (Klein / Mittel / Gro├ƒ), Transparenz (25% bis 100%), Imperiale Einheiten (ein/aus)." eh="f3934884" />
+    <e k="helpLine_sf_se_p2_hud_text" v="Jeder Spieler steuert sein eigenes HUD, es wird nicht mit dem Server synchronisiert. Optionen: HUD anzeigen (ein/aus), Position (5 Voreinstellungen + Ziehen), Farbthema (Grün / Blau / Bernstein / Monochrome), Schriftgröße (Klein / Mittel / Groß), Transparenz (25% bis 100%), Imperiale Einheiten (ein/aus)." eh="f3934884" />
     <e k="helpLine_sf_se_p2_rate_title" v="SmartSpray" eh="5ecdfa23" />
-    <e k="helpLine_sf_se_p2_rate_text" v="Verwende in einer Feldspritze oder einem D├╝ngerstreuer von dir frei belegbare Tasten, um die Ausbringmenge von 0,10x bis 2,00x anzupassen. Schaltest du Auto-Ratensteuerung (Umschalt+L) ein, damit die Mod automatisch den optimalen N├ñhrstoffbedarf errechnet." eh="dd385e39" />
+    <e k="helpLine_sf_se_p2_rate_text" v="Verwende in einer Feldspritze oder einem Düngerstreuer von dir frei belegbare Tasten, um die Ausbringmenge von 0,10x bis 2,00x anzupassen. Schaltest du Auto-Ratensteuerung (Umschalt+L) ein, damit die Mod automatisch den optimalen Nährstoffbedarf errechnet." eh="dd385e39" />
 
     <e k="helpLine_sf_mp_p1_title" v="Wie Mehrspieler funktioniert" eh="8a4ce30e" />
     <e k="helpLine_sf_mp_p1_auth_title" v="Server-autoritative Simulation" eh="8d324792" />
-    <e k="helpLine_sf_mp_p1_auth_text" v="Alle Bodensimulationen laufen auf dem Server. Clients erhalten beim Beitritt vollst├ñndige Felddaten und Einstellungen, mit automatischem Wiederholungsversuch, wenn der Server noch l├ñdt. HUD-Anzeigeeinstellungen (Position, Thema, Gr├Â├ƒe) sind pro Spieler und werden nie mit dem Server synchronisiert." eh="db72a3f9" />
+    <e k="helpLine_sf_mp_p1_auth_text" v="Alle Bodensimulationen laufen auf dem Server. Clients erhalten beim Beitritt vollständige Felddaten und Einstellungen, mit automatischem Wiederholungsversuch, wenn der Server noch lädt. HUD-Anzeigeeinstellungen (Position, Thema, Größe) sind pro Spieler und werden nie mit dem Server synchronisiert." eh="db72a3f9" />
     <e k="helpLine_sf_mp_p1_ded_title" v="Dedizierte Server" eh="4d3a45ba" />
-    <e k="helpLine_sf_mp_p1_ded_text" v="Dedizierte Server f├╝hren die vollst├ñndige Simulation ohne HUD- oder GUI-Overhead aus - dies ist erwartet und normal. Verwenden Sie Konsolenbefehle (soilStatus, SoilSetDifficulty, SoilShowSettings usw.), um Einstellungen auf einem dedizierten Server zu verwalten und zu ├╝berpr├╝fen." eh="3df784d6" />
+    <e k="helpLine_sf_mp_p1_ded_text" v="Dedizierte Server führen die vollständige Simulation ohne HUD- oder GUI-Overhead aus - dies ist erwartet und normal. Verwenden Sie Konsolenbefehle (soilStatus, SoilSetDifficulty, SoilShowSettings usw.), um Einstellungen auf einem dedizierten Server zu verwalten und zu überprüfen." eh="3df784d6" />
     <e k="helpLine_sf_mp_p2_title" v="[EN] Compatibility and Workflow" eh="b25d25e9" />
     <e k="helpLine_sf_mp_p2_compat_title" v="[EN] Mod Compatibility" eh="5581e454" />
     <e k="helpLine_sf_mp_p2_compat_text" v="[EN] Soil &amp; Fertilizer uses appended function hooks, so it runs alongside Courseplay, AutoDrive and most equipment mods without conflict. When Precision Farming is active in a savegame it detects it and stands down automatically, so the two never fight over the same fields." eh="54b87e0c" />
@@ -347,21 +347,21 @@
     <e k="helpLine_sf_mp_p2_workflow_text" v="[EN] In multiplayer only server admins can change settings. Change them from the panel or console on the host and every change is validated and pushed to all clients. On Realistic and Hardcore the tuning editors and challenge toggles are locked, so no one can soften the simulation mid-game." eh="42ace095" />
 
     <e k="sf_crop_rotation_short" v="Fruchtfolge" eh="def2c162" />
-    <e k="sf_crop_rotation_long" v="Fruchtfolgebonus und Fruchtfolgeprobleme aktivieren/deaktivieren (Leguminosen k├Ânnen durch Stickstoffbindung den Stickstoffvorrat erh├Âhen; wiederholter Anbau derselben Kultur verst├ñrkt den N├ñhrstoffentzug)." eh="958b4212" />
+    <e k="sf_crop_rotation_long" v="Fruchtfolgebonus und Fruchtfolgeprobleme aktivieren/deaktivieren (Leguminosen können durch Stickstoffbindung den Stickstoffvorrat erhöhen; wiederholter Anbau derselben Kultur verstärkt den Nährstoffentzug)." eh="958b4212" />
 
     <e k="sf_gypsum_title" v="Gips" eh="d66da34c" />
     <e k="sf_compost_title" v="Kompost" eh="c3e2071a" />
-    <e k="sf_biosolids_title" v="Kl├ñrschlammpellets" eh="f0c901dc" />
-    <e k="sf_chicken_manure_title" v="H├╝hnermist" eh="338128e2" />
+    <e k="sf_biosolids_title" v="Klärschlammpellets" eh="f0c901dc" />
+    <e k="sf_chicken_manure_title" v="Hühnermist" eh="338128e2" />
     <e k="sf_pelletized_manure_title" v="Mistpellets" eh="c1b39b71" />
     <e k="sf_liquidlime_title" v="Kalk" eh="d4ec4bb9" />
 
     <e k="helpLine_sf_nu_p4_title" v="Fruchtfolge" eh="def2c162" />
     <e k="helpLine_sf_nu_p4_bonus_title" v="Fruchtfolgevorteil" eh="2831a7ac" />
-    <e k="helpLine_sf_nu_p4_bonus_text" v="Der Anbau einer Leguminose wie Sojabohnen, Erbsen oder Bohnen nach einer Nicht-Leguminose verbessert die Stickstoffversorgung des Bodens. Im Fr├╝hjahr wird f├╝r 3 Tage ein zus├ñtzlicher Stickstoffschub gew├ñhrt." eh="e1fce95b" />
+    <e k="helpLine_sf_nu_p4_bonus_text" v="Der Anbau einer Leguminose wie Sojabohnen, Erbsen oder Bohnen nach einer Nicht-Leguminose verbessert die Stickstoffversorgung des Bodens. Im Frühjahr wird für 3 Tage ein zusätzlicher Stickstoffschub gewährt." eh="e1fce95b" />
 
     <e k="helpLine_sf_nu_p4_fatigue_title" v="Fruchtfolgeprobleme" eh="236a590c" />
-    <e k="helpLine_sf_nu_p4_fatigue_text" v="Wird dieselbe Kultur in zwei aufeinanderfolgenden Jahren angebaut, steigt der N├ñhrstoffentzug um 15 %. Eine abwechslungsreiche Fruchtfolge hilft dabei, Fruchtfolgeprobleme zu vermeiden und die Bodenfruchtbarkeit langfristig zu erhalten." eh="1613f3c6" />
+    <e k="helpLine_sf_nu_p4_fatigue_text" v="Wird dieselbe Kultur in zwei aufeinanderfolgenden Jahren angebaut, steigt der Nährstoffentzug um 15 %. Eine abwechslungsreiche Fruchtfolge hilft dabei, Fruchtfolgeprobleme zu vermeiden und die Bodenfruchtbarkeit langfristig zu erhalten." eh="1613f3c6" />
 
     <e k="sf_map_layer_off" v="Bodenkarte: Aus" eh="3e654ade" />
     <e k="sf_map_layer_n" v="Stickstoff" eh="1e9ef3ba" />
@@ -378,7 +378,7 @@
     <e k="sf_map_layer_desc_urgency" v="[EN] Fields that need treatment soonest, highest first." />
     <e k="sf_map_layer_weed" v="Unkraut" eh="53f8b936" />
     <e k="sf_map_layer_desc_weed" v="[EN] Weed pressure per field." />
-    <e k="sf_map_layer_pest" v="Sch├ñdlinge" eh="18a7c2be" />
+    <e k="sf_map_layer_pest" v="Schädlinge" eh="18a7c2be" />
     <e k="sf_map_layer_desc_pest" v="[EN] Pest pressure per field." />
     <e k="sf_map_layer_disease" v="Krankheiten" eh="2b805cc9" />
     <e k="sf_map_layer_desc_disease" v="[EN] Disease pressure per field." />
@@ -390,7 +390,7 @@
     <e k="sf_map_page_title" v="Feldmonitor" eh="04a675fb" />
     <e k="sf_map_sidebar_header" v="Bodenkartenebene" eh="81332549" />
     <e k="sf_map_sidebar_label" v="Aktive Ebene" eh="f8a2c198" />
-    <e k="sf_map_sidebar_tooltip" v="W├ñhle, welcher N├ñhrstoff auf der Karte angezeigt werden soll" eh="eb926e9a" />
+    <e k="sf_map_sidebar_tooltip" v="Wähle, welcher Nährstoff auf der Karte angezeigt werden soll" eh="eb926e9a" />
     <e k="sf_map_overlay_low" v="Niedrig" eh="28d0edd0" />
     <e k="sf_map_overlay_med" v="Mittel" eh="248c9511" />
     <e k="sf_map_overlay_high" v="Hoch" eh="655d20c1" />
@@ -399,10 +399,10 @@
     <e k="sf_pda_tab_map" v="Bodenkarte" eh="59f988b2" />
     <e k="sf_pda_tab_fields" v="Felder" eh="a4ca5edd" />
     <e k="sf_pda_tab_treatment" v="Behandlungsplan" eh="4ba012e2" />
-    <e k="sf_pda_section_farm_overview" v="Hof├╝bersicht" eh="47f2c19a" />
+    <e k="sf_pda_section_farm_overview" v="Hofübersicht" eh="47f2c19a" />
     <e k="sf_pda_fields_tracked_label" v="alle Felder" eh="c763e26e" />
     <e k="sf_pda_fields_owned_label" v="deine Felder" eh="335f5f7e" />
-    <e k="sf_pda_section_avg_nutrients" v="Ôêà N├ñhrstoffe" eh="f06b2704" />
+    <e k="sf_pda_section_avg_nutrients" v="Ø Nährstoffe" eh="f06b2704" />
     <e k="sf_pda_avg_n_label" v="Stickstoff (N)" eh="25cee53b" />
     <e k="sf_pda_avg_p_label" v="Phosphor (P)" eh="75cb5cd6" />
     <e k="sf_pda_avg_k_label" v="Kalium (K)" eh="39797137" />
@@ -410,24 +410,24 @@
     <e k="sf_pda_avg_om_label" v="Organische Substanz" eh="6305f4bb" />
     <e k="sf_pda_section_pressure" v="Wirtschaftliche Schadschwelle erreicht" eh="a73974d0" />
     <e k="sf_pda_weed_label" v="Unkraut" eh="2b75024d" />
-    <e k="sf_pda_pest_label" v="Sch├ñdling" eh="8f2aee79" />
+    <e k="sf_pda_pest_label" v="Schädling" eh="8f2aee79" />
     <e k="sf_pda_disease_label" v="Krankheiten" eh="e7067a8c" />
     <e k="sf_pda_section_attention" v="Behandlungsempfehlungen" eh="80e48bc3" />
-    <e k="sf_pda_needs_fert_label" v="D├╝ngung empfohlen" eh="fa9ded5e" />
+    <e k="sf_pda_needs_fert_label" v="Düngung empfohlen" eh="fa9ded5e" />
     <e k="sf_pda_total_urgent_label" v="Behandlung empfohlen (gesamt)" eh="b3ce2db9" />
     <e k="sf_pda_no_data_left" v="Noch keine Felddaten." eh="ba71c6b1" />
     <e k="sf_pda_map_section_title" v="Bodenkartenebenen" eh="85d63132" />
     <e k="sf_pda_map_active_layer" v="Aktive Ebene" eh="f8a2c198" />
-    <e k="sf_pda_map_layer_off_desc" v="Keine Bodenebene aktiv. Bitte w├ñhle eine Ebene zur Anzeige aus." eh="3bd7e65a" />
-    <e k="sf_pda_map_layer_n_desc" v="Stickstoffgehalt auf allen Feldern. Gr├╝n = gut, rot = schlecht." eh="60484ead" />
-    <e k="sf_pda_map_layer_p_desc" v="Phosphorgehalt auf allen Feldern. Gr├╝n = gut, rot = schlecht." eh="9fa2e72d" />
-    <e k="sf_pda_map_layer_k_desc" v="Kaliumgehalt auf allen Feldern. Gr├╝n = gut, rot = schlecht." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="pH-Wert. Optimaler Bereich ist zwischen 6,5 und 7,0 (gr├╝n)." eh="ce7009e7" />
-    <e k="sf_pda_map_layer_om_desc" v="Gehalt an organischer Substanz. H├Âher ist besser f├╝r die langfristige Fruchtbarkeit." eh="f64c5706" />
-    <e k="sf_pda_map_layer_urgency_desc" v="Indikator f├╝r den Handlungsbedarf. Rot zeigt den schlechtesten Zustand an. Kombination aus allen Faktoren." eh="f29ddc2b" />
-    <e k="sf_pda_map_layer_weed_desc" v="Unkrautdruck. Von Schadschwelle (Rot) ├╝berschritten bis Unkrautfrei (Gr├╝n)." eh="24009598" />
-    <e k="sf_pda_map_layer_pest_desc" v="Sch├ñdlingsdruck. Von Schadschwelle (Rot) ├╝berschritten bis ohne Sch├ñdlingsbefall (Gr├╝n)." eh="86ba29dc" />
-    <e k="sf_pda_map_layer_disease_desc" v="Krankheitsdruck. Von Schadschwelle (Rot) ├╝berschritten bis ohne Pilzbefall (Gr├╝n)." eh="5d32d30a" />
+    <e k="sf_pda_map_layer_off_desc" v="Keine Bodenebene aktiv. Bitte wähle eine Ebene zur Anzeige aus." eh="3bd7e65a" />
+    <e k="sf_pda_map_layer_n_desc" v="Stickstoffgehalt auf allen Feldern. Grün = gut, rot = schlecht." eh="60484ead" />
+    <e k="sf_pda_map_layer_p_desc" v="Phosphorgehalt auf allen Feldern. Grün = gut, rot = schlecht." eh="9fa2e72d" />
+    <e k="sf_pda_map_layer_k_desc" v="Kaliumgehalt auf allen Feldern. Grün = gut, rot = schlecht." eh="a61d25b7" />
+    <e k="sf_pda_map_layer_ph_desc" v="pH-Wert. Optimaler Bereich ist zwischen 6,5 und 7,0 (grün)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_om_desc" v="Gehalt an organischer Substanz. Höher ist besser für die langfristige Fruchtbarkeit." eh="f64c5706" />
+    <e k="sf_pda_map_layer_urgency_desc" v="Indikator für den Handlungsbedarf. Rot zeigt den schlechtesten Zustand an. Kombination aus allen Faktoren." eh="f29ddc2b" />
+    <e k="sf_pda_map_layer_weed_desc" v="Unkrautdruck. Von Schadschwelle (Rot) überschritten bis Unkrautfrei (Grün)." eh="24009598" />
+    <e k="sf_pda_map_layer_pest_desc" v="Schädlingsdruck. Von Schadschwelle (Rot) überschritten bis ohne Schädlingsbefall (Grün)." eh="86ba29dc" />
+    <e k="sf_pda_map_layer_disease_desc" v="Krankheitsdruck. Von Schadschwelle (Rot) überschritten bis ohne Pilzbefall (Grün)." eh="5d32d30a" />
     <e k="sf_pda_map_legend_title" v="Kartenlegende" eh="86448402" />
     <e k="sf_pda_map_legend_good" v="Gut" eh="0c6ad70b" />
     <e k="sf_pda_map_legend_fair" v="Mittel" eh="f7f20cf0" />
@@ -435,38 +435,38 @@
     <e k="sf_pda_map_legend_low" v="Niedrig" eh="28d0edd0" />
     <e k="sf_pda_map_legend_medium" v="Mittel" eh="87f8a6ab" />
     <e k="sf_pda_map_legend_high" v="Hoch" eh="655d20c1" />
-    <e k="sf_pda_map_legend_excess" v="├£berschuss" eh="d1d25b9f" />
-    <e k="sf_pda_map_instructions" v="W├ñhle eine Ebene in der Seitenleiste aus, um sie auf der Karte anzuzeigen." eh="eee76c81" />
+    <e k="sf_pda_map_legend_excess" v="Überschuss" eh="d1d25b9f" />
+    <e k="sf_pda_map_instructions" v="Wähle eine Ebene in der Seitenleiste aus, um sie auf der Karte anzuzeigen." eh="eee76c81" />
     <e k="sf_pda_map_jump_hint" v="Klicke auf ein Feld, um es auf der Karte anzuzeigen" eh="006d5371" />
     <e k="sf_pda_map_native_hint" v="Die Bodenlagen-Visualisierung ist umgezogen! Du kannst nun direkt von der Standard-Karte aus auf alle Feld-Daten zugreifen. Halte nach dem Reiter 'Feldmonitor' ausschau" eh="3210d828" />
     <e k="sf_pda_map_open_btn" v="ENTWICKLER-NOTIZ" eh="ef40b93f" />
     <e k="sf_pda_btn_help" v="Hilfe" eh="6a26f548" />
-    <e k="sf_pda_help_text" v="Hallo, ich bin's, der Entwickler! Ich habe die Bodenkartenebenen auf die native PDA-Karte (ESC &gt; Karte) verschoben, um ein nahtloseres Erlebnis zu erm├Âglichen. Du kannst nun Ebenen direkt in der Seitenleiste ausw├ñhlen. Die PDA-Seite wird noch verfeinert, also bleib dran f├╝r weitere Updates!" eh="67643ddd" />
-    <e k="sf_pda_help_github" v="DEIN FEEDBACK Z├äHLT! Wenn du Fehler findest, Vorschl├ñge f├╝r neue Funktionen hast oder zum Code beitragen m├Âchtest, besuche das Projekt auf GitHub. Du kannst jederzeit einn Issue oder eine Pull-Request ├Âffnen, um diese Mod f├╝r alle zu verbessern. Danke f├╝rs Testen!" eh="3a10b023" />
-    <e k="sf_pda_help_note" v="Hinweis: Die Registerkarte f├╝r Bodenebenen auf der Kartenseite FUNKTIONIERT NICHT. Ich bin mir des Problems bewusst und arbeite an einer L├Âsung (was einige Zeit dauern kann)." eh="2d8f5dc7" />
-    <e k="sf_pda_map_unavailable" v="Karten-Vorschau nicht verf├╝gbar" eh="43983f81" />
+    <e k="sf_pda_help_text" v="Hallo, ich bin's, der Entwickler! Ich habe die Bodenkartenebenen auf die native PDA-Karte (ESC &gt; Karte) verschoben, um ein nahtloseres Erlebnis zu ermöglichen. Du kannst nun Ebenen direkt in der Seitenleiste auswählen. Die PDA-Seite wird noch verfeinert, also bleib dran für weitere Updates!" eh="67643ddd" />
+    <e k="sf_pda_help_github" v="DEIN FEEDBACK ZÄHLT! Wenn du Fehler findest, Vorschläge für neue Funktionen hast oder zum Code beitragen möchtest, besuche das Projekt auf GitHub. Du kannst jederzeit einn Issue oder eine Pull-Request öffnen, um diese Mod für alle zu verbessern. Danke fürs Testen!" eh="3a10b023" />
+    <e k="sf_pda_help_note" v="Hinweis: Die Registerkarte für Bodenebenen auf der Kartenseite FUNKTIONIERT NICHT. Ich bin mir des Problems bewusst und arbeite an einer Lösung (was einige Zeit dauern kann)." eh="2d8f5dc7" />
+    <e k="sf_pda_map_unavailable" v="Karten-Vorschau nicht verfügbar" eh="43983f81" />
     <e k="sf_map_health_overall" v="&#8960; Bodengesundheit" eh="5533cbe3" />
-    <e k="sf_map_btn_report" v="Hof├╝bersicht" eh="6f0800e8" />
+    <e k="sf_map_btn_report" v="Hofübersicht" eh="6f0800e8" />
     <e k="sf_map_btn_help" v="Hilfe" eh="6a26f548" />
     <e k="sf_map_btn_cycle_layer" v="Ebene wechseln" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Behandlungsplan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Overlay deaktivieren" eh="8e75dec5" />
     <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
     <e k="sf_help_title" v="Boden-Schnellreferenz" eh="8986bb6d" />
-    <e k="sf_help_nutrients_header" v="N├äHRSTOFFE" eh="9aeb39bf" />
-    <e k="sf_help_n" v="N  (Stickstoff)   - Schnell ersch├Âpft. AHL, Harnstoff oder Mist ausbringen." eh="f2d0c792" />
+    <e k="sf_help_nutrients_header" v="NÄHRSTOFFE" eh="9aeb39bf" />
+    <e k="sf_help_n" v="N  (Stickstoff)   - Schnell erschöpft. AHL, Harnstoff oder Mist ausbringen." eh="f2d0c792" />
     <e k="sf_help_p" v="P  (Phosphor)     - Langanhaltend. MAP oder DAP ausbringen." eh="fdfbd91e" />
-    <e k="sf_help_k" v="K  (Kalium)       - Kalium ausbringen. Wichtig f├╝r Wurzeln." eh="e0217634" />
-    <e k="sf_help_om" v="OS (Organisch)    - Baut sich langsam auf. Mist/Kompost einpfl├╝gen." eh="a4e29617" />
+    <e k="sf_help_k" v="K  (Kalium)       - Kalium ausbringen. Wichtig für Wurzeln." eh="e0217634" />
+    <e k="sf_help_om" v="OS (Organisch)    - Baut sich langsam auf. Mist/Kompost einpflügen." eh="a4e29617" />
     <e k="sf_help_soil_header" v="BODENCHEMIE" eh="19c67ff5" />
     <e k="sf_help_ph" v="pH  6,5-7,0 = Ideal.  &lt; 6,5 Kalk ausbringen.  &gt; 7,5 Gips ausbringen." eh="8929304d" />
     <e k="sf_help_pressure_header" v="PFLANZENDRUCK" eh="132b0f66" />
     <e k="sf_help_weed" v="Unkraut  &gt; 20% - Herbizid ausbringen." eh="c8d890df" />
-    <e k="sf_help_pest" v="Sch├ñdling &gt; 20% - Insektizid ausbringen." eh="f4932a05" />
+    <e k="sf_help_pest" v="Schädling &gt; 20% - Insektizid ausbringen." eh="f4932a05" />
     <e k="sf_help_disease" v="Krankheit &gt; 20% - Fungizid ausbringen." eh="1bfd0913" />
     <e k="sf_help_status_header" v="STATUSNIVEAUS" eh="b081c2c6" />
     <e k="sf_help_good" v="Gut - Keine Aktion erforderlich." eh="03910bec" />
-    <e k="sf_help_fair" v="Mittel - Beobachten / vorbeugend nachd├╝ngen." eh="2922eb1c" />
+    <e k="sf_help_fair" v="Mittel - Beobachten / vorbeugend nachdüngen." eh="2922eb1c" />
     <e k="sf_help_poor" v="Schlecht - Sofortige Behandlung erforderlich." eh="b287d206" />
     <e k="sf_pda_fields_section_title" v="Alle Felder" eh="48729e0b" />
     <e k="sf_pda_col_field" v="Feld" eh="6f16a5f8" />
@@ -479,7 +479,7 @@
     <e k="sf_pda_col_om" v="Organische Substanz" eh="bfbebc07" />
     <e k="sf_pda_col_status" v="Status" eh="ec53a8c4" />
 		<e k="sf_pda_col_weeds" v="[EN] Weeds" eh="324181de" />
-		<e k="sf_pda_col_pests" v="Sch├ñdling" eh="2fed5101" />
+		<e k="sf_pda_col_pests" v="Schädling" eh="2fed5101" />
 		<e k="sf_pda_col_disease" v="Krankheiten" eh="e7067a8c" />
     <e k="sf_pda_no_fields" v="Noch keine Felddaten aufgezeichnet." eh="72265670" />
     <e k="sf_pda_status_good" v="Gut" eh="0c6ad70b" />
@@ -500,11 +500,11 @@
     <e k="sf_pda_need_disease" v="Fungizid" eh="e8512698" />
     <e k="sf_pda_need_multiple" v="Mehrfach" eh="a0bf169f" />
     <e k="sf_pda_treatment_minor" v="Gering" eh="6fed0c37" />
-    <e k="sf_detail_title" v="├£bersicht" eh="03b5acd7" />
+    <e k="sf_detail_title" v="Übersicht" eh="03b5acd7" />
     <e k="sf_detail_close" v="Ok" eh="d3d2e617" />
     <e k="sf_detail_field_label" v="Schlagnummer:" eh="228118ab" />
     <e k="sf_detail_urgency_label" v="Zustand:" eh="9a83237c" />
-    <e k="sf_detail_section_nutrients" v="N├ñhrstoffversorgung" eh="64377acf" />
+    <e k="sf_detail_section_nutrients" v="Nährstoffversorgung" eh="64377acf" />
     <e k="sf_detail_section_pressure" v="Wirtschaftliche Schadschwelle" eh="a73974d0" />
     <e k="sf_detail_section_history" v="Anbauverlauf" eh="54c27499" />
     <e k="sf_detail_n_label" v="Stickstoff (N)" eh="25cee53b" />
@@ -513,36 +513,36 @@
     <e k="sf_detail_ph_label" v="pH-Wert" eh="0c85daad" />
     <e k="sf_detail_om_label" v="Organische Substanz" eh="6305f4bb" />
     <e k="sf_detail_weed_label" v="Unkraut" eh="53f8b936" />
-    <e k="sf_detail_pest_label" v="Sch├ñdlinge" eh="18a7c2be" />
+    <e k="sf_detail_pest_label" v="Schädlinge" eh="18a7c2be" />
     <e k="sf_detail_disease_label" v="Krankheiten" eh="2b805cc9" />
     <e k="sf_detail_last_crop_label" v="Vorfrucht" eh="ff41e5eb" />
     <e k="sf_detail_rotation_label" v="Fruchtfolgestatus" eh="83f7f522" />
 
     <!-- Rotation Foresight (pre-plant preview - SoilFieldDetailDialog.lua) -->
     <e k="sf_rf_section" v="Bewertung deiner Fruchtfolge" eh="6f977043" />
-    <e k="sf_rf_intro" v="Wenn du als n├ñchstes folgende Kultur anbaust:" eh="34964567" />
+    <e k="sf_rf_intro" v="Wenn du als nächstes folgende Kultur anbaust:" eh="34964567" />
     <e k="sf_rf_hint" v="Baue erst eine Kultur auf dem Feld an, um eine Bewertung deiner Fruchtfolge zu erhalten." eh="817d250a" />
     <e k="sf_rf_status_bonus" v="als Vorfrucht hervorragend geeignet" eh="3c0ee4ba" />
     <e k="sf_rf_status_ok" v="als Vorfrucht geeignet" eh="e0aa021e" />
     <e k="sf_rf_status_fatigue" v="als Vorfrucht ungeeignet" eh="b5ff1b29" />
-    <e k="sf_rf_effect_fatigue" v="1,15-facher N├ñhrstoffentzug" eh="5f05aded" />
+    <e k="sf_rf_effect_fatigue" v="1,15-facher Nährstoffentzug" eh="5f05aded" />
     <e k="sf_rf_effect_nplus" v="Stickstoffzufuhr" eh="fa91409a" />
-    <e k="sf_rf_effect_disease_down" v="geringe Krankheitsanf├ñlligkeit" eh="f1375cc1" />
-    <e k="sf_rf_effect_disease_up" v="hohe Krankheitsanf├ñlligkeit" eh="0417d38f" />
-    <e k="sf_rf_effect_neutral" v="unver├ñnderte Krankheitsanf├ñlligkeit" eh="66d22a5d" />
+    <e k="sf_rf_effect_disease_down" v="geringe Krankheitsanfälligkeit" eh="f1375cc1" />
+    <e k="sf_rf_effect_disease_up" v="hohe Krankheitsanfälligkeit" eh="0417d38f" />
+    <e k="sf_rf_effect_neutral" v="unveränderte Krankheitsanfälligkeit" eh="66d22a5d" />
 
-    <e k="sf_treat_title" v="Empfohlene Ma├ƒnahmen" eh="0ccc3ee5" />
+    <e k="sf_treat_title" v="Empfohlene Maßnahmen" eh="0ccc3ee5" />
     <e k="sf_treat_section_soil" v="Bodenfruchtbarkeit" eh="09e016e4" />
-    <e k="sf_treat_section_fert" v="N├ñhrstoffversorgung" eh="76521e8e" />
+    <e k="sf_treat_section_fert" v="Nährstoffversorgung" eh="76521e8e" />
     <e k="sf_treat_section_prot" v="Pflanzenschutz" eh="bd3fe9cd" />
-    <e k="sf_treat_hint" v="Bei deinem lokalen H├ñndler kannst du spezialisierte D├╝nger und Pflanzenschutzmittel finden." eh="540bff4d" />
+    <e k="sf_treat_hint" v="Bei deinem lokalen Händler kannst du spezialisierte Dünger und Pflanzenschutzmittel finden." eh="540bff4d" />
     <e k="sf_treat_action_optimal" v="Optimal - Keine Aktion erforderlich." eh="4501a96b" />
-    <e k="sf_treat_action_lime" v="Kalk ausbringen, um den pH-Wert zu erh├Âhen." eh="d1420b97" />
+    <e k="sf_treat_action_lime" v="Kalk ausbringen, um den pH-Wert zu erhöhen." eh="d1420b97" />
     <e k="sf_treat_action_gypsum" v="Gips ausbringen, um den pH-Wert zu senken." eh="4cb3f0dc" />
     <e k="sf_treat_action_om_low" v="Mist oder Kompost einarbeiten. Strohmatte auf dem Feld belassen." eh="33ec544c" />
     <e k="sf_treat_action_om_fair" v="Zufuhr Organischer Substanz beibehalten." eh="ae3af748" />
     <e k="sf_treat_action_n_poor" v="AHL-32, Harnstoff oder Ammoniumsulfat ausbringen." eh="ebc225b0" />
-    <e k="sf_treat_action_n_fair" v="Ammoniumsulfat oder Starter-D├╝nger ausbringen." eh="dc8fbeba" />
+    <e k="sf_treat_action_n_fair" v="Ammoniumsulfat oder Starter-Dünger ausbringen." eh="dc8fbeba" />
     <e k="sf_treat_action_p_poor" v="MAP oder DAP ausbringen." eh="ec2d9afa" />
     <e k="sf_treat_action_p_fair" v="MAP oder DAP ausbringen." eh="0c99c3e8" />
     <e k="sf_treat_action_k_poor" v="Kaliumchlorid ausbringen." eh="bb2960f3" />
@@ -554,8 +554,8 @@
     <e k="sf_detail_yield_eff_label" v="Effizienz" eh="2aa6bf08" />
     <e k="sf_detail_yield_optimal" v="Optimal" eh="cb61fef1" />
     <e k="sf_detail_rotation_bonus" v="Stickstofffixierung durch Leguminosen" eh="8ab86f6a" />
-    <e k="sf_detail_rotation_fatigue" v="unpassende Vorfrucht (1,15-fach erh├Âhter N├ñhrstoffentzug)" eh="522a6d93" />
-    <e k="sf_detail_no_field" v="Keine Daten verf├╝gbar." eh="c6d95d5e" />
+    <e k="sf_detail_rotation_fatigue" v="unpassende Vorfrucht (1,15-fach erhöhter Nährstoffentzug)" eh="522a6d93" />
+    <e k="sf_detail_no_field" v="Keine Daten verfügbar." eh="c6d95d5e" />
     <e k="sf_detail_no_crop" v="Keine Aufzeichnugen." eh="a4b5a996" />
 
     <e k="sf_hud_label_ph" v="pH" eh="397dff20" />
@@ -569,97 +569,97 @@
     <e k="sf_hud_amend_burn" v="[EN] Burn penalty: -%d%%" eh="34059aac" />
 		<e k="sf_hud_burn_risk" v="[EN] Amend. burn risk: Yes" eh="6f553cf3" />
 
-    <e k="sf_sprayer_auto_on" v="Bedarfsgerechte D├╝ngung aktiv" eh="099b5dac" />
-    <e k="sf_sprayer_auto_off" v="Bedarfsgerechte D├╝ngung inaktiv [%s]" eh="848cc106" />
+    <e k="sf_sprayer_auto_on" v="Bedarfsgerechte Düngung aktiv" eh="099b5dac" />
+    <e k="sf_sprayer_auto_off" v="Bedarfsgerechte Düngung inaktiv [%s]" eh="848cc106" />
     <e k="sf_sprayer_target" v="Angestrebte Menge:" eh="31d43504" />
-    <e k="sf_sprayer_burn_guaranteed" v="Ver├ñtzungen garantiert" eh="422601c4" />
-    <e k="sf_sprayer_burn_possible" v="Ver├ñtzungen m├Âglich" eh="25b251b6" />
+    <e k="sf_sprayer_burn_guaranteed" v="Verätzungen garantiert" eh="422601c4" />
+    <e k="sf_sprayer_burn_possible" v="Verätzungen möglich" eh="25b251b6" />
 
-    <e k="sf_notify_welcome" v="Boden- &amp; D├╝nger-Mod aktiv | J = HUD | K = Bodenbericht | 'soilfertility' f├╝r Befehle" eh="d97e4139" />
+    <e k="sf_notify_welcome" v="Boden- &amp; Dünger-Mod aktiv | J = HUD | K = Bodenbericht | 'soilfertility' für Befehle" eh="d97e4139" />
     <e k="sf_startup_dialog_version" v="Neuheiten in dieser Version:" eh="0b25f5c2" />
     <e k="sf_startup_dialog_footer" v="Vielen Dank, dass du meinen Mod benutzt, es bedeutet mir viel &lt;3" eh="0f08d735" />
     <e k="sf_startup_dialog_footer2" v="Fehler gefunden? Bitte melde ihn auf GitHub!" eh="728e2cf3" />
-    <e k="sf_startup_dialog_footer3" v="Fr├Âhliches Farmen und nicht vergessen:" eh="aa38e511" />
+    <e k="sf_startup_dialog_footer3" v="Fröhliches Farmen und nicht vergessen:" eh="aa38e511" />
     <e k="sf_startup_dialog_footer4" v="Dein Boden vergisst nichts..." eh="1a3e5c35" />
-    <e k="sf_notify_init_delayed" v="Boden-Mod: Feldinitialisierung verz├Âgert. Versuche alternative Methode..." eh="f8bd28f8" />
+    <e k="sf_notify_init_delayed" v="Boden-Mod: Feldinitialisierung verzögert. Versuche alternative Methode..." eh="f8bd28f8" />
     <e k="sf_notify_init_success" v="Boden-Mod: Feldinitialisierung erfolgreich!" eh="46214360" />
     <e k="sf_notify_critical_title" v="Kritischer Pflegealarm" eh="3f981d0c" />
-    <e k="sf_notify_critical_body" v="Feld %d ben├Âtigt deine Aufmerksamkeit! Zustand: %d%%" eh="171246aa" />
+    <e k="sf_notify_critical_body" v="Feld %d benötigt deine Aufmerksamkeit! Zustand: %d%%" eh="171246aa" />
     <e k="sf_notify_treated_title" v="Boden-Update" eh="4633156e" />
-    <e k="sf_notify_treated_body" v="Feld %d vollst├ñndig mit %s behandelt" eh="585aa9b7" />
-    <e k="sf_notify_burn_title" v="D├╝ngersch├ñden" eh="ad8ed599" />
-    <e k="sf_notify_burn_body" v="Feld %d: Sch├ñden durch ├£berdosierung (pH %.1f)" eh="cb731ee3" />
-    <e k="sf_notify_sync_error" v="Boden-Mod: Datensynchronisationsproblem erkannt. Bitte melden, falls dies anh├ñlt." eh="1a307946" />
+    <e k="sf_notify_treated_body" v="Feld %d vollständig mit %s behandelt" eh="585aa9b7" />
+    <e k="sf_notify_burn_title" v="Düngerschäden" eh="ad8ed599" />
+    <e k="sf_notify_burn_body" v="Feld %d: Schäden durch Überdosierung (pH %.1f)" eh="cb731ee3" />
+    <e k="sf_notify_sync_error" v="Boden-Mod: Datensynchronisationsproblem erkannt. Bitte melden, falls dies anhält." eh="1a307946" />
     <e k="sf_notify_lime_crop_title" v="Warnung Bodenverbesserung" eh="33228c86" />
     <e k="sf_notify_lime_crop_body" v="[EN] Field %d: Lime on growing crop - yield -80%% at harvest!" eh="9174b3ef" />
     <e k="sf_notify_om_crop_title" v="Warnung Bodenverbesserung" eh="33228c86" />
     <e k="sf_notify_om_crop_body" v="[EN] Field %d: Organic matter on growing crop - yield -20%% at harvest." eh="8a78f46a" />
 
     <e k="sf_panel_cat_sim" v="Spielmechanik" eh="4f502b57" />
-    <e k="sf_panel_cat_sim_desc" v="Ver├ñndere den Einfluss von Feuchtigkeit, Niederschlag und den Jahreszeiten auf deine B├Âden." eh="3c584cdb" />
+    <e k="sf_panel_cat_sim_desc" v="Verändere den Einfluss von Feuchtigkeit, Niederschlag und den Jahreszeiten auf deine Böden." eh="3c584cdb" />
     <e k="sf_panel_cat_display" v="Anzeige" eh="37b17394" />
-    <e k="sf_panel_cat_display_desc" v="Gestalte das HUD so wie du m├Âchtstest: Gr├Â├ƒe, Farbschema und Position." eh="5b91fada" />
+    <e k="sf_panel_cat_display_desc" v="Gestalte das HUD so wie du möchtstest: Größe, Farbschema und Position." eh="5b91fada" />
     <e k="sf_panel_cat_overlay" v="Overlay" eh="28b898b6" />
     <e k="sf_panel_cat_overlay_desc" v="Du bestimmst was du auf der Karte zu sehen bekommst." eh="a5892aef" />
     <e k="sf_panel_hdr_core" v="Simulation" eh="44a497a5" />
     <e k="sf_panel_hdr_difficulty" v="Schwierigkeitsgrad" eh="7b29ca96" />
-    <e k="sf_panel_hdr_environment" v="Umwelteinfl├╝sse" eh="0ba29c6a" />
+    <e k="sf_panel_hdr_environment" v="Umwelteinflüsse" eh="0ba29c6a" />
     <e k="sf_panel_hdr_crop_stress" v="Wirtschaftliche Schadschwelle" eh="260167bb" />
     <e k="sf_panel_hdr_visibility" v="HUD-Sichtbarkeit" eh="1729a56c" />
     <e k="sf_panel_hdr_hud_style" v="Darstellung" eh="1d4a8cac" />
     <e k="sf_panel_hdr_position" v="Layout" eh="52f5e0bc" />
     <e k="sf_panel_hdr_layer" v="Darstellung" eh="359b71e8" />
     <e k="sf_panel_hdr_performance" v="Grafik" eh="9446a98a" />
-    <e k="sf_panel_hdr_mod_ctrl" v="Zus├ñtzliche Einstellungen" eh="ae2e88fb" />
+    <e k="sf_panel_hdr_mod_ctrl" v="Zusätzliche Einstellungen" eh="ae2e88fb" />
     <e k="sf_panel_hdr_systems" v="Simulation" eh="d6856404" />
     <e k="sf_panel_hdr_actions" v="Werkzeuge" eh="f64ba1c9" />
     <e k="sf_panel_hdr_hud_layout" v="HUD-Layout" eh="54e1930b" />
     <e k="sf_hud_enter_drag_label" v="Panels bewegen &amp; skalieren" eh="be34d24d" />
-    <e k="sf_hud_enter_drag_desc" v="Verschiebe das HUD um seine Position zu ver├ñndern, ziehe an den Ecken um die Gr├Â├ƒe zu ├ñndern und dr├╝cke ESC oder Rechtsklick wenn du fertig bist." eh="1d7b1dee" />
+    <e k="sf_hud_enter_drag_desc" v="Verschiebe das HUD um seine Position zu verändern, ziehe an den Ecken um die Größe zu ändern und drücke ESC oder Rechtsklick wenn du fertig bist." eh="1d7b1dee" />
 
     <e k="sf_panel_admin_yes" v="Administrator" eh="4628842a" />
     <e k="sf_panel_admin_no" v="kein Administrator" eh="a9394f7b" />
     <e k="sf_panel_multiplayer" v="Multiplayer" eh="901a7320" />
     <e k="sf_panel_singleplayer" v="Einzelspieler" eh="da602601" />
-    <e k="sf_panel_btn_back" v="&lt; Zur├╝ck" eh="36cf3e1f" />
+    <e k="sf_panel_btn_back" v="&lt; Zurück" eh="36cf3e1f" />
     <e k="sf_panel_btn_reset_cat" v="Standardwerte wiederherstellen" eh="b66faa88" />
-    <e k="sf_panel_btn_close_hint" v="Schlie├ƒen: SHIFT+O" eh="254406e3" />
-    <e k="sf_panel_select_category" v="W├ñhle eine Kategorie um Einstellungen anzupassen" eh="a277d257" />
+    <e k="sf_panel_btn_close_hint" v="Schließen: SHIFT+O" eh="254406e3" />
+    <e k="sf_panel_select_category" v="Wähle eine Kategorie um Einstellungen anzupassen" eh="a277d257" />
     <e k="sf_panel_btn_configure" v="Einstellungen" eh="a2cb3902" />
-    <e k="sf_panel_btn_open" v="├ûffnen" eh="6624d17c" />
+    <e k="sf_panel_btn_open" v="Öffnen" eh="6624d17c" />
 
     <e k="sf_desc_enabled" v="Die Modifikation an- oder ausschalten" eh="895364cb" />
-    <e k="sf_desc_debugMode" v="Speichert n├╝tzliche Log-Daten f├╝r die Fehlersuche" eh="de508edb" />
+    <e k="sf_desc_debugMode" v="Speichert nützliche Log-Daten für die Fehlersuche" eh="de508edb" />
     <e k="sf_desc_fertilitySystem" v="realistische Simulation der Bodenfruchtbarkeit" eh="40efd611" />
-    <e k="sf_desc_nutrientCycles" v="Die Makron├ñhrstoffe in deinen B├Âden k├Ânnen sinken und wieder aufgef├╝llt werden." eh="6eff80b3" />
-    <e k="sf_desc_fertilizerCosts" v="realistische D├╝ngerpreise" eh="1c197c9f" />
-    <e k="sf_desc_showNotifications" v="erhalte Benachrichtigungen ├╝ber den Zustand deiner B├Âden" eh="7f275b4b" />
+    <e k="sf_desc_nutrientCycles" v="Die Makronährstoffe in deinen Böden können sinken und wieder aufgefüllt werden." eh="6eff80b3" />
+    <e k="sf_desc_fertilizerCosts" v="realistische Düngerpreise" eh="1c197c9f" />
+    <e k="sf_desc_showNotifications" v="erhalte Benachrichtigungen über den Zustand deiner Böden" eh="7f275b4b" />
     <e k="sf_desc_showHUD" v="HUD anzeigen" eh="fa8b9224" />
     <e k="sf_desc_showWorkTrail" v="Zeige kleine Markierungen auf dem Feld," eh="3a3da614" />
 		<e k="sf_desc_showSprayerInfoPanel" v="Zeige das Feldspritzen-HUD wenn du ein entsprechende Maschine benutzt" eh="016b4402" />
-		<e k="sf_desc_showHarvesterPanel" v="Zeige das M├ñhdrescher-HUD wenn du ein entsprechende Maschine benutzt" eh="b16a1726" />
+		<e k="sf_desc_showHarvesterPanel" v="Zeige das Mähdrescher-HUD wenn du ein entsprechende Maschine benutzt" eh="b16a1726" />
     <e k="sf_desc_hudPosition" v="Ausrichtung" eh="98c8bcea" />
     <e k="sf_desc_hudColorTheme" v="Farbschema" eh="97271907" />
-    <e k="sf_desc_hudFontSize" v="Textgr├Â├ƒe" eh="48a6fc15" />
+    <e k="sf_desc_hudFontSize" v="Textgröße" eh="48a6fc15" />
     <e k="sf_desc_hudTransparency" v="Hintergrundtransparenz" eh="d20d72dc" />
     <e k="sf_desc_seasonalEffects" v="beeinflusst den Stickstoffhaushalt deiner Pflanzen" eh="f515f484" />
-    <e k="sf_desc_rainEffects" v="Regen verursacht N├ñhrstoffauswaschung" eh="82fec75d" />
-    <e k="sf_desc_plowingBonus" v="Pflugbonus f├╝r Bodenwiederherstellung" eh="23522b97" />
-    <e k="sf_desc_residueIncorporation" v="Bodenbearbeitung setzt N├ñhrstoffe aus Ernter├╝ckst├ñnden frei" eh="e8cd556b" />
-    <e k="sf_desc_weedPressure" v="Unkraut konkurriert mit den Kulturpflanzen um Wasser und N├ñhrstoffe und kann den Ertrag verringern." eh="df20c38d" />
-    <e k="sf_desc_pestPressure" v="Sch├ñdlinge k├Ânnen Pflanzen sch├ñdigen und bei starkem Befall den Ertrag reduzieren." eh="12b3412e" />
-    <e k="sf_desc_diseasePressure" v="Ein Befall mit Krankheiten kann das Pflanzenwachstum beeintr├ñchtigen und zu Ertragsverlusten f├╝hren." eh="0858395f" />
+    <e k="sf_desc_rainEffects" v="Regen verursacht Nährstoffauswaschung" eh="82fec75d" />
+    <e k="sf_desc_plowingBonus" v="Pflugbonus für Bodenwiederherstellung" eh="23522b97" />
+    <e k="sf_desc_residueIncorporation" v="Bodenbearbeitung setzt Nährstoffe aus Ernterückständen frei" eh="e8cd556b" />
+    <e k="sf_desc_weedPressure" v="Unkraut konkurriert mit den Kulturpflanzen um Wasser und Nährstoffe und kann den Ertrag verringern." eh="df20c38d" />
+    <e k="sf_desc_pestPressure" v="Schädlinge können Pflanzen schädigen und bei starkem Befall den Ertrag reduzieren." eh="12b3412e" />
+    <e k="sf_desc_diseasePressure" v="Ein Befall mit Krankheiten kann das Pflanzenwachstum beeinträchtigen und zu Ertragsverlusten führen." eh="0858395f" />
     <e k="sf_desc_diseaseMoisture" v="Klimatische Bedingungen wie die Luftfeuchtigkeit haben einen Einfluss auf die Ausbreitung von Krankheiten und die Wirksamkeit von Fungiziden." eh="97cb48de" />
-    <e k="sf_desc_compactionEnabled" v="Der Boden wird durch schwere Ger├ñte und Fahrzeuge verdichtet" eh="a7d3a795" />
-    <e k="sf_desc_difficulty" v="Intensit├ñt des N├ñhrstoffentzugs" eh="54a7902e" />
-    <e k="sf_desc_replenishmentRate" v="Geschwindigkeit der N├ñhrstoffwiederherstellung" eh="858d2b23" />
+    <e k="sf_desc_compactionEnabled" v="Der Boden wird durch schwere Geräte und Fahrzeuge verdichtet" eh="a7d3a795" />
+    <e k="sf_desc_difficulty" v="Intensität des Nährstoffentzugs" eh="54a7902e" />
+    <e k="sf_desc_replenishmentRate" v="Geschwindigkeit der Nährstoffwiederherstellung" eh="858d2b23" />
     <e k="sf_desc_useImperialUnits" v="Einheiten werden in gal/ac und lb/ac dargestellt." eh="8ba3d81a" />
     <e k="sf_desc_autoRateControl" v="DoseControl" eh="bb4e5880" />
-    <e k="sf_desc_cropRotation" v="Unterschiedliche Kulturen haben unterschiedliche Einfl├╝sse auf die Folgekultur" eh="bb79b03a" />
+    <e k="sf_desc_cropRotation" v="Unterschiedliche Kulturen haben unterschiedliche Einflüsse auf die Folgekultur" eh="bb79b03a" />
     <e k="sf_desc_activeMapLayer" v="Welche Information als Overlay auf der Minimap angezeigt wird" eh="3c01c599" />
-    <e k="sf_desc_overlayDensity" v="Darstellungsqualit├ñt des Overlay. Niedrig: 8k, Mittel: 20k oder Hoch: 40k" eh="42503763" />
-    <e k="sf_desc_colorblindMode" v="Orange- und Blaut├Âne anstatt von Rot- und Gr├╝nt├Ânen verwenden" eh="2862b921" />
-    <e k="sf_desc_showFieldInfoBox" v="Zeige die Informationen in der Standard-Feldinfo w├ñhrend du auf einem Feld stehst." eh="815e419e" />
+    <e k="sf_desc_overlayDensity" v="Darstellungsqualität des Overlay. Niedrig: 8k, Mittel: 20k oder Hoch: 40k" eh="42503763" />
+    <e k="sf_desc_colorblindMode" v="Orange- und Blautöne anstatt von Rot- und Grüntönen verwenden" eh="2862b921" />
+    <e k="sf_desc_showFieldInfoBox" v="Zeige die Informationen in der Standard-Feldinfo während du auf einem Feld stehst." eh="815e419e" />
 
     <e k="sf_rr_1" v="Sehr langsam (0.25x)" eh="b681a1b4" />
     <e k="sf_rr_2" v="Langsam (0.5x)" eh="db69874d" />
@@ -674,7 +674,7 @@
     <e k="sf_layer_6" v="Organische Substanz" eh="d2e254bc" />
     <e k="sf_layer_7" v="Zustand" eh="c94e3850" />
     <e k="sf_layer_8" v="Unkraut" eh="2b75024d" />
-    <e k="sf_layer_9" v="Sch├ñdlinge" eh="8f2aee79" />
+    <e k="sf_layer_9" v="Schädlinge" eh="8f2aee79" />
     <e k="sf_layer_10" v="Krankheiten" eh="e7067a8c" />
     <e k="sf_layer_11" v="Verdichtung" eh="19cf3ee7" />
     <e k="sf_density_1" v="Niedrig" eh="28d0edd0" />
@@ -683,43 +683,43 @@
 
     <e k="sf_admin_save_label" v="Daten sichern" eh="d4e9a279" />
     <e k="sf_admin_save_desc" v="Es werden alle Bodendaten gespeichert." eh="f365613a" />
-    <e k="sf_admin_reset_label" v="Einstellungen zur├╝cksetzen" eh="6e7d5f9f" />
-    <e k="sf_admin_reset_desc" v="Setzt alle Einstellungen auf ihre Standardwerte zur├╝ck" eh="599b7454" />
+    <e k="sf_admin_reset_label" v="Einstellungen zurücksetzen" eh="6e7d5f9f" />
+    <e k="sf_admin_reset_desc" v="Setzt alle Einstellungen auf ihre Standardwerte zurück" eh="599b7454" />
     
     <e k="sf_panel_hdr_field_tools" v="Feldverwaltung" eh="2b250a56" />
     <e k="sf_nav_field_tools_label" v="Feldverwaltung" eh="2b250a56" />
-    <e k="sf_nav_field_tools_desc" v="Werkzeuge zum ├£berpr├╝fen und Bearbeiten von Feldzust├ñnden." eh="360db19b" />
+    <e k="sf_nav_field_tools_desc" v="Werkzeuge zum Überprüfen und Bearbeiten von Feldzuständen." eh="360db19b" />
     
     <e k="sf_panel_hdr_vehicle_tools" v="Fahrzeugverwaltung" eh="9b6d6e4c" />
     <e k="sf_nav_vehicle_tools_label" v="Fahrzeugverwaltung" eh="9b6d6e4c" />
-    <e k="sf_nav_vehicle_tools_desc" v="Werkzeuge f├╝r Fahrzeuge und Ger├ñte." eh="1a8b2100" />
+    <e k="sf_nav_vehicle_tools_desc" v="Werkzeuge für Fahrzeuge und Geräte." eh="1a8b2100" />
     <e k="sf_admin_drain_label" v="Entleeren" eh="d216b101" />
-    <e k="sf_admin_drain_desc" v="Ger├ñt oder Fahrzeug entleeren. Dir werden 50% erstattet." eh="5e048a34" />
+    <e k="sf_admin_drain_desc" v="Gerät oder Fahrzeug entleeren. Dir werden 50% erstattet." eh="5e048a34" />
     <e k="sf_admin_field_info_label" v="Diagnose" eh="5df500d6" />
-    <e k="sf_admin_field_info_desc" v="Aktuellen Daten f├╝r das Feld an deiner Position." eh="b7e2a72d" />
+    <e k="sf_admin_field_info_desc" v="Aktuellen Daten für das Feld an deiner Position." eh="b7e2a72d" />
     <e k="sf_admin_field_forecast_label" v="Prognose" eh="1df41470" />
-    <e k="sf_admin_field_forecast_desc" v="Ertragsprognose f├╝r das aktuelle Feld." eh="67e56b9d" />
+    <e k="sf_admin_field_forecast_desc" v="Ertragsprognose für das aktuelle Feld." eh="67e56b9d" />
     <e k="sf_admin_list_fields_label" v="Liste" eh="efeb1b25" />
     <e k="sf_admin_list_fields_desc" v="Alle Daten von jedem Feld in die Log-Datei schreiben." eh="c9fa812e" />
     <e k="sf_admin_field_set_state_label" v="Feldzustand" eh="5b0d7a31" />
     <e k="sf_admin_field_set_state_desc" v="N, P, K, pH-Wert und OS-Anteil anpassen." eh="a491e190" />
-    <e k="sf_admin_field_recover_label" v="Zur├╝cksetzen" eh="e1c82ff0" />
-    <e k="sf_admin_field_recover_desc" v="Aktuelles Feld auf Standardwerte zur├╝cksetzen." eh="68b687a2" />
-    <e k="sf_infobox_title" v="Bodenn├ñhrstoffe" eh="64377acf" />
-    <e k="sf_infobox_grade" v="Bodenqualit├ñt" eh="65d1be5f" />
+    <e k="sf_admin_field_recover_label" v="Zurücksetzen" eh="e1c82ff0" />
+    <e k="sf_admin_field_recover_desc" v="Aktuelles Feld auf Standardwerte zurücksetzen." eh="68b687a2" />
+    <e k="sf_infobox_title" v="Bodennährstoffe" eh="64377acf" />
+    <e k="sf_infobox_grade" v="Bodenqualität" eh="65d1be5f" />
     <e k="sf_infobox_needs" v="Bedarf" eh="94d6125d" />
-    <e k="sf_infobox_fertilizer" v="D├╝nger" eh="cd248829" />
+    <e k="sf_infobox_fertilizer" v="Dünger" eh="cd248829" />
 
-    <e k="sf_fieldinfo_box_title" v="Bodenn├ñhrstoffe" eh="64377acf" />
-    <e k="sf_fieldinfo_grade" v="Bodenqualit├ñt" eh="65d1be5f" />
+    <e k="sf_fieldinfo_box_title" v="Bodennährstoffe" eh="64377acf" />
+    <e k="sf_fieldinfo_grade" v="Bodenqualität" eh="65d1be5f" />
     <e k="sf_fieldinfo_yield" v="Ertrag" eh="97345487" />
     <e k="sf_fieldinfo_rotation" v="Fruchtfolge" eh="f1a42bd4" />
 		<e k="sf_fieldinfo_disease" v="Krankheit" eh="a94ce36d" />
-		<e k="sf_fieldinfo_burn_risk" v="Ver├ñtzungsrisiko" eh="759e4661" />
+		<e k="sf_fieldinfo_burn_risk" v="Verätzungsrisiko" eh="759e4661" />
 		<e k="sf_fieldinfo_sim_status" v="Simulation" eh="c39e57f0" />
-    <e k="sf_fieldinfo_needs" v="ben├Âtigt" eh="94d6125d" />
+    <e k="sf_fieldinfo_needs" v="benötigt" eh="94d6125d" />
     <e k="sf_field" v="Feld" eh="6f16a5f8" />
-    <e k="sf_no_field" v="Kein Feld ausgew├ñhlt" eh="717ff56f" />
+    <e k="sf_no_field" v="Kein Feld ausgewählt" eh="717ff56f" />
     <e k="sf_overall_Good" v="Gut" eh="0c6ad70b" />
     <e k="sf_overall_Fair" v="Mittel" eh="f7f20cf0" />
     <e k="sf_overall_Poor" v="Schlecht" eh="0e94d017" />
@@ -736,15 +736,15 @@
     <e k="sf_panel_hdr_smart_systems"    v="Smart-Systeme" />
     <e k="sf_smart_sensor_short"         v="Smart-Sensor" />
     <e k="sf_smart_sensor_long"          v="Smart-Spray-Sensor-System aktivieren oder deaktivieren" />
-    <e k="sf_desc_smartSensorEnabled"    v="Erlaubt Spielern die Smart-Sensor-Gest├ñngesektionssteuerung auf Basis von Live-Bodendaten" />
+    <e k="sf_desc_smartSensorEnabled"    v="Erlaubt Spielern die Smart-Sensor-Gestängesektionssteuerung auf Basis von Live-Bodendaten" />
     <!-- SMART-SENSOR-PANEL -->
     <e k="sf_sensor_panel_title" v="SMARTSPRAY-Sensoren" eh="33809906" />
-    <e k="sf_sensor_pest"        v="Sch├ñdlingssensor" />
+    <e k="sf_sensor_pest"        v="Schädlingssensor" />
     <e k="sf_sensor_disease"     v="Krankheitssensor" />
-    <e k="sf_sensor_nutrient"    v="N├ñhrstoffsensor" />
+    <e k="sf_sensor_nutrient"    v="Nährstoffsensor" />
     <e k="sf_sensor_state_on"    v="EIN" />
     <e k="sf_sensor_state_off"   v="AUS" />
-    <e k="action_SF_SENSOR_PEST"     v="SF: Sch├ñdlingssensor umschalten" />
+    <e k="action_SF_SENSOR_PEST"     v="SF: Schädlingssensor umschalten" />
     <e k="action_SF_SENSOR_DISEASE"  v="SF: Krankheitssensor umschalten" />
         <!-- SMART-SYSTEME -->
     <e k="sf_nav_smart_systems_label"      v="Smart-Systeme" />
@@ -757,78 +757,78 @@
     <e k="sf_panel_hdr_see_spray_sys"      v="See-&amp;-Spray-System" />
     <e k="sf_panel_hdr_var_rate_sys"       v="Variable-Rate-System" />
     <e k="sf_see_and_spray_short"          v="See &amp; Spray" />
-    <e k="sf_see_and_spray_long"           v="See-&amp;-Spray-Pr├ñzisionsspr├╝hsystem aktivieren oder deaktivieren" />
+    <e k="sf_see_and_spray_long"           v="See-&amp;-Spray-Präzisionssprühsystem aktivieren oder deaktivieren" />
     <e k="sf_variable_rate_short"          v="Variable Ausbringmenge" />
     <e k="sf_variable_rate_long"           v="Variable Ausbringmenge basierend auf Bodendefiziten aktivieren oder deaktivieren" />
-    <e k="sf_desc_seeAndSprayEnabled"      v="Gest├ñngesektionen ├╝ber Bereichen ohne Spritzbedarf unterdr├╝cken" />
+    <e k="sf_desc_seeAndSprayEnabled"      v="Gestängesektionen über Bereichen ohne Spritzbedarf unterdrücken" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Unkraut" />
-    <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Sch├ñdlinge" />
+    <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Schädlinge" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Krankheit" />
-    <e k="sf_desc_variableRateEnabled"     v="Ausbringmenge pro Sektion basierend auf Bodenn├ñhrstoffdefiziten anpassen" />
+    <e k="sf_desc_variableRateEnabled"     v="Ausbringmenge pro Sektion basierend auf Bodennährstoffdefiziten anpassen" />
     <e k="sf_panel_hdr_field_boundary"     v="Feldgrenzenkontrolle" />
     <e k="sf_field_boundary_short"         v="Grenzenkontrolle" />
     <e k="sf_field_boundary_long"          v="Automatische Feldgrenzen-Sektionssteuerung aktivieren oder deaktivieren" />
-    <e k="sf_desc_fieldBoundaryControl"    v="Schaltet Gest├ñngesektionen automatisch ab, die au├ƒerhalb der Feldgrenzen liegen, und verhindert so Ausbringung au├ƒerhalb des Feldes." />
-    <e k="sf_panel_hdr_overlap_prev"      v="├£berlappungsvermeidung" />
-    <e k="sf_overlap_prev_short"           v="├£berlappungsvermeidung" />
-    <e k="sf_overlap_prev_long"            v="Dichtekartenbasierte ├£berlappungsvermeidung aktivieren oder deaktivieren" />
-    <e k="sf_desc_overlapPrevention"       v="Schaltet Gest├ñngesektionen ├╝ber bereits vollst├ñndig ged├╝ngten Fl├ñchen automatisch ab und verhindert verschwenderische Doppelausbringung auf ├£berlappungen." />
+    <e k="sf_desc_fieldBoundaryControl"    v="Schaltet Gestängesektionen automatisch ab, die außerhalb der Feldgrenzen liegen, und verhindert so Ausbringung außerhalb des Feldes." />
+    <e k="sf_panel_hdr_overlap_prev"      v="Überlappungsvermeidung" />
+    <e k="sf_overlap_prev_short"           v="Überlappungsvermeidung" />
+    <e k="sf_overlap_prev_long"            v="Dichtekartenbasierte Überlappungsvermeidung aktivieren oder deaktivieren" />
+    <e k="sf_desc_overlapPrevention"       v="Schaltet Gestängesektionen über bereits vollständig gedüngten Flächen automatisch ab und verhindert verschwenderische Doppelausbringung auf Überlappungen." />
 
     <!-- SMART-SENSOR-PANEL -->
     <!-- SEE-&-SPRAY-PANEL -->
-    <e k="sf_see_spray_panel_title" v="Punktuelle Unkrautbek├ñmpfung" eh="a7e00bf0" />
-    <e k="sf_see_spray_pest"        v="Sch├ñdlinge" />
+    <e k="sf_see_spray_panel_title" v="Punktuelle Unkrautbekämpfung" eh="a7e00bf0" />
+    <e k="sf_see_spray_pest"        v="Schädlinge" />
     <e k="sf_see_spray_disease"     v="Krankheit" />
     <e k="sf_see_spray_weed"        v="Unkraut" />
-    <e k="sf_see_spray_suppressed"  v="Alle Sektionen unterdr├╝ckt: kein Druck erkannt" />
+    <e k="sf_see_spray_suppressed"  v="Alle Sektionen unterdrückt: kein Druck erkannt" />
     <!-- PANEL F├£R VARIABLE AUSBRINGMENGE -->
     <e k="sf_var_rate_panel_title" v="SmartRate" eh="799c3bf7" />
     <e k="sf_var_rate_label"       v="Var. Rate" />
     <!-- EINGABEAKTIONEN -->
-    <e k="action_SF_SENSOR_NUTRIENT"   v="SF: N├ñhrstoffsensor umschalten" />
-    <e k="action_SF_SEE_SPRAY_PEST"    v="SF: See &amp; Spray Sch├ñdlinge umschalten" />
+    <e k="action_SF_SENSOR_NUTRIENT"   v="SF: Nährstoffsensor umschalten" />
+    <e k="action_SF_SEE_SPRAY_PEST"    v="SF: See &amp; Spray Schädlinge umschalten" />
     <e k="action_SF_SEE_SPRAY_DISEASE" v="SMARTSPRAY-Sensor Krankheit umschalten" eh="205a3668" />
     <e k="action_SF_SEE_SPRAY_WEED"    v="SF: See &amp; Spray Unkraut umschalten" />
     <e k="action_SF_VARIABLE_RATE"     v="SF: Variable Ausbringmenge umschalten" />
         <!-- HUD-LAYOUT-ZIEHMODUS-SCHALTFL├äCHE -->
     <e k="sf_independent_panels_short" v="Freies Panel-Layout" eh="704a20a4" />
-    <e k="sf_independent_panels_long" v="Smart-System-Panels d├╝rfen im Bearbeitungsmodus unabh├ñngig positioniert werden" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="69091cec" />
+    <e k="sf_independent_panels_long" v="Smart-System-Panels dürfen im Bearbeitungsmodus unabhängig positioniert werden" eh="de43cebd" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="d61cf296" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="69091cec" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="da09523b" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="438cd61b" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="ab1d5b05" />
     <e k="sf_guide_sub_5" v="[EN] F.A.Q. - Common questions answered" eh="b383de9c" />
     <e k="sf_guide_p1_01" v="WAS IST DIESE MOD" eh="fe4d3283" />
-    <e k="sf_guide_p1_02" v="Sie verfolgt 5 Bodenn├ñhrstoffe pro Feld ├╝ber Ihren" eh="93e6595b" />
-    <e k="sf_guide_p1_03" v="Hof hinweg. Pflanzen entziehen bei der Ernte N├ñhrstoffe." eh="5e6dc5a8" />
-    <e k="sf_guide_p1_04" v="D├╝nger f├╝llt sie wieder auf. Wetter und" eh="325d9382" />
+    <e k="sf_guide_p1_02" v="Sie verfolgt 5 Bodennährstoffe pro Feld über Ihren" eh="93e6595b" />
+    <e k="sf_guide_p1_03" v="Hof hinweg. Pflanzen entziehen bei der Ernte Nährstoffe." eh="5e6dc5a8" />
+    <e k="sf_guide_p1_04" v="Dünger füllt sie wieder auf. Wetter und" eh="325d9382" />
     <e k="sf_guide_p1_05" v="Jahreszeiten erzeugen mit der Zeit realistischen Druck." eh="bd62219e" />
     <e k="sf_guide_p1_06" v="DIE 5 BODENPARAMETER" eh="6c5948d1" />
-    <e k="sf_guide_p1_07" v="N   Stickstoff      Wird bei jeder Ernte zu gro├ƒen Teilen entfernt." eh="df28927d" />
-    <e k="sf_guide_p1_08" v="P   Phosphor        Verschwindet langsamer. Vermehrt bei Wurzelfr├╝chte." eh="651919e6" />
-    <e k="sf_guide_p1_09" v="K   Kalium          Wurzelfr├╝chte entziehen besonders viel." eh="e23e2d33" />
-    <e k="sf_guide_p1_10" v="OS  Organische Substanz   Baut sich ├╝ber viele Saisons langsam auf." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
+    <e k="sf_guide_p1_07" v="N   Stickstoff      Wird bei jeder Ernte zu großen Teilen entfernt." eh="df28927d" />
+    <e k="sf_guide_p1_08" v="P   Phosphor        Verschwindet langsamer. Vermehrt bei Wurzelfrüchte." eh="651919e6" />
+    <e k="sf_guide_p1_09" v="K   Kalium          Wurzelfrüchte entziehen besonders viel." eh="e23e2d33" />
+    <e k="sf_guide_p1_10" v="OS  Organische Substanz   Baut sich über viele Saisons langsam auf." eh="b235300c" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="9b966ead" />
     <e k="sf_guide_p1_12" v="STATUSSTUFEN" eh="b081c2c6" />
-    <e k="sf_guide_p1_13" v="GUT (gr├╝n)  Auf oder ├╝ber dem Optimalwert der Frucht." eh="a081208f" />
-    <e k="sf_guide_p1_14" v="Diese Saison ist keine Aktion n├Âtig." eh="58b36ac2" />
+    <e k="sf_guide_p1_13" v="GUT (grün)  Auf oder über dem Optimalwert der Frucht." eh="a081208f" />
+    <e k="sf_guide_p1_14" v="Diese Saison ist keine Aktion nötig." eh="58b36ac2" />
     <e k="sf_guide_p1_15" v="MITTEL (gelb) Unter dem Optimalwert." eh="0d30dbe4" />
-    <e k="sf_guide_p1_16" v="Eine Aufd├╝ngung einplanen. Ertrag leicht reduziert." eh="0363160b" />
+    <e k="sf_guide_p1_16" v="Eine Aufdüngung einplanen. Ertrag leicht reduziert." eh="0363160b" />
     <e k="sf_guide_p1_17" v="SCHLECHT (rot) Unter dem Mindestschwellwert." eh="96f2a246" />
     <e k="sf_guide_p1_18" v="[EN]   Act now - yield impact is severe." eh="587bdd4a" />
     <e k="sf_guide_p1_19" v="SCHNELLSTART (5 SCHRITTE)" eh="f1bcfcdb" />
-    <e k="sf_guide_p1_20" v="1. PDA ├Âffnen (Spielmen├╝) &gt; Boden &amp; D├╝nger." eh="22539c14" />
-    <e k="sf_guide_p1_21" v="2. Hof├╝bersicht auf rot markierte Felder pr├╝fen." eh="d4e823e8" />
-    <e k="sf_guide_p1_22" v="3. Im Behandlungsplan den Bedarf pr├╝fen." eh="1a0c7961" />
-    <e k="sf_guide_p1_23" v="4. Das passende D├╝ngemittel ausbringen." eh="b44bcac2" />
+    <e k="sf_guide_p1_20" v="1. PDA öffnen (Spielmenü) &gt; Boden &amp; Dünger." eh="22539c14" />
+    <e k="sf_guide_p1_21" v="2. Hofübersicht auf rot markierte Felder prüfen." eh="d4e823e8" />
+    <e k="sf_guide_p1_22" v="3. Im Behandlungsplan den Bedarf prüfen." eh="1a0c7961" />
+    <e k="sf_guide_p1_23" v="4. Das passende Düngemittel ausbringen." eh="b44bcac2" />
     <e k="sf_guide_p1_24" v="[EN] 5. Harvest normally - nutrients auto-deduct." eh="fa399c0f" />
     <e k="sf_guide_p1_25" v="WERKZEUGE AUF EINEN BLICK" eh="103ce1b5" />
-    <e k="sf_guide_p1_26" v="HUD-Balken    Bodenwerte f├╝r Ihr aktuelles Feld." eh="4d0661d7" />
+    <e k="sf_guide_p1_26" v="HUD-Balken    Bodenwerte für Ihr aktuelles Feld." eh="4d0661d7" />
     <e k="sf_guide_p1_27" v="[EN]   Key: Toggle Soil HUD (ships unbound)." eh="4e3fc48e" />
-    <e k="sf_guide_p1_28" v="PDA-Bildschirm  Vollst├ñndige Hof├╝bersicht + Behandlungsplan." eh="a6cc969d" />
+    <e k="sf_guide_p1_28" v="PDA-Bildschirm  Vollständige Hofübersicht + Behandlungsplan." eh="a6cc969d" />
     <e k="sf_guide_p1_29" v="[EN]   Open the ESC menu, Soil &amp; Fertilizer tab." eh="3096c5f3" />
-    <e k="sf_guide_p1_30" v="Bodenkarte    N├ñhrstoff-Overlay pro Zelle." eh="1ade7e4f" />
+    <e k="sf_guide_p1_30" v="Bodenkarte    Nährstoff-Overlay pro Zelle." eh="1ade7e4f" />
     <e k="sf_guide_p1_31" v="[EN]   Key: Cycle Soil Map Layer (ships unbound)." eh="80ee4072" />
     <e k="sf_guide_p1_32" v="[EN] Field Detail Per-field breakdown popup." eh="b48eb562" />
     <e k="sf_guide_p1_33" v="[EN]   Click any row in Farm Overview to open it." eh="56cbdc85" />
@@ -843,89 +843,89 @@
     <e k="sf_guide_p1_42" v="[EN] HUD Drag = Shift+H, Variable Rate = Alt+7," eh="4dde87a3" />
     <e k="sf_guide_p1_43" v="[EN] Scout = Shift+K, Treatment = Shift+T." eh="74a97e3a" />
     <e k="sf_guide_p1_44" v="[EN] Rebind any of them in Options &gt; Controls &gt; Mods." eh="a800a99e" />
-    <e k="sf_guide_p2_01" v="DIE N├äHRSTOFFBALKEN" eh="ad76f0e9" />
-    <e k="sf_guide_p2_02" v="Das HUD zeigt einen Balken pro N├ñhrstoff: N P K OS pH." eh="b84d3955" />
-    <e k="sf_guide_p2_03" v="Der Balken f├╝llt sich von links (0) nach rechts (100 = Maximum)." eh="fb617f3c" />
+    <e k="sf_guide_p2_01" v="DIE NÄHRSTOFFBALKEN" eh="ad76f0e9" />
+    <e k="sf_guide_p2_02" v="Das HUD zeigt einen Balken pro Nährstoff: N P K OS pH." eh="b84d3955" />
+    <e k="sf_guide_p2_03" v="Der Balken füllt sich von links (0) nach rechts (100 = Maximum)." eh="fb617f3c" />
     <e k="sf_guide_p2_04" v="Die Balkenfarbe zeigt den Status auf einen Blick." eh="e07e4240" />
     <e k="sf_guide_p2_05" v="DIE DREI MARKIERUNGEN" eh="70556f5d" />
     <e k="sf_guide_p2_06" v="Jeder Balken hat drei kleine vertikale Markierungen." eh="65bb2211" />
     <e k="sf_guide_p2_07" v="[EN] ORANGE tick - Poor/Fair boundary." eh="5f9f1409" />
     <e k="sf_guide_p2_08" v="Unter dieser Linie ist der Balken ROT." eh="4cebe452" />
     <e k="sf_guide_p2_09" v="Ihr Boden befindet sich im Status SCHLECHT." eh="7a3175e4" />
-    <e k="sf_guide_p2_10" v="Aktion: sofort d├╝ngen." eh="209e2635" />
+    <e k="sf_guide_p2_10" v="Aktion: sofort düngen." eh="209e2635" />
     <e k="sf_guide_p2_11" v="[EN] YELLOW tick - Fair/Good boundary." eh="f7a41325" />
     <e k="sf_guide_p2_12" v="Zwischen orange und gelb ist der Balken GELB." eh="cac82a8d" />
     <e k="sf_guide_p2_13" v="[EN]   Your soil is FAIR - below the crop's optimum." eh="320016a7" />
-    <e k="sf_guide_p2_14" v="Aktion: in dieser Saison aufd├╝ngen einplanen." eh="3cf7dfa3" />
+    <e k="sf_guide_p2_14" v="Aktion: in dieser Saison aufdüngen einplanen." eh="3cf7dfa3" />
     <e k="sf_guide_p2_15" v="[EN] CYAN tick - Your planted crop's optimal target." eh="6a0b26f8" />
-    <e k="sf_guide_p2_16" v="Erreichen Sie diesen Punkt f├╝r maximalen Ertrag." eh="cc7c263f" />
-    <e k="sf_guide_p2_17" v="Wenn er erreicht ist, ist der Balken GR├£N." eh="b5e669ea" />
+    <e k="sf_guide_p2_16" v="Erreichen Sie diesen Punkt für maximalen Ertrag." eh="cc7c263f" />
+    <e k="sf_guide_p2_17" v="Wenn er erreicht ist, ist der Balken GRÜN." eh="b5e669ea" />
     <e k="sf_guide_p2_18" v="Jede Frucht hat andere N/P/K-Zielwerte." eh="d25b96a5" />
     <e k="sf_guide_p2_19" v="DER GEISTERBALKEN" eh="becfc79a" />
-    <e k="sf_guide_p2_20" v="Eine schwache Balkenverl├ñngerung (gleiche Farbe, dunkler)." eh="98f8ec88" />
+    <e k="sf_guide_p2_20" v="Eine schwache Balkenverlängerung (gleiche Farbe, dunkler)." eh="98f8ec88" />
     <e k="sf_guide_p2_21" v="Sie zeigt Ihren prognostizierten Wert NACH dem" eh="61741e0c" />
-    <e k="sf_guide_p2_22" v="Ausbringen des aktuell in Ihrer Spritze geladenen D├╝ngers." eh="7f65010e" />
+    <e k="sf_guide_p2_22" v="Ausbringen des aktuell in Ihrer Spritze geladenen Düngers." eh="7f65010e" />
     <e k="sf_guide_p2_23" v="Fahren Sie mit geladener Spritze auf ein Feld, um ihn zu sehen." eh="771539b2" />
-    <e k="sf_guide_p2_24" v="Damit vermeiden Sie ├£berd├╝ngung und Verschwendung." eh="23015626" />
+    <e k="sf_guide_p2_24" v="Damit vermeiden Sie Überdüngung und Verschwendung." eh="23015626" />
     <e k="sf_guide_p2_25" v="ZAHLEN RICHTIG LESEN" eh="1764c3ed" />
     <e k="sf_guide_p2_26" v="Format:  Wert  /  Ziel  ( +prognose )" eh="6368d79f" />
     <e k="sf_guide_p2_27" v="Beispiel: 245 / 320 (+85)" eh="b40caf59" />
     <e k="sf_guide_p2_28" v="" eh="d41d8cd9" />
     <e k="sf_guide_p2_29" v="245  = Ihr aktueller Stickstoffwert in ppm" eh="fd4fee69" />
     <e k="sf_guide_p2_30" v="320  = Optimaler Stickstoff-Zielwert der Frucht" eh="29f8fc0d" />
-    <e k="sf_guide_p2_31" v="+85  = so viel f├╝gt Ihre aktuelle Spritzenladung hinzu" eh="00ac0744" />
+    <e k="sf_guide_p2_31" v="+85  = so viel fügt Ihre aktuelle Spritzenladung hinzu" eh="00ac0744" />
     <e k="sf_guide_p2_32" v="STATUSFARBEN" eh="e29e5046" />
     <e k="sf_guide_p2_33" v="ROTER Balken   Unter der orangefarbenen Markierung (SCHLECHT)." eh="f9522ff8" />
     <e k="sf_guide_p2_34" v="Ertragsabzug. Jetzt ausbringen." eh="121691a9" />
     <e k="sf_guide_p2_35" v="GELBER Balken Zwischen orange und gelb (MITTEL)." eh="3c16bbc5" />
     <e k="sf_guide_p2_36" v="Leichter Abzug. Vorausschauend planen." eh="74d99045" />
-    <e k="sf_guide_p2_37" v="GR├£NER Balken ├£ber der gelben Markierung (GUT)." eh="922aa27a" />
-    <e k="sf_guide_p2_38" v="Auf oder ├╝ber dem Fruchtoptimum. Keine Aktion." eh="37eb57bb" />
+    <e k="sf_guide_p2_37" v="GRÜNER Balken Über der gelben Markierung (GUT)." eh="922aa27a" />
+    <e k="sf_guide_p2_38" v="Auf oder über dem Fruchtoptimum. Keine Aktion." eh="37eb57bb" />
     <e k="sf_guide_p2_39" v="SMART-SYSTEM-PANELS (VWW-Spritze erforderlich)" eh="0aabd1ee" />
-    <e k="sf_guide_p2_40" v="In einer VWW-f├ñhigen Spritze erscheinen drei Panels:" eh="94268ff4" />
+    <e k="sf_guide_p2_40" v="In einer VWW-fähigen Spritze erscheinen drei Panels:" eh="94268ff4" />
     <e k="sf_guide_p2_41" v="Smart-Sensor / See &amp; Spray / Variable Ausbringmenge." eh="c55d00f9" />
-    <e k="sf_guide_p2_42" v="Aktivierung jeweils ├╝ber Admin &gt; Smart-Systeme in den Einstellungen." eh="1148de7e" />
+    <e k="sf_guide_p2_42" v="Aktivierung jeweils über Admin &gt; Smart-Systeme in den Einstellungen." eh="1148de7e" />
     <e k="sf_guide_p2_43" v="FREIES PANEL-LAYOUT" eh="49225d9e" />
     <e k="sf_guide_p2_44" v="In Einstellungen &gt; Anzeige aktivieren. Mit Shift+H ziehen." eh="d0d2147c" />
     <e k="sf_guide_p2_45" v="Mit [-] in der Titelleiste ein Panel einklappen." eh="44f81359" />
     <e k="sf_guide_p3_01" v="DER LANDWIRTSCHAFTLICHE KREISLAUF" eh="168fa544" />
-    <e k="sf_guide_p3_02" v="N├ñhrstoffentzug  Ernte entzieht dem Boden N/P/K." eh="cc585bcd" />
-    <e k="sf_guide_p3_03" v="Die Menge h├ñngt von Fruchtart und Ertrag ab." eh="261e13ac" />
-    <e k="sf_guide_p3_04" v="AUFF├£LLEN  D├╝ngen Sie, um N├ñhrstoffe wiederherzustellen." eh="91b11b7a" />
-    <e k="sf_guide_p3_05" v="BALANCE  pH und OS ver├ñndern sich langsam ├╝ber die Zeit." eh="d6421178" />
+    <e k="sf_guide_p3_02" v="Nährstoffentzug  Ernte entzieht dem Boden N/P/K." eh="cc585bcd" />
+    <e k="sf_guide_p3_03" v="Die Menge hängt von Fruchtart und Ertrag ab." eh="261e13ac" />
+    <e k="sf_guide_p3_04" v="AUFFÜLLEN  Düngen Sie, um Nährstoffe wiederherzustellen." eh="91b11b7a" />
+    <e k="sf_guide_p3_05" v="BALANCE  pH und OS verändern sich langsam über die Zeit." eh="d6421178" />
     <e k="sf_guide_p3_06" v="Das erfordert langfristiges Management." eh="7adc65a7" />
-    <e k="sf_guide_p3_07" v="T├äGLICHE GEWOHNHEITEN" eh="9df55db7" />
+    <e k="sf_guide_p3_07" v="TÄGLICHE GEWOHNHEITEN" eh="9df55db7" />
     <e k="sf_guide_p3_08" v="1. Vor der Feldarbeit kurz ins HUD schauen." eh="73ebf080" />
-    <e k="sf_guide_p3_09" v="2. Roter Balken = vor oder nach der Kultur d├╝ngen." eh="b0e925a7" />
+    <e k="sf_guide_p3_09" v="2. Roter Balken = vor oder nach der Kultur düngen." eh="b0e925a7" />
     <e k="sf_guide_p3_10" v="3. Gelber Balken = Feld merken, diese Saison behandeln." eh="c93dd62c" />
-    <e k="sf_guide_p3_11" v="4. Gr├╝ner Balken = weiterarbeiten, nichts n├Âtig." eh="107f713e" />
-    <e k="sf_guide_p3_12" v="W├ûCHENTLICHE ROUTINE" eh="a303bfde" />
-    <e k="sf_guide_p3_13" v="PDA &gt; Register Behandlungsplan ├Âffnen." eh="2e03b237" />
+    <e k="sf_guide_p3_11" v="4. Grüner Balken = weiterarbeiten, nichts nötig." eh="107f713e" />
+    <e k="sf_guide_p3_12" v="WÖCHENTLICHE ROUTINE" eh="a303bfde" />
+    <e k="sf_guide_p3_13" v="PDA &gt; Register Behandlungsplan öffnen." eh="2e03b237" />
     <e k="sf_guide_p3_14" v="Felder sind nach Zustand sortiert (schlechtester zuerst)." eh="dece938b" />
     <e k="sf_guide_p3_15" v="Arbeite von ioben nach unten. Behandle Felder mit hohen Zustands-Werten zuerst." eh="4df4bfda" />
-    <e k="sf_guide_p3_16" v="Zeile anklicken, um die detaillierte Feldansicht zu ├Âffnen." eh="147b8267" />
+    <e k="sf_guide_p3_16" v="Zeile anklicken, um die detaillierte Feldansicht zu öffnen." eh="147b8267" />
     <e k="sf_guide_p3_17" v="DEN BEHANDLUNGSPLAN LESEN" eh="ff6ee8e4" />
-    <e k="sf_guide_p3_18" v="Priorit├ñtswerte bewerten, wie weit jeder" eh="39d2360b" />
-    <e k="sf_guide_p3_19" v="N├ñhrstoff unter dem Ziel liegt. Ein Feld mit zwei roten" eh="dc519211" />
-    <e k="sf_guide_p3_20" v="N├ñhrstoffen steht h├Âher als eines mit nur einem mittleren Wert." eh="41d157db" />
+    <e k="sf_guide_p3_18" v="Prioritätswerte bewerten, wie weit jeder" eh="39d2360b" />
+    <e k="sf_guide_p3_19" v="Nährstoff unter dem Ziel liegt. Ein Feld mit zwei roten" eh="dc519211" />
+    <e k="sf_guide_p3_20" v="Nährstoffen steht höher als eines mit nur einem mittleren Wert." eh="41d157db" />
     <e k="sf_guide_p3_21" v="CHECKLISTE VOR DER AUSSAAT" eh="14b36869" />
     <e k="sf_guide_p3_22" v="[EN] 1. Check N level - depletes every harvest." eh="c5c2a681" />
     <e k="sf_guide_p3_23" v="Stickstoff ausbringen, wenn MITTEL oder SCHLECHT." eh="4c69f9f8" />
     <e k="sf_guide_p3_24" v="[EN] 2. Check P and K - change more slowly." eh="f121afca" />
-    <e k="sf_guide_p3_25" v="Auff├╝llen, wenn unter der Mittel-Schwelle." eh="81a25810" />
+    <e k="sf_guide_p3_25" v="Auffüllen, wenn unter der Mittel-Schwelle." eh="81a25810" />
     <e k="sf_guide_p3_26" v="[EN] 3. Check pH - lime if acidic, gypsum if alkaline." eh="29b4ac85" />
     <e k="sf_guide_p3_27" v="[EN] 4. Check OM - add manure or compost if low." eh="d1ead06b" />
     <e k="sf_guide_p3_28" v="MASSNAHMEN NACH DER ERNTE" eh="eb52e29f" />
     <e k="sf_guide_p3_29" v="[EN] 1. Nitrogen is depleted - apply fertilizer soon." eh="42800253" />
     <e k="sf_guide_p3_30" v="2. Leguminosen (Soja, Klee) liefern kostenlosen N-" eh="75f466af" />
-    <e k="sf_guide_p3_31" v="Bonus f├╝r die N├äCHSTE Saison automatisch." eh="80169436" />
+    <e k="sf_guide_p3_31" v="Bonus für die NÄCHSTE Saison automatisch." eh="80169436" />
     <e k="sf_guide_p3_32" v="3. Mist oder Kompost nutzen, um OS langfristig aufzubauen." eh="dc25a4c7" />
     <e k="sf_guide_p3_33" v="SAISONALE HINWEISE" eh="bb392619" />
-    <e k="sf_guide_p3_34" v="FR├£HLING  N-Bedarf erreicht den H├Âchstwert. Vor der Aussaat ausbringen." eh="b402526b" />
-    <e k="sf_guide_p3_35" v="SOMMER  Sch├ñdlings- und Krankheitsdruck beobachten." eh="76b840ad" />
-    <e k="sf_guide_p3_36" v="HERBST  Hohe N-Gaben vor angek├╝ndigtem Regen vermeiden" eh="1d1c0439" />
-    <e k="sf_guide_p3_37" v="(Regen w├ñscht N aus dem Boden aus)." eh="6c48f9c9" />
-    <e k="sf_guide_p3_38" v="WINTER  Brachfelder erholen N├ñhrstoffe langsam." eh="b68db0d1" />
+    <e k="sf_guide_p3_34" v="FRÜHLING  N-Bedarf erreicht den Höchstwert. Vor der Aussaat ausbringen." eh="b402526b" />
+    <e k="sf_guide_p3_35" v="SOMMER  Schädlings- und Krankheitsdruck beobachten." eh="76b840ad" />
+    <e k="sf_guide_p3_36" v="HERBST  Hohe N-Gaben vor angekündigtem Regen vermeiden" eh="1d1c0439" />
+    <e k="sf_guide_p3_37" v="(Regen wäscht N aus dem Boden aus)." eh="6c48f9c9" />
+    <e k="sf_guide_p3_38" v="WINTER  Brachfelder erholen Nährstoffe langsam." eh="b68db0d1" />
     <e k="sf_guide_p3_39" v="Lassen Sie ein Feld zeitweise brach zur Regeneration." eh="0f67aea5" />
 		<e k="sf_guide_p3_40" v="[EN] SOIL COMPACTION" eh="b0b6c5c6" />
 		<e k="sf_guide_p3_41" v="[EN] Heavy vehicles (8t+) compact the soil they" eh="ef98c98b" />
@@ -933,21 +933,21 @@
 		<e k="sf_guide_p3_43" v="[EN] A subsoiler pass relieves it. The whole" eh="7bb6f80d" />
 		<e k="sf_guide_p3_44" v="[EN] mechanic can be toggled off in Settings." eh="e65b251c" />
     <e k="sf_guide_p4_01" v="STICKSTOFF-(N)-PRODUKTE" eh="6040f0f5" />
-    <e k="sf_guide_p4_02" v="AHL-L├Âsung      Hoher N-Gehalt, schnell wirksame Fl├╝ssigkeit." eh="60baf1c0" />
+    <e k="sf_guide_p4_02" v="AHL-Lösung      Hoher N-Gehalt, schnell wirksame Flüssigkeit." eh="60baf1c0" />
     <e k="sf_guide_p4_03" v="Harnstoff       Hoher N-Gehalt, klassische feste Form." eh="7619f3d7" />
     <e k="sf_guide_p4_04" v="AMS             Stickstoff + kleiner Schwefelvorteil." eh="9430151c" />
-    <e k="sf_guide_p4_05" v="Mist            Mittleres N + gro├ƒer OS-Schub." eh="36e4eeef" />
-    <e k="sf_guide_p4_06" v="Biosolids       N + P + gro├ƒer OS-Schub." eh="70b8003e" />
-    <e k="sf_guide_p4_07" v="G├ñrrest         Mittleres N + leichter OS-Vorteil." eh="70740674" />
+    <e k="sf_guide_p4_05" v="Mist            Mittleres N + großer OS-Schub." eh="36e4eeef" />
+    <e k="sf_guide_p4_06" v="Biosolids       N + P + großer OS-Schub." eh="70b8003e" />
+    <e k="sf_guide_p4_07" v="Gärrest         Mittleres N + leichter OS-Vorteil." eh="70740674" />
     <e k="sf_guide_p4_08" v="PHOSPHOR-(P)-PRODUKTE" eh="b143a8c7" />
     <e k="sf_guide_p4_09" v="MAP             Hoher P-Gehalt, kleiner N-Anteil." eh="f7e3a5e4" />
     <e k="sf_guide_p4_10" v="DAP             Hoher P-Gehalt + Stickstoffmischung." eh="1674361e" />
-    <e k="sf_guide_p4_11" v="Fl├╝ssig-MAP      Hoher P-Gehalt, schnellere Aufnahme." eh="59782949" />
-    <e k="sf_guide_p4_12" v="Fl├╝ssig-DAP      Hoher P-Gehalt + N, fl├╝ssige Form." eh="6eb70f1d" />
-    <e k="sf_guide_p4_13" v="Biosolids       P + N + OS. Effizienter Mehrn├ñhrstoff." eh="7adb8104" />
+    <e k="sf_guide_p4_11" v="Flüssig-MAP      Hoher P-Gehalt, schnellere Aufnahme." eh="59782949" />
+    <e k="sf_guide_p4_12" v="Flüssig-DAP      Hoher P-Gehalt + N, flüssige Form." eh="6eb70f1d" />
+    <e k="sf_guide_p4_13" v="Biosolids       P + N + OS. Effizienter Mehrnährstoff." eh="7adb8104" />
     <e k="sf_guide_p4_14" v="KALIUM-(K)-PRODUKTE" eh="7a9f5cc7" />
     <e k="sf_guide_p4_15" v="Kalium          Hoher K-Gehalt, feste Form." eh="cb71f3a0" />
-    <e k="sf_guide_p4_16" v="Fl├╝ssig-Kalium   Hoher K-Gehalt, fl├╝ssig. Schnellere Aufnahme." eh="0c3d2ad4" />
+    <e k="sf_guide_p4_16" v="Flüssig-Kalium   Hoher K-Gehalt, flüssig. Schnellere Aufnahme." eh="0c3d2ad4" />
 		<e k="sf_guide_p4_40" v="[EN] CROP PROTECTION" eh="f9ce6483" />
 		<e k="sf_guide_p4_41" v="[EN] Herbicide    Cuts weed pressure." eh="48782b85" />
 		<e k="sf_guide_p4_42" v="[EN] Insecticide  Cuts pest pressure." eh="de909cc7" />
@@ -957,74 +957,74 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="pH-KORREKTUR" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="7d422dfe" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH zu NIEDRIG (sauer, unter 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
-    <e k="sf_guide_p4_22" v="pH zu HOCH (alkalisch, ├╝ber 7.5):" eh="4204b7df" />
+    <e k="sf_guide_p4_22" v="pH zu HOCH (alkalisch, über 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="a35d71d3" />
     <e k="sf_guide_p4_25" v="ORGANISCHE SUBSTANZ (OS)" eh="4b06f65b" />
-    <e k="sf_guide_p4_26" v="Mist            Bester OS-Aufbauer. F├╝gt auch N hinzu." eh="99834812" />
+    <e k="sf_guide_p4_26" v="Mist            Bester OS-Aufbauer. Fügt auch N hinzu." eh="99834812" />
     <e k="sf_guide_p4_27" v="Kompost         Mittlere OS-Wirkung, gut ausgewogen." eh="d9b0e2f9" />
     <e k="sf_guide_p4_28" v="Biosolids       OS + N + P. Sehr effizient." eh="ba425a0e" />
-    <e k="sf_guide_p4_29" v="G├ñrrest         Leichter OS-Vorteil." eh="73cd0835" />
+    <e k="sf_guide_p4_29" v="Gärrest         Leichter OS-Vorteil." eh="73cd0835" />
     <e k="sf_guide_p4_30" v="Brachland (blankes Feld) stellt OS langsam wieder her." eh="da732797" />
     <e k="sf_guide_p4_31" v="AUSBRINGTIPPS" eh="180e4a50" />
-    <e k="sf_guide_p4_32" v="* D├╝nger laden und zuerst den Geisterbalken pr├╝fen." eh="2126b07c" />
+    <e k="sf_guide_p4_32" v="* Dünger laden und zuerst den Geisterbalken prüfen." eh="2126b07c" />
     <e k="sf_guide_p4_33" v="Er zeigt Ihr prognostiziertes Ergebnis vor dem Ausbringen." eh="7ee23768" />
-    <e k="sf_guide_p4_34" v="* Fl├╝ssige Produkte wirken in der Regel schneller als feste." eh="a5b6f4a7" />
+    <e k="sf_guide_p4_34" v="* Flüssige Produkte wirken in der Regel schneller als feste." eh="a5b6f4a7" />
     <e k="sf_guide_p4_35" v="[EN] * Manure improves OS AND adds N - very efficient." eh="18ca8c3e" />
-    <e k="sf_guide_p4_36" v="* Fl├╝ssigen N m├Âglichst vor Regen ausbringen" eh="50d601b0" />
-    <e k="sf_guide_p4_37" v="(Regen w├ñscht nach der Ausbringung einen Teil aus)." eh="c10189dd" />
-    <e k="sf_guide_p4_38" v="* Fruchtziele f├╝r die geplante Kultur pr├╝fen" eh="a3ccec1e" />
+    <e k="sf_guide_p4_36" v="* Flüssigen N möglichst vor Regen ausbringen" eh="50d601b0" />
+    <e k="sf_guide_p4_37" v="(Regen wäscht nach der Ausbringung einen Teil aus)." eh="c10189dd" />
+    <e k="sf_guide_p4_38" v="* Fruchtziele für die geplante Kultur prüfen" eh="a3ccec1e" />
     <e k="sf_guide_p4_39" v="[EN]   - different crops need different NPK ratios." eh="a83d4f85" />
     <e k="sf_guide_p5_01" v="[EN] MY BARS ARE ALWAYS EMPTY - IS IT BROKEN?" eh="5cbd724e" />
     <e k="sf_guide_p5_02" v="Nein. Auf einem neuen Spielstand startet der Boden mit niedrigen Grundwerten." eh="459b03bb" />
-    <e k="sf_guide_p5_03" v="Ein nie ged├╝ngtes Feld zeigt reale Ausgangswerte." eh="0d7762f2" />
-    <e k="sf_guide_p5_04" v="Durch D├╝ngung bauen sich die Werte mit der Zeit auf." eh="4419bc2a" />
+    <e k="sf_guide_p5_03" v="Ein nie gedüngtes Feld zeigt reale Ausgangswerte." eh="0d7762f2" />
+    <e k="sf_guide_p5_04" v="Durch Düngung bauen sich die Werte mit der Zeit auf." eh="4419bc2a" />
     <e k="sf_guide_p5_05" v="[EN] This is intentional - it reflects real soil depletion." eh="510b0d5a" />
-    <e k="sf_guide_p5_06" v="WO WEISE ICH TASTENK├£RZEL ZU?" eh="0717d029" />
+    <e k="sf_guide_p5_06" v="WO WEISE ICH TASTENKÜRZEL ZU?" eh="0717d029" />
     <e k="sf_guide_p5_07" v="Optionen &gt; Steuerung &gt; Mods" eh="7cf00a23" />
     <e k="sf_guide_p5_08" v="[EN] Most SF_ keys ship unbound. Four have defaults:" eh="aa3dd3e1" />
     <e k="sf_guide_p5_09" v="[EN] HUD Drag Shift+H, Variable Rate Alt+7, Scout" eh="3f2f823e" />
     <e k="sf_guide_p5_10" v="[EN] Shift+K, Treatment Shift+T. Rebind them in Mods." eh="28bfb301" />
     <e k="sf_guide_p5_11" v="WARUM IST MEIN STICKSTOFF NACH REGEN GESUNKEN?" eh="114dc15a" />
-    <e k="sf_guide_p5_12" v="Starker Regen w├ñscht Stickstoff aus dem Boden aus." eh="e8e84bec" />
+    <e k="sf_guide_p5_12" v="Starker Regen wäscht Stickstoff aus dem Boden aus." eh="e8e84bec" />
     <e k="sf_guide_p5_13" v="Das ist beabsichtigt und realistisch." eh="e3636ff4" />
     <e k="sf_guide_p5_14" v="Planen Sie N-Gaben vor trockener Witterung," eh="795c7892" />
     <e k="sf_guide_p5_15" v="nicht vor Starkregenprognosen." eh="73782fd0" />
-    <e k="sf_guide_p5_16" v="Die Regenempfindlichkeit k├Ânnen Sie in den Einstellungen anpassen." eh="2b64da19" />
+    <e k="sf_guide_p5_16" v="Die Regenempfindlichkeit können Sie in den Einstellungen anpassen." eh="2b64da19" />
     <e k="sf_guide_p5_17" v="WAS IST DER GEISTERBALKEN?" eh="f0a1df7e" />
-    <e k="sf_guide_p5_18" v="Die schwache Balkenverl├ñngerung zeigt," eh="6b72696f" />
-    <e k="sf_guide_p5_19" v="wie viel Ihre geladene Spritze hier hinzuf├╝gen w├╝rde." eh="dfee8857" />
-    <e k="sf_guide_p5_20" v="D├╝nger in die Spritze laden, auf ein Feld fahren," eh="605a9e8e" />
+    <e k="sf_guide_p5_18" v="Die schwache Balkenverlängerung zeigt," eh="6b72696f" />
+    <e k="sf_guide_p5_19" v="wie viel Ihre geladene Spritze hier hinzufügen würde." eh="dfee8857" />
+    <e k="sf_guide_p5_20" v="Dünger in die Spritze laden, auf ein Feld fahren," eh="605a9e8e" />
     <e k="sf_guide_p5_21" v="und der Geisterbalken erscheint automatisch." eh="0c120b03" />
-    <e k="sf_guide_p5_22" v="MUSS ICH JEDE SAISON D├£NGEN?" eh="778fc0ad" />
-    <e k="sf_guide_p5_23" v="Stickstoff: Ja, m├Âglichst jede Saison." eh="5232d8d2" />
+    <e k="sf_guide_p5_22" v="MUSS ICH JEDE SAISON DÜNGEN?" eh="778fc0ad" />
+    <e k="sf_guide_p5_23" v="Stickstoff: Ja, möglichst jede Saison." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="Er verarmt bei jeder Ernte stark." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
-    <e k="sf_guide_p5_26" v="Organische Substanz: langfristig. Mist einmal pro Jahr zuf├╝hren." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="d6e2db5f" />
+    <e k="sf_guide_p5_26" v="Organische Substanz: langfristig. Mist einmal pro Jahr zuführen." eh="78827593" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="66a52606" />
     <e k="sf_guide_p5_28" v="WIE FUNKTIONIEREN DIE SMART-SENSOR-SYSTEME?" eh="3b9aa5b3" />
-    <e k="sf_guide_p5_29" v="Smart-Sensor blockiert einzelne Gest├ñngesektionen, wenn" eh="ec681a8d" />
-    <e k="sf_guide_p5_30" v="kein Bedarf erkannt wird (kein Sch├ñdlings-, Krankheits- oder N├ñhrstoff-" eh="22de015a" />
+    <e k="sf_guide_p5_29" v="Smart-Sensor blockiert einzelne Gestängesektionen, wenn" eh="ec681a8d" />
+    <e k="sf_guide_p5_30" v="kein Bedarf erkannt wird (kein Schädlings-, Krankheits- oder Nährstoff-" eh="22de015a" />
     <e k="sf_guide_p5_31" v="defizit). See &amp; Spray zeigt Live-Druck je Zelle." eh="7bba77a1" />
     <e k="sf_guide_p5_32" v="Variable Ausbringmenge passt die Rate anhand von Bodendaten an." eh="a820fc55" />
-    <e k="sf_guide_p5_33" v="Alle drei ben├Âtigen eine VWW-f├ñhige Spritze. Aktivierung ├╝ber" eh="c3fdd607" />
+    <e k="sf_guide_p5_33" v="Alle drei benötigen eine VWW-fähige Spritze. Aktivierung über" eh="c3fdd607" />
     <e k="sf_guide_p5_34" v="Einstellungen &gt; Admin &gt; Smart-Systeme." eh="628b6090" />
     <e k="sf_guide_p5_35" v="KANN ICH DIE MOD IM MEHRSPIELER NUTZEN?" eh="c58f827c" />
-    <e k="sf_guide_p5_36" v="Ja. Die Mod ist vollst├ñndig mehrspielerkompatibel." eh="bb26b4d3" />
-    <e k="sf_guide_p5_37" v="Bodendaten werden serverseitig autoritativ gef├╝hrt." eh="e8c6a85e" />
-    <e k="sf_guide_p5_38" v="Clients synchronisieren beim Beitritt. Einstellungs├ñnderungen" eh="1d2473fd" />
+    <e k="sf_guide_p5_36" v="Ja. Die Mod ist vollständig mehrspielerkompatibel." eh="bb26b4d3" />
+    <e k="sf_guide_p5_37" v="Bodendaten werden serverseitig autoritativ geführt." eh="e8c6a85e" />
+    <e k="sf_guide_p5_38" v="Clients synchronisieren beim Beitritt. Einstellungsänderungen" eh="1d2473fd" />
     <e k="sf_guide_p5_39" v="erfordern Admin-Rechte in Mehrspieler-Sitzungen." eh="a48c5146" />
     <e k="sf_guide_p5_40" v="WIE BEEINFLUSST DER BODEN DEN ERTRAG?" eh="456d3c9f" />
     <e k="sf_guide_p5_41" v="[EN] GOOD soil: full yield - no penalty." eh="49e249c2" />
-    <e k="sf_guide_p5_42" v="MITTLERER Boden: ca. 5-15% Ertragsabzug pro N├ñhrstoff." eh="bced6a1c" />
+    <e k="sf_guide_p5_42" v="MITTLERER Boden: ca. 5-15% Ertragsabzug pro Nährstoff." eh="bced6a1c" />
     <e k="sf_guide_p5_43" v="SCHLECHTER Boden: bis zu 40% Abzug. Schnell korrigieren." eh="244d5bf2" />
-    <e k="sf_guide_p5_44" v="Abz├╝ge stapeln sich: SCHLECHT N + MITTEL P = starker Verlust." eh="8afb61f9" />
+    <e k="sf_guide_p5_44" v="Abzüge stapeln sich: SCHLECHT N + MITTEL P = starker Verlust." eh="8afb61f9" />
     <e k="sf_guide_title" v="[EN] Soil &amp; Fertilizer - Field Guide" eh="0e662248" />
-    <e k="sf_guide_tab_1" v="├£BERBLICK" eh="3b9ae4ee" />
+    <e k="sf_guide_tab_1" v="ÜBERBLICK" eh="3b9ae4ee" />
     <e k="sf_guide_tab_2" v="HUD-LEITFADEN" eh="843ca8c2" />
     <e k="sf_guide_tab_3" v="ABLAUF" eh="7337e059" />
     <e k="sf_guide_tab_4" v="PRODUKTE" eh="d71bd8a0" />
@@ -1037,25 +1037,25 @@
     <e k="sf_report_rec_good"         v="Gut" />
     <e k="sf_report_rec_fair"         v="Mittel" />
     <e k="sf_report_rec_poor"         v="Schlecht" />
-    	<e k="sf_fieldsentry_asleep" v="Sim. schl├ñft" eh="7d49241b" />
+    	<e k="sf_fieldsentry_asleep" v="Sim. schläft" eh="7d49241b" />
     	<e k="sf_fs_reason_manual" v="manuell" eh="3c78b355" />
     	<e k="sf_fs_reason_npc" v="NPC-Auftrag" eh="2e1a268b" />
     	<e k="sf_fs_reason_deco" v="dekorativ" eh="8a817367" />
     <e k="input_SF_SCOUT" v="Feldbonitur starten" eh="34e6d14b" />
     <e k="sf_scout_no_field" v="Du kannst die Feldbonitur nur auf einem Feld starten!" eh="2c33ecb7" />
-    <e k="sf_scout_found" v="Auf dem Feld %d wurde %s festgestellt (%d%% befallene Fl├ñche). Gr├Â├ƒter Behandlungserfolg: %s" eh="d6af78b1" />
-    <e k="sf_scout_pressure" v="Feld %d: %d%% Krankheit entdeckt - erkunde das Feld erneut um die Krankheit abschlie├ƒend zu bestimmen." eh="07d06c55" />
+    <e k="sf_scout_found" v="Auf dem Feld %d wurde %s festgestellt (%d%% befallene Fläche). Größter Behandlungserfolg: %s" eh="d6af78b1" />
+    <e k="sf_scout_pressure" v="Feld %d: %d%% Krankheit entdeckt - erkunde das Feld erneut um die Krankheit abschließend zu bestimmen." eh="07d06c55" />
     <e k="sf_scout_healthy" v="Auf dem Feld %d: wurde keine Erkrankung festgestellt." eh="98e53fbf" />
     <e k="sf_scout_clean" v="gesund" eh="741839f3" />
-    <e k="sf_treat_best" v="Gr├Â├ƒter Behandlungserfolg" eh="db82206b" />
+    <e k="sf_treat_best" v="Größter Behandlungserfolg" eh="db82206b" />
     <e k="sf_disease_difficulty_short" v="Krankheitsdruck" eh="882ec867" />
     <e k="sf_disease_difficulty_long" v="Beeinflusst die Entwicklungsgeschwindigkeit von Pflanzenkrankheiten und die Wirksamkeit von Fungiziden." eh="9027ce0f" />
     <e k="sf_desc_diseaseDifficulty" v="Anpassung des Krankheitsdrucks und der Fungizidwirkung." eh="83eb161e" />
     <e k="sf_disease_difficulty_1" v="Einfach" eh="7f943921" />
     <e k="sf_disease_difficulty_2" v="Normal" eh="960b44c5" />
     <e k="sf_disease_difficulty_3" v="Schwer" eh="36561831" />
-		<e k="sf_dis_septoria_tritici" v="Blattd├╝rre (Septoria tritici)" eh="1cad9da1" />
-		<e k="sf_dis_fhb" v="├ährenf├ñule (Fusarium)" eh="28a0c2d7" />
+		<e k="sf_dis_septoria_tritici" v="Blattdürre (Septoria tritici)" eh="1cad9da1" />
+		<e k="sf_dis_fhb" v="Ährenfäule (Fusarium)" eh="28a0c2d7" />
 		<e k="sf_dis_ergot" v="Mutterkorn" eh="cb0a1a23" />
 		<e k="sf_dis_stripe_rust" v="Gelbrost (Puccinia striiformis)" eh="122c2fef" />
 		<e k="sf_dis_leaf_rust" v="Braunrost (Puccinia triticina)" eh="2f14f2ea" />
@@ -1064,32 +1064,32 @@
 		<e k="sf_dis_net_blotch" v="Netzfleckenkrankheit (Drechslera teres)" eh="7aec2b24" />
 		<e k="sf_dis_ramularia" v="Ramularia-Blattflecken (Ramularia beticola)" eh="8355d8f8" />
 		<e k="sf_dis_crown_rust" v="Kronenrost (Puccinia coronata)" eh="b9acaa43" />
-		<e k="sf_dis_leaf_blotch" v="Septoria-Blattd├╝rre (Septoria tritici)" eh="1f5f784d" />
+		<e k="sf_dis_leaf_blotch" v="Septoria-Blattdürre (Septoria tritici)" eh="1f5f784d" />
 		<e k="sf_dis_nclb" v="Blattfleckenkrankheit (Setosphaeria turcica)" eh="a3525b71" />
 		<e k="sf_dis_common_rust" v="Maisrost (Puccinia sorghi)" eh="5f826210" />
 		<e k="sf_dis_gray_leaf_spot" v="- (Cercospora zeae-maydis)" eh="b36e5db8" />
-		<e k="sf_dis_sclerotinia_stem" v="Wei├ƒst├ñngeligkeit (Sclerotinia sclerotiorum)" eh="190c8937" />
+		<e k="sf_dis_sclerotinia_stem" v="Weißstängeligkeit (Sclerotinia sclerotiorum)" eh="190c8937" />
 		<e k="sf_dis_sunflower_rust" v="Sonnenblumenrost (Puccinia helianthi)" eh="34f2a2be" />
 		<e k="sf_dis_downy_mildew" v="Falscher Mehltau" eh="b221542a" />
-		<e k="sf_dis_late_blight" v="Krautf├ñule (Phytophthora infestans)" eh="1bc14339" />
-		<e k="sf_dis_early_blight" v="D├╝rrfleckenkrankheit (Alternaria solani)" eh="7511a654" />
+		<e k="sf_dis_late_blight" v="Krautfäule (Phytophthora infestans)" eh="1bc14339" />
+		<e k="sf_dis_early_blight" v="Dürrfleckenkrankheit (Alternaria solani)" eh="7511a654" />
 		<e k="sf_dis_cercospora_leaf" v="Cercospora-Blattfleckenkrankheit (Cercospora beticola)" eh="1ef824d7" />
 		<e k="sf_dis_frogeye" v="- (Cercospora sojina)" eh="1924760e" />
-		<e k="sf_dis_white_mold" v="Wei├ƒst├ñngeligkeit (Sclerotinia sclerotiorum)" eh="d833fbf0" />
+		<e k="sf_dis_white_mold" v="Weißstängeligkeit (Sclerotinia sclerotiorum)" eh="d833fbf0" />
 		<e k="sf_dis_phytophthora_root" v="- (Phytophthora)" eh="aa360e1e" />
 		<e k="sf_dis_asian_rust" v="- (Phakopsora pachyrhizi)" eh="fec3aa67" />
 		<e k="sf_dis_ascochyta_blight" v="Blattflecken (Ascochyta)" eh="48dc1517" />
 		<e k="sf_dis_bean_anthracnose" v="Brennfleckenkrankheit (Olletotrichum lindemutheanum)" eh="bd03acec" />
-		<e k="sf_dis_root_rot" v="Wurzelf├ñule" eh="0f98f939" />
+		<e k="sf_dis_root_rot" v="Wurzelfäule" eh="0f98f939" />
 		<e k="sf_dis_verticillium_wilt" v="- (Verticillium wilt)" eh="ca6dee69" />
 		<e k="sf_dis_leaf_spot" v="Blattfleckenkrankheit" eh="2087d91f" />
 		<e k="sf_dis_alfalfa_rust" v="- (Uromyces striatus)" eh="31879f81" />
-		<e k="sf_dis_clover_anthracnose" v="S├╝dlicher St├ñngelbrenner (Colletotrichum trifolii )" eh="ca929ac0" />
+		<e k="sf_dis_clover_anthracnose" v="Südlicher Stängelbrenner (Colletotrichum trifolii )" eh="ca929ac0" />
 		<e k="sf_dis_pasmo" v="- (Septoria linicola)" eh="4d3166ae" />
 		<e k="sf_dis_anthracnose" v="Brennfleckenkrankheit" eh="d5ea8b42" />
 		<e k="sf_dis_rust" v="Rost" eh="f5e265d6" />
 		<e k="sf_dis_taro_leaf_blight" v="" eh="37240d66" />
-		<e k="sf_dis_corm_rot" v="Taro-Blattf├ñule (Phytophthora colocasiae)" eh="e1f1b9c1" />
+		<e k="sf_dis_corm_rot" v="Taro-Blattfäule (Phytophthora colocasiae)" eh="e1f1b9c1" />
 		<e k="sf_dis_early_leaf_spot" v="- (Cercospora arachidicola)" eh="f887d13d" />
 		<e k="sf_dis_late_leaf_spot" v="- (Cercosporidium personatum)" eh="a012753f" />
 		<e k="sf_dis_peanut_rust" v="- (Puccinia arachidis)" eh="5e46fad0" />
@@ -1117,7 +1117,7 @@
 		<e k="sf_chem_METALAXYL_M" v="Metalaxyl-M" eh="706a0ca9" />
 		<e k="sf_chem_THIRAM" v="Thiram" eh="63e2540c" />
 		<e k="sf_chem_CAPTAN" v="Captan" eh="dc89f49c" />
-    <e k="sf_treat_cycle" v="n├ñchstes Fungizid" eh="50e1cf57" />
+    <e k="sf_treat_cycle" v="nächstes Fungizid" eh="50e1cf57" />
     <e k="sf_treat_apply" v="Fungizid anwenden" eh="66b90889" />
 		<e k="sf_treat_vs" v="im Vergleich zu:" eh="f4842dcb" />
 		<e k="sf_treat_applied" v="Behandlung mit %s erfolgreich. %d%% control, -%d pressure, %d-day protection, $%d" eh="03a47259" />
@@ -1128,11 +1128,11 @@
 		<e k="sf_scout_tier_none" v="gesund" eh="741839f3" />
 		<e k="sf_scout_tier_mild" v="vereinzelt" eh="3cc4af7c" />
 		<e k="sf_scout_tier_moderate" v="[EN] moderate" eh="7f0217cd" />
-		<e k="sf_scout_tier_severe" v="gro├ƒfl├ñchig" eh="e709e56a" />
+		<e k="sf_scout_tier_severe" v="großflächig" eh="e709e56a" />
 		<e k="sf_scout_pressure_label" v="Im Bestand befallene Pflanzen" eh="49abd79e" />
-		<e k="sf_scout_budget" v="Preisg├╝nstig" eh="822bead6" />
+		<e k="sf_scout_budget" v="Preisgünstig" eh="822bead6" />
 		<e k="sf_scout_clean_title" v="Kein Krankheit entdeckt." eh="6bc14095" />
-		<e k="sf_scout_clean_hint" v="Der Bestand sieht gesund aus. Du kannst aber pr├ñventive Ma├ƒnahemn durchf├╝hren." eh="b81cdbda" />
+		<e k="sf_scout_clean_hint" v="Der Bestand sieht gesund aus. Du kannst aber präventive Maßnahemn durchführen." eh="b81cdbda" />
 		<e k="sf_scout_disabled" v="Krankheiten sind deaktiviert." eh="a2ffd328" />
     <e k="sf_admin_field_set_disease_label" v="Erkrankung festlegen" eh="faa773f5" />
 		<e k="sf_admin_field_set_disease_desc" v="Lege die aktuelle Erkrankung des Feldes fest und wie stark der Befall sein soll." eh="d86eb3e1" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Rendimiento" eh="97345487" />
     <e k="sf_hud_estYield" v="Rend. Est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Óptimo" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Arrastrar: mover   Esquina: redimensionar   RMB/Shift+H: listo" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: mover/redimensionar" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -776,7 +776,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -791,7 +791,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -939,13 +939,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -985,9 +985,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Yield" eh="97345487" />
     <e k="sf_hud_estYield" v="Est. Yield" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Drag: move   Corner: resize   RMB/Shift+H: done" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: move/resize" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" eh="89dbfc90" />
@@ -633,7 +633,7 @@
     <e k="sf_hud_enter_drag_desc" v="Drag HUD to reposition - drag corner to resize - RMB or Esc to finish" eh="1d7b1dee" />
     <e k="sf_independent_panels_short" v="Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />
+    <e k="sf_desc_independentPanels" v="Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="d61cf296" />
 
     <!-- ======================================================
          SETTINGS PANEL - CHROME
@@ -851,7 +851,7 @@
     <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
+    <e k="sf_guide_p1_11" v="pH  Soil acidity.  Target range: 6.5 - 7.0." eh="9b966ead" />
     <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="  No action needed this season." eh="58b36ac2" />
@@ -999,13 +999,13 @@
     <e k="sf_guide_p4_46" v="Treatment (Shift+T) lists what each field" eh="ccc651dc" />
     <e k="sf_guide_p4_47" v="  needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
+    <e k="sf_guide_p4_18" v="Target range: 6.5 - 7.0 for most crops." eh="7d422dfe" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="  Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="  Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
+    <e k="sf_guide_p4_24" v="Allow 1-2 seasons for full normalization." eh="a35d71d3" />
     <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1045,9 +1045,9 @@
     <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="  It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
+    <e k="sf_guide_p5_25" v="P and K: Every 2-3 seasons is usually enough." eh="d6e2db5f" />
     <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
+    <e k="sf_guide_p5_27" v="pH: Only when outside the 6.5-7.0 range." eh="66a52606" />
     <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Rendimiento" eh="97345487" />
     <e k="sf_hud_estYield" v="Rend. est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Óptimo" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Arrastrar: mover   Esquina: redimensionar   RMB/Shift+H: listo" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: mover/redimensionar" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -776,7 +776,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -791,7 +791,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -939,13 +939,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -985,9 +985,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="产量" eh="97345487" />
     <e k="sf_hud_estYield" v="预估产量" eh="32a4135e" />
     <e k="sf_hud_optimal" v="最佳" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="[EN] Drag: move   Corner: resize   RMB/Shift+H: done" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="[EN] Shift+H: move/resize" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Incompatibility Detected" eh="89dbfc90" />
@@ -633,7 +633,7 @@
     <e k="sf_hud_enter_drag_desc" v="[EN] Drag HUD to reposition - drag corner to resize - RMB or Esc to finish" eh="1d7b1dee" />
     <e k="sf_independent_panels_short" v="Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="d61cf296" />
 
     <!-- ======================================================
          SETTINGS PANEL - CHROME
@@ -851,7 +851,7 @@
     <e k="sf_guide_p1_08" v="P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="9b966ead" />
     <e k="sf_guide_p1_12" v="STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -999,13 +999,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="7d422dfe" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="a35d71d3" />
     <e k="sf_guide_p4_25" v="ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1045,9 +1045,9 @@
     <e k="sf_guide_p5_22" v="DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="d6e2db5f" />
     <e k="sf_guide_p5_26" v="Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="66a52606" />
     <e k="sf_guide_p5_28" v="HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -72,7 +72,7 @@
     <e k="sf_diff_short" v="Vaikeusaste" eh="7b29ca96" />
     <e k="sf_diff_long" v="Maaperänhallinnan vaikeustaso" eh="d6f4560c" />
     <e k="sf_rr_short" v="Täyttymisnopeus" eh="b363b336" />
-    <e k="sf_rr_long" v="Kuinka nopeasti lannoite palauttaa pellon ravinteet (0,25x erittäin hidas – 2,0x erittäin nopea)" eh="afe78a6d" />
+    <e k="sf_rr_long" v="Kuinka nopeasti lannoite palauttaa pellon ravinteet (0,25x erittäin hidas - 2,0x erittäin nopea)" eh="afe78a6d" />
     <e k="sf_dm_short" v="[EN] Disease Climate" />
     <e k="sf_dm_long" v="[EN] Climate moisture level - controls how quickly fungal diseases build up and how long fungicide protection lasts" />
     <e k="sf_dm_1" v="[EN] Arid" />
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Sato" eh="97345487" />
     <e k="sf_hud_estYield" v="Satoarvio" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimaalinen" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Veto: siirrä   Kulma: koko   RMB/Shift+H: valmis" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: siirrä/muuta kokoa" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -256,19 +256,19 @@
     <e k="helpLine_sf_gs_p3_access_text" v="Asetukset löytyvät kohdasta ESC &gt; Asetukset &gt; Maaperä ja lannoitus. Moninpelissä vain ylläpitäjä voi muuttaa simulaatiota." eh="4ba9d860" />
 
     <e k="helpLine_sf_nu_p1_title" v="Typpi ja fosfori" eh="27d37372" />
-    <e k="helpLine_sf_nu_p1_n_title" v="Typpi (N) - Asteikko 0–100" eh="10a358f4" />
-    <e k="helpLine_sf_nu_p1_n_text" v="Liikkuvin ravinne – kuluu nopeasti ja huuhtoutuu sateella. Huono: alle 30. Hyvä: yli 50. Nosta: nestelannoite, UAN, ammoniakki, urea tai lanta." eh="58d62253" />
-    <e k="helpLine_sf_nu_p1_p_title" v="Fosfori (P) - Asteikko 0–100" eh="979bba64" />
+    <e k="helpLine_sf_nu_p1_n_title" v="Typpi (N) - Asteikko 0-100" eh="10a358f4" />
+    <e k="helpLine_sf_nu_p1_n_text" v="Liikkuvin ravinne - kuluu nopeasti ja huuhtoutuu sateella. Huono: alle 30. Hyvä: yli 50. Nosta: nestelannoite, UAN, ammoniakki, urea tai lanta." eh="58d62253" />
+    <e k="helpLine_sf_nu_p1_p_title" v="Fosfori (P) - Asteikko 0-100" eh="979bba64" />
     <e k="helpLine_sf_nu_p1_p_text" v="Sitoutuu tiukasti maahan, huuhtoutuu hitaasti. Kuluu lähinnä sadon mukana. Rapsi on vaativin. Huono: alle 25. Hyvä: yli 45. Nosta: MAP, DAP tai startteri." eh="92c5ac66" />
 
     <e k="helpLine_sf_nu_p2_title" v="Kalium ja pH" eh="6bd92f25" />
-    <e k="helpLine_sf_nu_p2_k_title" v="Kalium (K) - Asteikko 0–100" eh="2a16e8bc" />
+    <e k="helpLine_sf_nu_p2_k_title" v="Kalium (K) - Asteikko 0-100" eh="2a16e8bc" />
     <e k="helpLine_sf_nu_p2_k_text" v="Tärkeä juuri- ja mukulakasveille. Peruna ja juurikas kuluttavat paljon K. Huuhtoutuu jonkin verran. Huono: alle 20. Hyvä: yli 40. Nosta: kaliumsuola, lanta tai nestelannoite." eh="7230fee4" />
-    <e k="helpLine_sf_nu_p2_ph_title" v="pH - Asteikko 5.0–7.5" eh="944beca2" />
-    <e k="helpLine_sf_nu_p2_ph_text" v="Kasvit viihtyvät pH-arvossa 6.5–7.0. Sade happamoittaa maata. pH ei palaudu itsestään – vain kalkitus auttaa. Huono: alle 5.5. Kalkitse ennen seuraavaa kylvöä." eh="08e0aefd" />
+    <e k="helpLine_sf_nu_p2_ph_title" v="pH - Asteikko 5.0-7.5" eh="944beca2" />
+    <e k="helpLine_sf_nu_p2_ph_text" v="Kasvit viihtyvät pH-arvossa 6.5-7.0. Sade happamoittaa maata. pH ei palaudu itsestään - vain kalkitus auttaa. Huono: alle 5.5. Kalkitse ennen seuraavaa kylvöä." eh="08e0aefd" />
 
     <e k="helpLine_sf_nu_p3_title" v="Orgaaninen aines" eh="6305f4bb" />
-    <e k="helpLine_sf_nu_p3_om_title" v="Orgaaninen aines (OM) - Asteikko 0–10" eh="58f490f3" />
+    <e k="helpLine_sf_nu_p3_om_title" v="Orgaaninen aines (OM) - Asteikko 0-10" eh="58f490f3" />
     <e k="helpLine_sf_nu_p3_om_text" v="Kertyy hitaasti, ei kulu sadon mukana. Huono: alle 2.5. Hyvä: yli 4.0. Nosta: lanta, komposti, biojäte tai silppuamalla olki takaisin peltoon." eh="f9a02359" />
     <e k="helpLine_sf_nu_p3_fallow_title" v="Kesannon vaikutus" eh="14133b0b" />
     <e k="helpLine_sf_nu_p3_fallow_text" v="Viljelemätön pelto palautuu hitaasti (7+ vrk jälkeen). Päivittäin: N +0,07, P +0,03, K +0,05, OM +0,01. Viljelykierrolla ja levolla on merkitystä." eh="81fa82b3" />
@@ -300,7 +300,7 @@
 
     <e k="helpLine_sf_hu_p2_title" v="Pellon terveyspaineet" eh="b4d35b30" />
     <e k="helpLine_sf_hu_p2_press_title" v="Rikkakasvit, tuholaiset ja taudit" eh="0a3fae00" />
-    <e k="helpLine_sf_hu_p2_press_text" v="Kolme pisteytystä (0–100) seuraa biologisia uhkia. Hoitamattomina ne laskevat satoa: rikkakasvit -30%, tuholaiset -20%, taudit -25%. HUD näyttää vakavuuden värein." eh="3fc3c400" />
+    <e k="helpLine_sf_hu_p2_press_text" v="Kolme pisteytystä (0-100) seuraa biologisia uhkia. Hoitamattomina ne laskevat satoa: rikkakasvit -30%, tuholaiset -20%, taudit -25%. HUD näyttää vakavuuden värein." eh="3fc3c400" />
     <e k="helpLine_sf_hu_p2_treat_title" v="Paineiden hoito" eh="cb24bf50" />
     <e k="helpLine_sf_hu_p2_treat_text" v="Rikkakasvimyrkky poistaa rikkakasvit (samoin muokkaus). Hyönteismyrkky laskee painetta 25 pistettä. Sienimyrkky laskee 20 pistettä. Kaikki voi kytkeä pois päältä." eh="4d65bdec" />
 
@@ -320,7 +320,7 @@
     <e k="helpLine_sf_se_p2_hud_title" v="Pelaajakohtainen HUD" eh="0df76500" />
     <e k="helpLine_sf_se_p2_hud_text" v="Jokainen pelaaja säätää oman HUD-näyttönsä. Valinnat: näyttö päällä, sijainti, väriteema, koko, läpinäkyvyys ja yksiköt." eh="f3934884" />
     <e k="helpLine_sf_se_p2_rate_title" v="Ruiskun annostelun hallinta" eh="5ecdfa23" />
-    <e k="helpLine_sf_se_p2_rate_text" v="Käytä levittimessä näppäimiä ] ja [ säätääksesi määrää välillä 0.10x–2.00x. Shift+L vaihtaa automaattitilan päälle, jolloin modi tähtää optimaaliseen tasoon." eh="dd385e39" />
+    <e k="helpLine_sf_se_p2_rate_text" v="Käytä levittimessä näppäimiä ] ja [ säätääksesi määrää välillä 0.10x-2.00x. Shift+L vaihtaa automaattitilan päälle, jolloin modi tähtää optimaaliseen tasoon." eh="dd385e39" />
 
     <e k="helpLine_sf_mp_p1_title" v="Miten moninpeli toimii" eh="8a4ce30e" />
     <e k="helpLine_sf_mp_p1_auth_title" v="Palvelinkeskeinen simulaatio" eh="8d324792" />
@@ -406,7 +406,7 @@
     <e k="sf_pda_map_layer_n_desc" v="Typen määrä pelloilla. Vihreä = hyvä, punainen = kulunut." eh="60484ead" />
     <e k="sf_pda_map_layer_p_desc" v="Fosforin määrä pelloilla. Vihreä = hyvä, punainen = kulunut." eh="9fa2e72d" />
     <e k="sf_pda_map_layer_k_desc" v="Kaliumin määrä pelloilla. Vihreä = hyvä, punainen = kulunut." eh="a61d25b7" />
-    <e k="sf_pda_map_layer_ph_desc" v="Maaperän pH. Optimaalinen alue on 6.5–7.0 (vihreä)." eh="ce7009e7" />
+    <e k="sf_pda_map_layer_ph_desc" v="Maaperän pH. Optimaalinen alue on 6.5-7.0 (vihreä)." eh="ce7009e7" />
     <e k="sf_pda_map_layer_om_desc" v="Orgaanisen aineen määrä. Korkeampi on parempi pitkällä aikavälillä." eh="f64c5706" />
     <e k="sf_pda_map_layer_urgency_desc" v="Yhdistetty hoidon kiireellisyys. Punainen = vaatii pikaista huoltoa." eh="f29ddc2b" />
     <e k="sf_pda_map_layer_weed_desc" v="Rikkakasvipaine. Punainen = paljon rikkakasveja, käytä myrkkyä." eh="24009598" />
@@ -520,7 +520,7 @@
     <e k="sf_treat_section_fert" v="Ravinteiden lisäys" eh="76521e8e" />
     <e k="sf_treat_section_prot" v="Kasvinsuojelu" eh="bd3fe9cd" />
     <e k="sf_treat_hint" v="Katso kaupan 'Tuotteet'-osio erikoislannoitteita varten." eh="540bff4d" />
-    <e k="sf_treat_action_optimal" v="Optimaalinen – ei toimia." eh="4501a96b" />
+    <e k="sf_treat_action_optimal" v="Optimaalinen - ei toimia." eh="4501a96b" />
     <e k="sf_treat_action_lime" v="Lisää KALKKIA tai NESTEKALKKIA nostaaksesi pH-arvoa." eh="d1420b97" />
     <e k="sf_treat_action_gypsum" v="Lisää KIPSIÄ laskeaksesi pH-arvoa / parantaaksesi rakennetta." eh="4cb3f0dc" />
     <e k="sf_treat_action_om_low" v="Kynnä LANTAA, KOMPOSTIA tai silppua olki." eh="33ec544c" />
@@ -777,7 +777,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -792,7 +792,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -940,13 +940,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -986,9 +986,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -204,7 +204,7 @@
     <e k="sf_hud_yield" v="Rendement" eh="97345487" />
     <e k="sf_hud_estYield" v="Rendement estimé" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="Après récolte · Fertilisation" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="Après récolte · Fertilisation" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Glisser: déplacer   Coin: redimensionner   clic droit/Maj+H: terminer" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Maj+H: déplacer/redimensionner" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Incompatibilité détectée" eh="89dbfc90" />
@@ -620,7 +620,7 @@
     <e k="sf_hud_enter_drag_desc" v="Déplacez le HUD pour le repositionner - faites glisser un coin pour le redimensionner - clic droit ou Échap pour terminer" eh="1d7b1dee" />
     <e k="sf_independent_panels_short" v="Disposition libre des panneaux" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Permet de positionner indépendamment les panneaux du système intelligent en mode édition" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="Déplace chaque panneau librement via le mode édition Maj+H. Réduis les panneaux avec le bouton − dans leur barre de titre." eh="6f96e17c" />
+    <e k="sf_desc_independentPanels" v="Déplace chaque panneau librement via le mode édition Maj+H. Réduis les panneaux avec le bouton - dans leur barre de titre." eh="d61cf296" />
 
     <!-- ======================================================
          PANNEAU DES PARAMÈTRES - INTERFACE
@@ -794,7 +794,7 @@
     <e k="sf_guide_p1_08" v="P   Phosphore         Épuisement lent. Cultures racines." eh="651919e6" />
     <e k="sf_guide_p1_09" v="K   Potassium         Fortement consommé par les cultures racines." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="MO  Matière organique Augmente lentement au fil des saisons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="pH  Acidité du sol. Plage idéale : 6,5 à 7,0." eh="66ec261a" />
+    <e k="sf_guide_p1_11" v="pH  Acidité du sol. Plage idéale : 6,5 à 7,0." eh="9b966ead" />
     <e k="sf_guide_p1_12" v="NIVEAUX D'ÉTAT" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="BON (vert)     Au niveau optimal ou au-dessus." eh="a081208f" />
     <e k="sf_guide_p1_14" v="Aucune action nécessaire cette saison." eh="58b36ac2" />
@@ -942,13 +942,13 @@
     <e k="sf_guide_p4_46" v="Le menu Traitement (Maj+T) indique les besoins actuels" eh="ccc651dc" />
     <e k="sf_guide_p4_47" v="de chaque champ, produit par produit." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="CORRECTION DU pH" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="Plage idéale : pH de 6,5 à 7,0 pour la plupart des cultures." eh="142248c3" />
+    <e k="sf_guide_p4_18" v="Plage idéale : pH de 6,5 à 7,0 pour la plupart des cultures." eh="7d422dfe" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH trop BAS (sol acide, inférieur à 6,5) :" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="Appliquez de la CHAUX pour relever le pH vers la neutralité." eh="6595685a" />
     <e k="sf_guide_p4_22" v="pH trop ÉLEVÉ (sol alcalin, supérieur à 7,5) :" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="Appliquez du GYPSE pour abaisser le pH vers la neutralité." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="Comptez une à deux saisons pour un retour complet à la normale." eh="b64ec970" />
+    <e k="sf_guide_p4_24" v="Comptez une à deux saisons pour un retour complet à la normale." eh="a35d71d3" />
     <e k="sf_guide_p4_25" v="MATIÈRE ORGANIQUE (MO)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="Fumier : meilleur apport en matière organique, ajoute aussi de l'azote." eh="99834812" />
     <e k="sf_guide_p4_27" v="Compost : apport équilibré de matière organique." eh="d9b0e2f9" />
@@ -988,9 +988,9 @@
     <e k="sf_guide_p5_22" v="DOIS-JE FERTILISER À CHAQUE SAISON ?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="Azote : oui, idéalement à chaque saison." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="Il s'épuise fortement à chaque récolte." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="Phosphore et potassium : tous les 2 à 3 ans suffisent généralement." eh="8863dc51" />
+    <e k="sf_guide_p5_25" v="Phosphore et potassium : tous les 2 à 3 ans suffisent généralement." eh="d6e2db5f" />
     <e k="sf_guide_p5_26" v="Matière organique : sur le long terme. Ajoutez du fumier une fois par an." eh="78827593" />
-    <e k="sf_guide_p5_27" v="pH : seulement lorsqu'il sort de la plage 6,5 à 7,0." eh="2dcf1b6d" />
+    <e k="sf_guide_p5_27" v="pH : seulement lorsqu'il sort de la plage 6,5 à 7,0." eh="66a52606" />
     <e k="sf_guide_p5_28" v="COMMENT FONCTIONNENT LES SMART SENSORS ?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="Les Capteur intelligents coupent automatiquement les tronçons de rampe" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="lorsqu'aucun besoin n'est détecté (ravageurs, maladies ou nutriments)." eh="22de015a" />

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Hozam" eh="97345487" />
     <e k="sf_hud_estYield" v="Becsült hozam" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimális" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Húzás: mozgatás   Sarok: átméretezés   RMB/Shift+H: kész" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: mozgatás/átméretezés" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -796,7 +796,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -811,7 +811,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -959,13 +959,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1005,9 +1005,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Hasil" eh="97345487" />
     <e k="sf_hud_estYield" v="Est. Hasil" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Seret: pindah   Sudut: ubah ukuran   RMB/Shift+H: selesai" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: pindah/ubah ukuran" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -823,7 +823,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -838,7 +838,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -986,13 +986,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1032,9 +1032,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -211,7 +211,7 @@
 		<e k="sf_hud_yield" v="Resa" eh="97345487" />
 		<e k="sf_hud_estYield" v="Resa stimata" eh="32a4135e" />
 		<e k="sf_hud_optimal" v="Ottimale" eh="cb61fef1" />
-		<e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+		<e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
 		<e k="sf_hud_hint_edit" v="Trascina: sposta   Angolo: ridimensiona   RMB/Maiusc+H: fatto" eh="c3f1820c" />
 		<e k="sf_hud_hint_normal" v="Maiusc+H: sposta/ridimensiona" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -823,7 +823,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -838,7 +838,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -986,13 +986,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1032,9 +1032,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="収量" eh="97345487" />
     <e k="sf_hud_estYield" v="推定収量" eh="32a4135e" />
     <e k="sf_hud_optimal" v="最適" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="ドラッグ: 移動   角: サイズ変更   右クリック/Shift+H: 完了" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: 移動/サイズ変更" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -803,7 +803,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -818,7 +818,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -966,13 +966,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1012,9 +1012,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="수확량" eh="97345487" />
     <e k="sf_hud_estYield" v="예상 수확량" eh="32a4135e" />
     <e k="sf_hud_optimal" v="최적" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="드래그: 이동   모서리: 크기 조절   우클릭/Shift+H: 완료" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: 이동/크기 조절" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -804,7 +804,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -819,7 +819,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -967,13 +967,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1013,9 +1013,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Opbrengst" eh="97345487" />
     <e k="sf_hud_estYield" v="Verw. opbrengst" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimaal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Sleep: verplaats   Hoek: formaat   RMB/Shift+H: klaar" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: verplaats/formaat" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="Incompatibiliteit gedetecteerd" eh="89dbfc90" />
@@ -806,7 +806,7 @@
     <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="Vrije paneelindeling" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="Slimme systeempanelen toestaan onafhankelijk te worden gepositioneerd in de bewerkingsmodus" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the ├ó╦åÔÇÖ button in their title bar." eh="6f96e17c" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="d61cf296" />
     <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="69091cec" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="da09523b" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="438cd61b" />
@@ -822,7 +822,7 @@
     <e k="sf_guide_p1_08" v="P   Fosfor           Langzame uitputting. Wortelgewassen." eh="651919e6" />
     <e k="sf_guide_p1_09" v="K   Kalium           Wortelgewassen putten dit zwaar uit." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="OS  Organische stof  Bouwt langzaam op over meerdere seizoenen." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 ├óÔé¼ÔÇ£ 7.0." eh="66ec261a" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="9b966ead" />
     <e k="sf_guide_p1_12" v="STATUSNIVEAUS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="GOED (groen)   Op of boven het optimale doel van het gewas." eh="a081208f" />
     <e k="sf_guide_p1_14" v="Geen actie nodig dit seizoen." eh="58b36ac2" />
@@ -970,13 +970,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="PH-CORRECTIE" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 ├óÔé¼ÔÇ£ 7.0 for most crops." eh="142248c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="7d422dfe" />
     <e k="sf_guide_p4_19" v="" eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="pH te LAAG (zuur, onder 6,5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="pH te HOOG (alkalisch, boven 7,5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1├óÔé¼ÔÇ£2 seasons for full normalization." eh="b64ec970" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="a35d71d3" />
     <e k="sf_guide_p4_25" v="ORGANISCHE STOF (OS)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="Mest           Beste OS-opbouwer. Voegt ook N toe." eh="99834812" />
     <e k="sf_guide_p4_27" v="Compost        Matige OS, goed gebalanceerd." eh="d9b0e2f9" />
@@ -1016,9 +1016,9 @@
     <e k="sf_guide_p5_22" v="MOET IK ELK SEIZOEN BEMESTEN?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="Stikstof: Ja, elk seizoen indien mogelijk." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="Het putt zwaar uit bij elke oogst." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2├óÔé¼ÔÇ£3 seasons is usually enough." eh="8863dc51" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="d6e2db5f" />
     <e k="sf_guide_p5_26" v="Organische OS: Langdurig. Eens per jaar mest toevoegen." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5├óÔé¼ÔÇ£7.0 range." eh="2dcf1b6d" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="66a52606" />
     <e k="sf_guide_p5_28" v="HOE WERKEN DE SLIMME SENSORSYSTEMEN?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="Slimme sensor blokkeert individuele boomsecties wanneer" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="geen behoefte wordt gedetecteerd (geen plaag, ziekte of voedings-" eh="22de015a" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Avling" eh="97345487" />
     <e k="sf_hud_estYield" v="Est. avling" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Dra: flytt   Hjørne: endre størrelse   RMB/Shift+H: ferdig" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: flytt/endre størrelse" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -805,7 +805,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -820,7 +820,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -968,13 +968,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1014,9 +1014,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Plon" eh="97345487" />
     <e k="sf_hud_estYield" v="Szac. plon" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optymalne" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Przeciągnij: przesuń   Róg: zmień rozmiar   PPM/Shift+H: gotowe" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: przesuń/zmień rozmiar" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -805,7 +805,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -820,7 +820,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -968,13 +968,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1014,9 +1014,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Rendimento" eh="97345487" />
     <e k="sf_hud_estYield" v="Rend. Est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Ideal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Arrastar: mover   Canto: redimensionar   RMB/Shift+H: concluído" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: mover/redimensionar" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -824,7 +824,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -839,7 +839,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -987,13 +987,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1033,9 +1033,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Recoltă" eh="97345487" />
     <e k="sf_hud_estYield" v="Recoltă Est." eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optim" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Tragere: mutare   Colț: redimensionare   RMB/Shift+H: gata" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: mutare/redimensionare" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -824,7 +824,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -839,7 +839,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -987,13 +987,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -1033,9 +1033,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Урожай" eh="97345487" />
     <e k="sf_hud_estYield" v="Ожид. урожай" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Оптимально" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Перетаскивание: переместить  Угол: размер  ПКМ/Shift+H: готово" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: переместить/размер" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -765,7 +765,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -780,7 +780,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -928,13 +928,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -974,9 +974,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Skörd" eh="97345487" />
     <e k="sf_hud_estYield" v="Ber. skörd" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimalt" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Dra: flytta   Hörn: ändra storlek   HMB/Skift+H: klar" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Skift+H: flytta/ändra storlek" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -776,7 +776,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -791,7 +791,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -939,13 +939,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -985,9 +985,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Verim" eh="97345487" />
     <e k="sf_hud_estYield" v="Tahmini Verim" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Optimal" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Sürükle: taşı   Köşe: boyutlandır   Sağ Tık/Shift+H: tamam" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: taşı/boyutlandır" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -777,7 +777,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -792,7 +792,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -940,13 +940,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -986,9 +986,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Врожайність" eh="97345487" />
     <e k="sf_hud_estYield" v="Очік. врожай" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Оптимально" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Драг: рух  Кут: розмір  ПКМ/Shift+H: готово" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: рух/розмір" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -776,7 +776,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -791,7 +791,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -939,13 +939,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -985,9 +985,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -211,7 +211,7 @@
     <e k="sf_hud_yield" v="Sản lượng" eh="97345487" />
     <e k="sf_hud_estYield" v="Sản lượng dự tính" eh="32a4135e" />
     <e k="sf_hud_optimal" v="Tối ưu" eh="cb61fef1" />
-    <e k="sf_hud_post_harvest" v="[EN] Post-harvest ├é┬À Fertilize" eh="61d2d595" />
+    <e k="sf_hud_post_harvest" v="[EN] Post-harvest · Fertilize" eh="634de6fe" />
     <e k="sf_hud_hint_edit" v="Kéo: di chuyển   Góc: đổi cỡ   Chuột phải/Shift+H: xong" eh="c3f1820c" />
     <e k="sf_hud_hint_normal" v="Shift+H: di chuyển/đổi cỡ" eh="f1d565b1" />
     <e k="sf_incompatibility_pf_title" v="[EN] Incompatibility Detected" eh="89dbfc90" />
@@ -776,7 +776,7 @@
         <!-- HUD LAYOUT DRAG BUTTON -->
     <e k="sf_independent_panels_short" v="[EN] Free Panel Layout" eh="704a20a4" />
     <e k="sf_independent_panels_long" v="[EN] Allow smart system panels to be positioned independently in edit mode" eh="de43cebd" />
-    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the − button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
+    <e k="sf_desc_independentPanels" v="[EN] Drag each panel freely using Shift+H edit mode. Collapse panels with the - button in their title bar." eh="7c60edfc" />        <e k="sf_guide_sub_1" v="[EN] Overview - What this mod tracks and why it matters" eh="83e88693" />
     <e k="sf_guide_sub_2" v="[EN] HUD Guide - Reading the nutrient bars and on-screen indicators" eh="ffbe123f" />
     <e k="sf_guide_sub_3" v="[EN] Workflow - Your daily and seasonal soil management routine" eh="75d263dd" />
     <e k="sf_guide_sub_4" v="[EN] Products - What each fertilizer affects and when to use it" eh="2a127c60" />
@@ -791,7 +791,7 @@
     <e k="sf_guide_p1_08" v="[EN] P   Phosphorus     Slow depletion. Root crops." eh="651919e6" />
     <e k="sf_guide_p1_09" v="[EN] K   Potassium      Root crops deplete this heavily." eh="e23e2d33" />
     <e k="sf_guide_p1_10" v="[EN] OM  Organic Matter Builds slowly over many seasons." eh="b235300c" />
-    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 – 7.0." eh="e8145861" />
+    <e k="sf_guide_p1_11" v="[EN] pH  Soil acidity.  Target range: 6.5 - 7.0." eh="e8145861" />
     <e k="sf_guide_p1_12" v="[EN] STATUS LEVELS" eh="b081c2c6" />
     <e k="sf_guide_p1_13" v="[EN] GOOD (green)  At or above crop's optimal target." eh="a081208f" />
     <e k="sf_guide_p1_14" v="No action needed this season." eh="58b36ac2" />
@@ -939,13 +939,13 @@
 		<e k="sf_guide_p4_46" v="[EN] Treatment (Shift+T) lists what each field" eh="ccc651dc" />
 		<e k="sf_guide_p4_47" v="[EN]   needs right now, product by product." eh="2a63f8c5" />
     <e k="sf_guide_p4_17" v="[EN] pH CORRECTION" eh="dfe729d7" />
-    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 – 7.0 for most crops." eh="3fd904c3" />
+    <e k="sf_guide_p4_18" v="[EN] Target range: 6.5 - 7.0 for most crops." eh="3fd904c3" />
     <e k="sf_guide_p4_19" v="[EN] " eh="d41d8cd9" />
     <e k="sf_guide_p4_20" v="[EN] pH too LOW (acidic, below 6.5):" eh="0ec6357e" />
     <e k="sf_guide_p4_21" v="[EN]   Apply LIME - raises pH toward neutral." eh="6595685a" />
     <e k="sf_guide_p4_22" v="[EN] pH too HIGH (alkaline, above 7.5):" eh="4204b7df" />
     <e k="sf_guide_p4_23" v="[EN]   Apply GYPSUM - lowers pH toward neutral." eh="319aa724" />
-    <e k="sf_guide_p4_24" v="[EN] Allow 1–2 seasons for full normalization." eh="1f31526d" />
+    <e k="sf_guide_p4_24" v="[EN] Allow 1-2 seasons for full normalization." eh="1f31526d" />
     <e k="sf_guide_p4_25" v="[EN] ORGANIC MATTER (OM)" eh="4b06f65b" />
     <e k="sf_guide_p4_26" v="[EN] Manure         Best OM builder. Also adds N." eh="99834812" />
     <e k="sf_guide_p4_27" v="[EN] Compost        Moderate OM, well-balanced." eh="d9b0e2f9" />
@@ -985,9 +985,9 @@
     <e k="sf_guide_p5_22" v="[EN] DO I NEED TO FERTILIZE EVERY SEASON?" eh="778fc0ad" />
     <e k="sf_guide_p5_23" v="[EN] Nitrogen: Yes, every season if possible." eh="5232d8d2" />
     <e k="sf_guide_p5_24" v="It depletes heavily on every harvest." eh="696ed55e" />
-    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2–3 seasons is usually enough." eh="0757cb47" />
+    <e k="sf_guide_p5_25" v="[EN] P and K: Every 2-3 seasons is usually enough." eh="0757cb47" />
     <e k="sf_guide_p5_26" v="[EN] Organic OM: Long-term. Add manure once a year." eh="78827593" />
-    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5–7.0 range." eh="373553dc" />
+    <e k="sf_guide_p5_27" v="[EN] pH: Only when outside the 6.5-7.0 range." eh="373553dc" />
     <e k="sf_guide_p5_28" v="[EN] HOW DO THE SMART SENSOR SYSTEMS WORK?" eh="3b9aa5b3" />
     <e k="sf_guide_p5_29" v="[EN] Smart Sensor blocks individual boom sections when" eh="ec681a8d" />
     <e k="sf_guide_p5_30" v="[EN] no need is detected (no pest, disease, or nutrient" eh="22de015a" />

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -22,9 +22,13 @@
             </ThreePartBitmap>
 
             <Bitmap profile="fs25_subCategoryContainer" id="rfFilterBox">
-                <MultiTextOption profile="fs25_subCategorySelector" id="rfPanelSelector"
-                                 disableButtonsOnSingleText="false"
-                                 onClick="onClickRfPanelSelector" focusInit="onOpen"/>
+                <!-- BUILD 18:16: rfPanelSelector moved to LAST child of rfFilterBox (see below).
+                     George TASK 18:12 asked for z-order ~10-20 on the selector; this engine has no
+                     z attribute of any kind (GuiElement loads none, and no rfHeaderBg element exists
+                     in this page) - draw AND input priority are declaration order, walked in reverse
+                     for events. Declaring the selector last IS the engine's z-raise: it now receives
+                     events before every sibling in this box and draws above them. Positions are
+                     profile-absolute, so nothing moves a pixel. -->
                 <BoxLayout profile="fs25_subCategorySelectorBox" id="rfPanelDotBox">
                     <RoundCorner profile="fs25_subCategorySelectorDot" id="rfPanelDotTemplate"/>
                 </BoxLayout>
@@ -60,6 +64,16 @@
                         <Slider profile="fs25_listSlider" dataElementId="moduleList" hideParentWhenEmpty="true"/>
                     </ThreePartBitmap>
                 </GuiElement>
+
+                <!-- BUILD 18:16 (George TASK 18:12): the module selector is deliberately the LAST
+                     child of rfFilterBox. Events walk children in reverse declaration order, so
+                     last-declared = first offered = this engine's only "z-order raise". Its band
+                     rect (profile-positioned, unchanged) does not overlap any sibling's visible
+                     paint, so drawing on top changes no pixel. The BUILD 17:08 page-level click
+                     shield stays as the guarantee against anything OUTSIDE this box. -->
+                <MultiTextOption profile="fs25_subCategorySelector" id="rfPanelSelector"
+                                 disableButtonsOnSingleText="false"
+                                 onClick="onClickRfPanelSelector" focusInit="onOpen"/>
             </Bitmap>
 
             <!-- WC page chrome: sibling under Modules (NOT inside rfFilterBox — hit hygiene).
@@ -222,29 +236,43 @@
                              built by whichever mod loads first, from its own copy, so a change
                              in Soil alone would be overwritten by whoever won the race. -->
                         <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px" size="620px 248px">
-                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="600px 20px"
+                            <!-- BUILD 09:19 (PB-05). Brian read "Wait: amending now can burn t..." on
+                                 this strip: the sentence that says an apply will scorch the crop was
+                                 cut before its own verb.
+                                 The wrap was not broken. TextElement defaults to LAYOUT_MODE.TRUNCATE
+                                 (TextElement.lua:141) and with textMaxNumLines > 1 that takes the
+                                 limitVerticalLines path (:667-676), wrapping at absSize[1] and then
+                                 chopping characters until the text fits the line budget before adding
+                                 "..." (:679-699). So it wrapped to its two lines exactly as asked and
+                                 the string is simply longer than two lines of 18px across 600px.
+                                 Two allowed 18px lines become three. The 18px comes out of this zone
+                                 rather than out of the table: Selected moves up 2, the hairline and
+                                 the PRODUCTS heading close up, and the eight-row clip drops 4. Row 8
+                                 still ends 4px clear of the card frame (124 + 120 = 244 against 248),
+                                 so nothing is cut mid-glyph and the card does not grow. -->
+                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -4px" size="600px 20px"
                                   textAlignment="left"/>
-                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="600px 36px"
-                                  textAlignment="left" textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then ~16px of
-                                 air with one 1px hairline centred in it, then the PRODUCTS table.
+                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -24px" size="600px 54px"
+                                  textAlignment="left" textMaxNumLines="3" textVerticalAlignment="top"/>
+                            <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then air with
+                                 one 1px hairline in it, then the PRODUCTS table.
                                  One outer outline only; the rule is a Bitmap, not a second frame.
                                  Bodies inset X 0 -> 10 and widths 560 -> 540 so nothing kisses the
                                  white stroke on either side. -->
-                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="600px 1px"/>
-                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="600px 18px"
+                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -82px" size="600px 1px"/>
+                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -86px" size="600px 18px"
                                   text="$l10n_rf_pda_treat_products"/>
-                            <Text profile="RF_ProductColHeaderDense" position="10px -100px" size="40px 16px" text="NUT"/>
-                            <Text profile="RF_ProductColHeaderDense" position="54px -100px" size="270px 16px" text="PRODUCT"/>
-                            <Text profile="RF_ProductColHeaderDense" position="330px -100px" size="100px 16px"
+                            <Text profile="RF_ProductColHeaderDense" position="10px -106px" size="40px 16px" text="NUT"/>
+                            <Text profile="RF_ProductColHeaderDense" position="54px -106px" size="270px 16px" text="PRODUCT"/>
+                            <Text profile="RF_ProductColHeaderDense" position="330px -106px" size="100px 16px"
                                   textAlignment="right" text="RATE"/>
-                            <Text profile="RF_ProductColHeaderDense" position="440px -100px" size="110px 16px"
+                            <Text profile="RF_ProductColHeaderDense" position="440px -106px" size="110px 16px"
                                   textAlignment="right" text="TOTAL"/>
-                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="600px 22px"
+                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -124px" size="600px 22px"
                                   visible="false"/>
                             <!-- Clip sized to exactly the eight densified rows (8 x 15 = 120), so the
-                                 card bottom keeps 8px of air instead of cutting row 8 mid-glyph. -->
-                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="600px 120px">
+                                 card bottom keeps air instead of cutting row 8 mid-glyph. -->
+                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -124px" size="600px 120px">
                                 <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd1Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd1Name" position="44px 0px" size="270px 15px"/>
@@ -312,20 +340,43 @@
                             <Text profile="RF_ProductCell" id="soilRotationStatus" position="10px -56px" size="270px 20px"/>
                             <Text profile="RF_ProductCell" id="soilRotationTip" position="10px -76px" size="270px 32px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Bitmap profile="RF_EscCardRule" id="soilRotationRule" position="10px -116px" size="270px 1px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationWhatIfHeader" position="10px -124px" size="270px 16px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColCrop" position="10px -144px" size="92px 14px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColStatus" position="106px -144px" size="60px 14px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColEffect" position="170px -144px" size="110px 14px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Crop" position="10px -162px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Status" position="106px -162px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Effect" position="170px -162px" size="110px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Crop" position="10px -184px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Status" position="106px -184px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Effect" position="170px -184px" size="110px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Crop" position="10px -206px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Status" position="106px -206px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Effect" position="170px -206px" size="110px 18px"/>
+                            <!-- BUILD 09:19 (PB-05). The WHAT IF effect column lost whole consequences.
+                                 RotationPlannerData.effectText joins at most three items with ", " and
+                                 the set is closed: fatigue "x1.15 depletion", nitrogen "+N", and one of
+                                 "less disease" / "more disease". The worst real string is therefore
+                                 "x1.15 depletion, +N, less disease" at 33 characters, and the painter
+                                 capped the cell at 18 - so even the two-item "x1.15 depletion, +N" (19)
+                                 dropped an item and the player was told about the fatigue but not about
+                                 the disease.
+                                 18 was not arbitrary against the OLD cell: this card's own calibration
+                                 is ~6px per glyph at 17px (crop 92px/16, status 60px/10, effect 110px/18),
+                                 so 110px really does hold about 18. One 17px line cannot hold 33 and the
+                                 card cannot grow - George holds the footprint at 290x248 and it must
+                                 never take width back from PRODUCTS. So the effect cell gains a SECOND
+                                 line at 14px instead, which is the size the PRODUCTS table already uses
+                                 for its own cells (RF_ProductCellDense), and about 22 glyphs a line at
+                                 that size gives ~44 against a bounded worst case of 33.
+                                 Row pitch 22 -> 30 to hold the taller cell; the hairline and the two
+                                 header lines close up by 4-8px to pay for it. Row 3 ends at 240 against
+                                 the 248 frame, so the card keeps its 8px of bottom air. Crop and Status
+                                 stay one 17px line and are unchanged. -->
+                            <Bitmap profile="RF_EscCardRule" id="soilRotationRule" position="10px -112px" size="270px 1px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationWhatIfHeader" position="10px -118px" size="270px 16px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColCrop" position="10px -136px" size="92px 14px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColStatus" position="106px -136px" size="60px 14px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColEffect" position="170px -136px" size="110px 14px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf1Crop" position="10px -152px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf1Status" position="106px -152px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf1Effect" position="170px -152px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf2Crop" position="10px -182px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf2Status" position="106px -182px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf2Effect" position="170px -182px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf3Crop" position="10px -212px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf3Status" position="106px -212px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf3Effect" position="170px -212px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
                         </GuiElement>
 
                         <!-- Col 3: sampling — shifted right so widened PRODUCTS does not overlap -->
@@ -526,6 +577,19 @@
                             <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text=""/>
                             <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text=""/>
                             <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -300px" size="1120px 20px" text=""/>
+                            <!-- BUILD 09:19 (PB-07): row pager for this static eight-row table.
+                                 Hidden by default and shown ONLY by a guest that implements
+                                 onPageStep, so Income / Dairy / Depot keep exactly the page they
+                                 have today. Two Buttons, not a SmoothList: George's standing NO-GO
+                                 on nesting a SmoothList in this page (see csConsultPanel below)
+                                 applies here too, and a window offset held by the guest cannot
+                                 re-enter the layout the way a list rebuild can.
+                                 Parked on the rfFwTableTitle band, which every Table-mode guest
+                                 already hides, so the pager collides with nothing that paints. -->
+                            <Button profile="buttonActivate" id="rfFwPagePrev" position="880px -8px" size="120px 24px"
+                                    visible="false" text="" onClick="onClickRfFwPagePrev"/>
+                            <Button profile="buttonActivate" id="rfFwPageNext" position="1010px -8px" size="120px 24px"
+                                    visible="false" text="" onClick="onClickRfFwPageNext"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
                             <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <GUIProfiles>
     <!-- ============================================================ -->
     <!-- Realistic Farming PDA profiles — MOCKUP-ESC-RF-PDA swatches  -->
@@ -260,6 +260,16 @@
     </Profile>
     <Profile name="RF_ProductCellRight" extends="RF_ProductCell">
         <textAlignment value="right"/>
+    </Profile>
+    <!-- BUILD 09:19 (PB-05): WHAT IF effect cell only. Two lines at the same 14px the
+         PRODUCTS table already uses for its own cells, so a comma-joined consequence is
+         printed whole instead of losing its last item to a one-line 110px column. Top
+         aligned because a two-line cell that centres would not line up with the one-line
+         Crop and Status cells beside it. -->
+    <Profile name="RF_ProductCellEffect" extends="RF_ProductCell">
+        <textSize value="14px"/>
+        <textMaxNumLines value="2"/>
+        <textVerticalAlignment value="top"/>
     </Profile>
     <Profile name="RF_ProductOk" extends="fs25_textDefault" with="anchorTopLeft">
         <textSize value="18px"/>


### PR DESCRIPTION
## Summary
- Upgrades SoilFertilizer HUD and attached vehicle tool panels (Harvester, Smart Sensor, Sprayer Info, Variable Rate) to native base-game extension styling.
- Integrates full corner scale and left/right edge width resizing.
- Sets factory layout default for Soil HUD to (0.800, 0.532, scale 1.141, widthMult 0.909).
- Participates in MasterHUD global toggle and edit mode.

## Test plan
- Verified in-game: Soil HUD and attached tool panels render with clean base-game plates, scale and resize cleanly, and persist layout.