### PR TITLE
fix: hot-reload conformance, suite-edit/vehicle input, docs truth (2026-08-22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Three pressure scores (0–100) track threats to each field independently. Left 
 
 All three are visible in the HUD and the full Soil Report. Each can be toggled off in settings.
 
-**Named diseases and fungicide chemistry** - disease pressure isn't just a number. Each crop can catch specific real-world diseases (wheat gets septoria, rust, and fusarium head blight; potatoes get late and early blight; soybeans get frogeye and white mould, and so on - around 40 in total). Press **Scout** (`SF_SCOUT`, default **Shift+K**) on a field to identify the active disease, then choose from a catalog of **23 fungicides** across seven chemistry families (triazoles, strobilurins, SDHIs, contact protectants, specialty, preventatives, and seed treatments). Each product has its own cost, per-disease effectiveness, and application window, and works best applied early, on-window, and not in the rain. Rotate chemistry families to keep them working.
+**Named diseases and fungicide chemistry** - disease pressure isn't just a number. Each crop can catch specific real-world diseases (wheat gets septoria, rust, and fusarium head blight; potatoes get late and early blight; soybeans get frogeye and white mould, and so on - around 40 in total). Press **Scout** (`SF_SCOUT` - no default key, assign one under Options > Controls > Mods) on a field to identify the active disease, then choose from a catalog of **23 fungicides** across seven chemistry families (triazoles, strobilurins, SDHIs, contact protectants, specialty, preventatives, and seed treatments). Each product has its own cost, per-disease effectiveness, and application window, and works best applied early, on-window, and not in the rain. Rotate chemistry families to keep them working.
 
-**Treatment panel** - press **Open Soil Treatment Panel** (`SF_TREATMENT`, default **Shift+T**) for a per-field prescription: exactly which nutrients, lime, and protection products a field needs right now.
+**Treatment panel** - press **Open Soil Treatment Panel** (`SF_TREATMENT` - no default key, assign one under Options > Controls > Mods) for a per-field prescription: exactly which nutrients, lime, and protection products a field needs right now.
 
 ### 💊 Fertilizer Types
 
@@ -202,11 +202,11 @@ Three in-vehicle overlay panels that appear when you enter a supported sprayer. 
 |---|---|---|
 | **Smart Sensor** | Monitors pest, disease, and nutrient need per section. Blocks spraying on sections with no active need detected. | Settings → Admin → Smart Systems. Works with any VWW sprayer. |
 | **See & Spray** | Shows live per-cell pressure for pest, disease, and weed at the sprayer's current position. Colour-coded per section. | Buy any sprayer with the *See & Spray* shop configuration selected. |
-| **Variable Rate** | Adjusts boom output rate per section based on soil deficits for the loaded product. Green bar = low rate; red bar = high rate. | Default key **Alt+7** (rebind `SF_VARIABLE_RATE` in **Controls → Mods**). Enable in Admin → Smart Systems. |
+| **Variable Rate** | Adjusts boom output rate per section based on soil deficits for the loaded product. Green bar = low rate; red bar = high rate. | No default key (bind `SF_VARIABLE_RATE` in **Controls → Mods**). Enable in Admin → Smart Systems. |
 
 Smart Sensor and Variable Rate work with any VWW-capable sprayer. **See & Spray is available on any sprayer** with the See & Spray option selected at purchase.
 
-**Free Panel Layout** - Enable in Settings → Display → Position, then use the Shift+H edit mode to drag each panel independently. Press **[−]** in any panel's title bar to collapse it to the title bar only. Positions and collapse states are saved to `hud.xml`.
+**Free Panel Layout** - Enable in Settings → Display → Position, then use the HUD drag edit mode (`SF_HUD_DRAG`, bind it in Controls → Mods) to drag each panel independently. Press **[−]** in any panel's title bar to collapse it to the title bar only. Positions and collapse states are saved to `hud.xml`.
 
 ### 📊 Soil HUD
 
@@ -218,7 +218,7 @@ The **yield forecast row** (e.g. `Yield ~-18%`) is not just a warning - it refle
 
 Additional rows appear contextually: **Coverage** (`Coverage: X% / 70% min`) while a sprayer is active on a field, and **Compaction** (when soil compaction is above 0% and the setting is enabled). Both are colour-coded with the same green/amber/red tiers as nutrients.
 
-Fully customisable: 6 positions, 4 colour themes, 5 transparency levels, 3 font sizes, and a compact mode that shrinks to one line per nutrient. The HUD drag mode (`SF_HUD_DRAG`, default **Shift+H**) lets you reposition panels in Free Panel Layout and is rebindable through the standard FS25 key bindings menu.
+Fully customisable: 6 positions, 4 colour themes, 5 transparency levels, 3 font sizes, and a compact mode that shrinks to one line per nutrient. The HUD drag mode (`SF_HUD_DRAG` - no default key, assign one through the standard FS25 key bindings menu; note **Shift+H** is taken by FS25_MasterHUD's hide-all-HUDs toggle) lets you reposition panels in Free Panel Layout. With FS25_MasterHUD installed, the suite *Edit HUD Layout* action also enters this edit mode.
 
 ### 📋 Full Farm Soil Report
 
@@ -305,7 +305,7 @@ The full panel ships with its key **unbound** to avoid clashing with other mods.
 | **Harvester info panel** | On / Off | In-vehicle panel showing yield forecast and soil status while harvesting |
 | **Field info box** | On / Off | Small on-screen box summarising the current field |
 | **Colourblind mode** | On / Off | Swaps the status palette for colourblind-friendly colours |
-| **Free Panel Layout** | On / Off | Drag each in-vehicle panel to its own position (Shift+H edit mode) |
+| **Free Panel Layout** | On / Off | Drag each in-vehicle panel to its own position (`SF_HUD_DRAG` edit mode) |
 
 **🗺️ Map** - controls the PDA map overlay
 
@@ -337,7 +337,7 @@ Every core rate has its own multiplier: nutrient depletion, fertilizer efficienc
 
 ## 🖥️ Console Commands
 
-Open the developer console with **`~`** and type `soilfertility` for the full list, or press **`Shift+O`** → **Admin** to access all commands as buttons directly in-game.
+Open the developer console with **`~`** and type `soilfertility` for the full list, or press your **Open Soil Settings** key (`SF_OPEN_SETTINGS`, bound in Controls → Mods) → **Admin** to access all commands as buttons directly in-game.
 
 | Command | Arguments | Description |
 |---|---|---|
@@ -406,7 +406,7 @@ All integrations are detected automatically at runtime and fail gracefully if th
 4. Apply lime first - it unlocks the full value of everything else
 5. Apply fertilizer → watch N/P/K climb in real time
 6. Open the tablet → Soil & Fertilizer → Farm Overview to see all fields by urgency
-7. Press Shift+O → open the full settings panel to tune the simulation
+7. Press your Open Soil Settings key (bind SF_OPEN_SETTINGS in Controls → Mods) → open the full settings panel to tune the simulation
 8. Let a field go fallow for a season → it slowly recovers on its own
 9. At harvest → healthy soil means the full yield you worked for
 ```

--- a/src/CompostManager.lua
+++ b/src/CompostManager.lua
@@ -14,7 +14,7 @@
 -- The batch duration is a NATURAL rate, not days-per-period normalized.
 -- =========================================================
 
-CompostManager = {}
+CompostManager = CompostManager or {}
 local CompostManager_mt = Class(CompostManager)
 
 CompostManager.LEDGER = "DairyCore_FeedProvenance_Compost"  -- namespaced under this mod's slot

--- a/src/DiseaseSystem.lua
+++ b/src/DiseaseSystem.lua
@@ -14,7 +14,7 @@
 -- =========================================================
 
 ---@class SoilDiseaseSystem
-SoilDiseaseSystem = {}
+SoilDiseaseSystem = SoilDiseaseSystem or {}
 
 local function clamp(v, lo, hi)
     if v < lo then return lo end

--- a/src/EstablishmentFailure.lua
+++ b/src/EstablishmentFailure.lua
@@ -26,7 +26,7 @@
 -- =========================================================
 
 ---@class EstablishmentFailure
-EstablishmentFailure = {}
+EstablishmentFailure = EstablishmentFailure or {}
 local EstablishmentFailure_mt = Class(EstablishmentFailure)
 
 -- The daily kill threshold: SCS moisture (0-1) above which an establishing crop

--- a/src/FieldSentry.lua
+++ b/src/FieldSentry.lua
@@ -21,7 +21,7 @@
 -- =========================================================
 
 ---@class FieldSentry_Core
-FieldSentry_Core = {}
+FieldSentry_Core = FieldSentry_Core or {}
 
 -- Blacklist reason enum. Phase 1 uses NONE and MANUAL; the rest are reserved so the
 -- API shape is stable as later phases add structural/classification rules.
@@ -205,7 +205,7 @@ end
 -- Public API
 -- =========================================================
 ---@class FieldSentry_API
-FieldSentry_API = {}
+FieldSentry_API = FieldSentry_API or {}
 
 --- Hot path (O(1)): is this field's simulation currently disabled?
 ---@param fieldId number

--- a/src/GrowthBlock.lua
+++ b/src/GrowthBlock.lua
@@ -24,7 +24,7 @@
 -- (steward condition 2), not a comment.
 -- ============================================================
 
-GrowthBlock = {}
+GrowthBlock = GrowthBlock or {}
 local GrowthBlock_mt = Class(GrowthBlock)
 
 -- The restore cap: max growth steps held back per bracket. Default 1. Neutral

--- a/src/GrowthCredit.lua
+++ b/src/GrowthCredit.lua
@@ -24,7 +24,7 @@
 -- by one. DensityMapMultiModifier batching is sanctioned.
 -- ============================================================
 
-GrowthCredit = {}
+GrowthCredit = GrowthCredit or {}
 local GrowthCredit_mt = Class(GrowthCredit)
 
 -- Time Guard accrual. Priority 97 lands one behind the foundation's 96

--- a/src/HandfulRead.lua
+++ b/src/HandfulRead.lua
@@ -24,7 +24,7 @@
 -- Author: TisonK
 -- =========================================================
 
-HandfulRead = {}
+HandfulRead = HandfulRead or {}
 
 -- The frozen clause list. The panel renders these; a new clause needs a new
 -- source verification and a contract re-open (rule 1: no phantom fields).

--- a/src/HarvestContractUnderwrite.lua
+++ b/src/HarvestContractUnderwrite.lua
@@ -42,7 +42,7 @@
 -- =========================================================
 
 ---@class HarvestContractUnderwrite
-HarvestContractUnderwrite = {}
+HarvestContractUnderwrite = HarvestContractUnderwrite or {}
 
 -- AbstractMission:updateTick finishes a mission SUCCESS at completion >= 0.995 (the base
 -- game's own "99.5% shows as 100%" margin). We mirror it so the messaging fires exactly

--- a/src/HayBet.lua
+++ b/src/HayBet.lua
@@ -16,7 +16,7 @@
 -- =========================================================
 
 ---@class HayBet
-HayBet = {}
+HayBet = HayBet or {}
 local HayBet_mt = Class(HayBet)
 
 -- The fit boundary: moisture at or below this threshold means the

--- a/src/HybridStrains.lua
+++ b/src/HybridStrains.lua
@@ -15,7 +15,7 @@
 -- seasons-long consequence, inverting the entire design intent. That was a HARD build-order
 -- gate (Steward CD10-C1) and it cleared with b60677f8.
 
-HybridStrains = {}
+HybridStrains = HybridStrains or {}
 
 -- ── Eligibility (the threshold arithmetic) ────────────────────────────────────────────
 --

--- a/src/MaterialDown.lua
+++ b/src/MaterialDown.lua
@@ -29,7 +29,7 @@
 -- =========================================================
 
 ---@class MaterialDown
-MaterialDown = {}
+MaterialDown = MaterialDown or {}
 local MaterialDown_mt = Class(MaterialDown)
 
 MaterialDown.LAYER_KEY = "materialAge"

--- a/src/MaterialWetness.lua
+++ b/src/MaterialWetness.lua
@@ -21,7 +21,7 @@
 -- =========================================================
 
 ---@class MaterialWetness
-MaterialWetness = {}
+MaterialWetness = MaterialWetness or {}
 local MaterialWetness_mt = Class(MaterialWetness)
 
 MaterialWetness.LAYER_KEY = "materialWetness"

--- a/src/NeighbourCrossing.lua
+++ b/src/NeighbourCrossing.lua
@@ -38,7 +38,7 @@
 -- Author: TisonK
 -- =========================================================
 
-NeighbourCrossing = {}
+NeighbourCrossing = NeighbourCrossing or {}
 
 NeighbourCrossing.ENABLED = true
 

--- a/src/NpcSoilBridge.lua
+++ b/src/NpcSoilBridge.lua
@@ -26,7 +26,7 @@
 -- Author: TisonK
 -- =========================================================
 
-NpcSoilBridge = {}
+NpcSoilBridge = NpcSoilBridge or {}
 
 --- The mission-handle capability marker NPCFavor probes before deleting its flip.
 --- Published once the mission handle is available (Mission00.load hook).

--- a/src/OrganicCertification.lua
+++ b/src/OrganicCertification.lua
@@ -19,7 +19,7 @@
 -- downstream consumers in their own repos and only READ getFieldOrganicState().
 -- =========================================================
 
-OrganicCertification = {}
+OrganicCertification = OrganicCertification or {}
 local OrganicCertification_mt = Class(OrganicCertification)
 
 --- Constructor

--- a/src/PositionalCapture.lua
+++ b/src/PositionalCapture.lua
@@ -25,7 +25,7 @@
 -- Author: TisonK
 -- =========================================================
 
-PositionalCapture = {}
+PositionalCapture = PositionalCapture or {}
 
 PositionalCapture.ENABLED = true
 

--- a/src/ReleaseGate.lua
+++ b/src/ReleaseGate.lua
@@ -20,7 +20,7 @@
 -- never a default.
 -- =========================================================
 
-ReleaseGate = {}
+ReleaseGate = ReleaseGate or {}
 
 -- The certified experimental (LOCKED) set. Each entry: [systemId] = { name, status }.
 -- `status` is a SHORT player-facing note on what is not working or implemented yet.

--- a/src/ResistanceBands.lua
+++ b/src/ResistanceBands.lua
@@ -24,7 +24,7 @@
 -- survive the wholesale-replace handlers. Bands ride every payload the way organic does
 -- rather than being side-cached, because a value that travels cannot be wiped by a replace.
 
-ResistanceBands = {}
+ResistanceBands = ResistanceBands or {}
 
 local BANDS = SoilConstants.RESISTANCE.BANDS
 

--- a/src/SoilCompactionModel.lua
+++ b/src/SoilCompactionModel.lua
@@ -22,7 +22,7 @@
 -- pure and unit-tested under tools/test.
 -- =====================================================================================
 
-SoilCompactionModel = {}
+SoilCompactionModel = SoilCompactionModel or {}
 
 local function clamp(v, lo, hi)
     if v < lo then return lo end

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -6,7 +6,7 @@
 -- COPYRIGHT NOTICE: All rights reserved.
 -- =========================================================
 ---@class SoilFertilityManager
-SoilFertilityManager = {}
+SoilFertilityManager = SoilFertilityManager or {}
 local SoilFertilityManager_mt = Class(SoilFertilityManager)
 
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -9,7 +9,7 @@
 -- =========================================================
 
 ---@class SoilFertilitySystem
-SoilFertilitySystem = {}
+SoilFertilitySystem = SoilFertilitySystem or {}
 local SoilFertilitySystem_mt = Class(SoilFertilitySystem)
 
 local COVERAGE_MILESTONES = { 0.10, 0.25, 0.50, 0.75, 1.0 }

--- a/src/SoilSensorManager.lua
+++ b/src/SoilSensorManager.lua
@@ -13,7 +13,7 @@
 -- =========================================================
 
 ---@class SoilSensorManager
-SoilSensorManager = {}
+SoilSensorManager = SoilSensorManager or {}
 SoilSensorManager.__index = SoilSensorManager
 
 -- Nutrient level (0-100) above which the nutrient sensor skips spraying.

--- a/src/SpatialNutrients.lua
+++ b/src/SpatialNutrients.lua
@@ -43,7 +43,7 @@
 -- Author: TisonK
 -- =========================================================
 
-SpatialNutrients = {}
+SpatialNutrients = SpatialNutrients or {}
 
 SpatialNutrients.ENABLED = true
 

--- a/src/SpatialPressures.lua
+++ b/src/SpatialPressures.lua
@@ -30,7 +30,7 @@
 -- Author: TisonK
 -- =========================================================
 
-SpatialPressures = {}
+SpatialPressures = SpatialPressures or {}
 
 SpatialPressures.ENABLED = true
 

--- a/src/SpatialScouting.lua
+++ b/src/SpatialScouting.lua
@@ -31,7 +31,7 @@
 -- Author: TisonK
 -- =========================================================
 
-SpatialScouting = {}
+SpatialScouting = SpatialScouting or {}
 
 -- Age limit default. The brief says "N in XML, ratio-pass-tuned, never infinite
 -- by default". The ratio pass has not run; this is the flagged placeholder, one

--- a/src/SprayerRateManager.lua
+++ b/src/SprayerRateManager.lua
@@ -8,7 +8,7 @@
 -- =========================================================
 
 ---@class SprayerRateManager
-SprayerRateManager = {}
+SprayerRateManager = SprayerRateManager or {}
 SprayerRateManager.__index = SprayerRateManager
 
 function SprayerRateManager.new()

--- a/src/TopographyCache.lua
+++ b/src/TopographyCache.lua
@@ -25,7 +25,7 @@
 -- until a consumer wires in.
 -- ============================================================
 
-TopographyCache = {}
+TopographyCache = TopographyCache or {}
 local TopographyCache_mt = Class(TopographyCache)
 
 -- Grid constants (the brief's numbers).

--- a/src/TrafficDrag.lua
+++ b/src/TrafficDrag.lua
@@ -14,7 +14,7 @@
 -- SoilFertilityManager:_checkVehicleCompaction (driving pass).
 -- =====================================================================================
 
-TrafficDrag = {}
+TrafficDrag = TrafficDrag or {}
 
 -- -------------------------------------------------------------------------------------
 -- WETNESS BLEND (Engineering confirm 2). SCS's field-level moisture (0..1, nil when

--- a/src/ViabilityMask.lua
+++ b/src/ViabilityMask.lua
@@ -23,7 +23,7 @@
 -- The family ships LOCKED, so nothing here reaches a player yet.
 -- ============================================================
 
-ViabilityMask = {}
+ViabilityMask = ViabilityMask or {}
 local ViabilityMask_mt = Class(ViabilityMask)
 
 -- ── THE THREE-BAND DIAL FAMILY ──────────────────────────────

--- a/src/YardLadder.lua
+++ b/src/YardLadder.lua
@@ -46,7 +46,7 @@
 -- =========================================================
 
 ---@class YardLadder
-YardLadder = {}
+YardLadder = YardLadder or {}
 local YardLadder_mt = Class(YardLadder)
 
 -- Ruled numbers (SF-46 brief, NUMBERS ADDENDUM 2026-07-31).

--- a/src/ZoneYield.lua
+++ b/src/ZoneYield.lua
@@ -43,7 +43,7 @@
 -- release gate is open AND the mask is enabled.
 -- ============================================================
 
-ZoneYield = {}
+ZoneYield = ZoneYield or {}
 local ZoneYield_mt = Class(ZoneYield)
 
 -- ── THE EFFICIENCY BAND ──────────────────────────────────────

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -9,7 +9,7 @@
 -- =========================================================
 
 ---@class SoilConstants
-SoilConstants = {}
+SoilConstants = SoilConstants or {}
 
 -- ========================================
 -- TIMING
@@ -909,9 +909,9 @@ SoilConstants.HUD = {
         -- with BASE_H 0.228 the top edge is 0.708, inside Sam's <=0.760 / <=0.709
         -- bounds and AABB-clear of Tax and World Events. y is the overlay BOTTOM.
         -- Presets 2-5 are player choices and stay untouched.
-        -- Wizard 2026-08-21: preset [1] updated to the suite layout Wizard
+        -- Wizard 2026-08-22: preset [1] updated to the suite layout Wizard
         -- arranged in-game (right column, above Tax).
-        [1] = { x = 0.800068, y = 0.531852 },  -- Suite home (factory default)
+        [1] = { x = 0.810485, y = 0.567037 },  -- Suite home (factory default)
         [2] = { x = 0.010, y = 0.70 },  -- Top Left
         [3] = { x = 0.850, y = 0.20 },  -- Bottom Right
         [4] = { x = 0.010, y = 0.20 },  -- Bottom Left

--- a/src/config/SettingsSchema.lua
+++ b/src/config/SettingsSchema.lua
@@ -8,7 +8,7 @@
 -- =========================================================
 
 ---@class SettingsSchema
-SettingsSchema = {}
+SettingsSchema = SettingsSchema or {}
 
 -- Schema entries: each defines a setting completely
 -- Order matters for UI display and network sync

--- a/src/config/SoilBlends.lua
+++ b/src/config/SoilBlends.lua
@@ -19,7 +19,7 @@
 -- Loaded immediately after Constants.lua: it reads PHYSICAL_FUNGICIDE_ORDER and writes the
 -- derived entries back into SoilConstants, so every later module sees a complete picture.
 
-SoilBlends = {}
+SoilBlends = SoilBlends or {}
 
 SoilBlends.PREFIX = "BLEND_"
 

--- a/src/config/SoilCropTuning.lua
+++ b/src/config/SoilCropTuning.lua
@@ -21,7 +21,7 @@
 -- =========================================================
 
 ---@class SoilCropTuning
-SoilCropTuning = {}
+SoilCropTuning = SoilCropTuning or {}
 local SoilCropTuning_mt = Class(SoilCropTuning)
 
 SoilCropTuning.SAVE_FILE = "soilCropTuning.xml"

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -7,7 +7,7 @@
 -- =========================================================
 
 ---@class HookManager
-HookManager = {}
+HookManager = HookManager or {}
 local HookManager_mt = Class(HookManager)
 
 --- [SF-19 item 5] Resolve the per-section pest/disease pressure for See & Spray.

--- a/src/hooks/SoilMapHooks.lua
+++ b/src/hooks/SoilMapHooks.lua
@@ -11,7 +11,7 @@
 -- always call IngameMapElement.draw superFunc.
 -- =========================================================
 
-SoilMapHooks = {}
+SoilMapHooks = SoilMapHooks or {}
 
 local function logNilOnce(key, msg)
     if InGameMenuMapFrame == nil then

--- a/src/integrations/PrecisionFarmingBridge.lua
+++ b/src/integrations/PrecisionFarmingBridge.lua
@@ -13,7 +13,7 @@
 -- =========================================================
 
 ---@class PrecisionFarmingBridge
-PrecisionFarmingBridge = {}
+PrecisionFarmingBridge = PrecisionFarmingBridge or {}
 local PrecisionFarmingBridge_mt = { __index = PrecisionFarmingBridge }
 
 -- PF's mod directory name. Both g_modIsLoaded and missionDynamicInfo.mods

--- a/src/integrations/SoilMaterialDownBridge.lua
+++ b/src/integrations/SoilMaterialDownBridge.lua
@@ -15,7 +15,7 @@
 -- Author: TisonK
 -- =========================================================
 
-SoilMaterialDownBridge = {}
+SoilMaterialDownBridge = SoilMaterialDownBridge or {}
 
 -- =========================================================
 -- Time Guard

--- a/src/integrations/SoilNetworkSyncBridge.lua
+++ b/src/integrations/SoilNetworkSyncBridge.lua
@@ -42,7 +42,7 @@
 -- is order-independent.
 -- =========================================================
 
-SoilNetworkSyncBridge = {}
+SoilNetworkSyncBridge = SoilNetworkSyncBridge or {}
 
 -- Provisional module id. This is the network CHANNEL and the join-snapshot key, so
 -- it must be locked with Claude(A) before release (a later rename desyncs a mixed

--- a/src/integrations/SoilScoutingBridge.lua
+++ b/src/integrations/SoilScoutingBridge.lua
@@ -19,7 +19,7 @@
 -- Author: TisonK
 -- =========================================================
 
-SoilScoutingBridge = {}
+SoilScoutingBridge = SoilScoutingBridge or {}
 
 -- =========================================================
 -- Time Guard

--- a/src/integrations/SoilSettingsHubBridge.lua
+++ b/src/integrations/SoilSettingsHubBridge.lua
@@ -24,7 +24,7 @@
 -- FarmTablet's System Settings app is read-only for now.
 -- =========================================================
 
-SoilSettingsHubBridge = {}
+SoilSettingsHubBridge = SoilSettingsHubBridge or {}
 
 -- FarmTablet's System Settings app renders the label string as-is (no l10n
 -- lookup on its end), so resolve each setting's human-readable name here from

--- a/src/integrations/SoilStateLedgerBridge.lua
+++ b/src/integrations/SoilStateLedgerBridge.lua
@@ -20,7 +20,7 @@
 -- we register before or after it parses the master file.
 -- =========================================================
 
-SoilStateLedgerBridge = {}
+SoilStateLedgerBridge = SoilStateLedgerBridge or {}
 
 -- Provisional module id. This is the persistence KEY inside the master file, so it
 -- must be locked with Claude(A) before any release (a later rename orphans saved

--- a/src/integrations/SoilTopographyBridge.lua
+++ b/src/integrations/SoilTopographyBridge.lua
@@ -8,7 +8,7 @@
 -- soil bridges use: no-op when StateLedger / NetworkSync is absent.
 -- =========================================================
 
-SoilTopographyBridge = {}
+SoilTopographyBridge = SoilTopographyBridge or {}
 
 -- Provisional module ids (must be locked with Claude(A) before release, the
 -- same <Mod>_<Thing> convention as the soil bridges).

--- a/src/main.lua
+++ b/src/main.lua
@@ -11,11 +11,18 @@
 -- or claiming this code as your own is strictly prohibited.
 -- =========================================================
 
-local modDirectory = g_currentModDirectory
-local modName = g_currentModName
+-- Hot-reload latch (FuelCosts reference): g_currentModDirectory and
+-- g_currentModName are nil on a live re-source, so they are latched into
+-- module globals on first load, with a g_modsDirectory loose-folder fallback.
+SoilFertilizerModDirectory = SoilFertilizerModDirectory
+    or g_currentModDirectory
+    or (g_modsDirectory ~= nil and (g_modsDirectory .. "FS25_SoilFertilizer/") or nil)
+SoilFertilizerModName = SoilFertilizerModName or g_currentModName or "FS25_SoilFertilizer"
+local modDirectory = SoilFertilizerModDirectory
+local modName = SoilFertilizerModName
 
 -- Menu icon global (resolved by XML imageFilename="g_SFIconMenu" via GuiOverlay hook below)
-g_SFIconMenu = Utils.getFilename("textures/ui/menuIcon.dds", g_currentModDirectory)
+g_SFIconMenu = Utils.getFilename("textures/ui/menuIcon.dds", (SoilFertilizerModDirectory or g_currentModDirectory))
 
 -- Resolve g_SFIconMenu in XML imageFilename attributes (EmployeeManager/MDM pattern)
 local SF_ICON_GLOBALS = { g_SFIconMenu = true }
@@ -837,7 +844,7 @@ end
 --   patching working in the same callback).
 
 -- Route mouse events to SoilHUD (for drag/resize edit mode).
--- Edit mode is entered via Shift+H (SF_HUD_DRAG input action) - not via RMB.
+-- Edit mode is entered via the SF_HUD_DRAG input action (player-assigned key) - not via RMB.
 -- RMB only exits edit mode (and only when this mod is already in edit mode).
 -- This guarantees RMB is never consumed during normal play, preserving
 -- CoursePlay, AutoDrive, and other mods that rely on RMB.

--- a/src/maps/SoilBundledMaps.lua
+++ b/src/maps/SoilBundledMaps.lua
@@ -19,11 +19,11 @@
 -- Author: TisonK
 -- =========================================================
 
--- Capture mod directory at source() time - g_currentModDirectory is nil after mission load
-local MOD_DIRECTORY = g_currentModDirectory
+-- Capture mod directory at source() time - (SoilFertilizerModDirectory or g_currentModDirectory) is nil after mission load
+local MOD_DIRECTORY = (SoilFertilizerModDirectory or g_currentModDirectory)
 
 ---@class SoilBundledMaps
-SoilBundledMaps = {}
+SoilBundledMaps = SoilBundledMaps or {}
 local SoilBundledMaps_mt = Class(SoilBundledMaps)
 
 -- ─────────────────────────────────────────────────────────

--- a/src/maps/SoilValueMaps.lua
+++ b/src/maps/SoilValueMaps.lua
@@ -25,7 +25,7 @@
 -- =========================================================
 
 ---@class SoilValueMaps
-SoilValueMaps = {}
+SoilValueMaps = SoilValueMaps or {}
 local SoilValueMaps_mt = Class(SoilValueMaps)
 
 -- Unscouted-disease marker (Unscouted Indicator). The diseasePressure DISPLAY

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -11,7 +11,7 @@
 -- ========================================
 -- SETTING CHANGE EVENT (Client -> Server)
 -- ========================================
-SoilSettingChangeEvent = {}
+SoilSettingChangeEvent = SoilSettingChangeEvent or {}
 SoilSettingChangeEvent_mt = Class(SoilSettingChangeEvent, Event)
 
 InitEventClass(SoilSettingChangeEvent, "SoilSettingChangeEvent")
@@ -121,7 +121,7 @@ end
 -- ========================================
 -- SETTING SYNC EVENT (Server -> Clients)
 -- ========================================
-SoilSettingSyncEvent = {}
+SoilSettingSyncEvent = SoilSettingSyncEvent or {}
 SoilSettingSyncEvent_mt = Class(SoilSettingSyncEvent, Event)
 
 InitEventClass(SoilSettingSyncEvent, "SoilSettingSyncEvent")
@@ -200,7 +200,7 @@ end
 -- ========================================
 -- FULL SYNC REQUEST (Client -> Server)
 -- ========================================
-SoilRequestFullSyncEvent = {}
+SoilRequestFullSyncEvent = SoilRequestFullSyncEvent or {}
 SoilRequestFullSyncEvent_mt = Class(SoilRequestFullSyncEvent, Event)
 
 InitEventClass(SoilRequestFullSyncEvent, "SoilRequestFullSyncEvent")
@@ -356,7 +356,7 @@ end
 -- ========================================
 -- FULL SYNC RESPONSE (Server -> Client)
 -- ========================================
-SoilFullSyncEvent = {}
+SoilFullSyncEvent = SoilFullSyncEvent or {}
 SoilFullSyncEvent_mt = Class(SoilFullSyncEvent, Event)
 
 InitEventClass(SoilFullSyncEvent, "SoilFullSyncEvent")
@@ -643,7 +643,7 @@ end
 -- The server sends one of these per batch of fields after the initial
 -- SoilFullSyncEvent (which carries settings + signals sync start).
 -- isLast=true on the final batch so the client can finalise.
-SoilFieldBatchSyncEvent = {}
+SoilFieldBatchSyncEvent = SoilFieldBatchSyncEvent or {}
 SoilFieldBatchSyncEvent_mt = Class(SoilFieldBatchSyncEvent, Event)
 
 InitEventClass(SoilFieldBatchSyncEvent, "SoilFieldBatchSyncEvent")
@@ -958,7 +958,7 @@ end
 -- FIELD UPDATE EVENT (Server -> Clients)
 -- ========================================
 -- Sent when soil data changes (harvest, fertilizer) for a single field
-SoilFieldUpdateEvent = {}
+SoilFieldUpdateEvent = SoilFieldUpdateEvent or {}
 SoilFieldUpdateEvent_mt = Class(SoilFieldUpdateEvent, Event)
 
 InitEventClass(SoilFieldUpdateEvent, "SoilFieldUpdateEvent")
@@ -1228,7 +1228,7 @@ end
 -- menu. The server is authoritative: it validates the chemical, applies the
 -- effectiveness/pressure/protection math, charges the requesting farm, and
 -- broadcasts the resulting field state via SoilFieldUpdateEvent.
-SoilTreatFieldEvent = {}
+SoilTreatFieldEvent = SoilTreatFieldEvent or {}
 SoilTreatFieldEvent_mt = Class(SoilTreatFieldEvent, Event)
 
 InitEventClass(SoilTreatFieldEvent, "SoilTreatFieldEvent")
@@ -1287,7 +1287,7 @@ end
 -- (single-writer): the server validates and calls optIn/optOut, and those methods
 -- self-broadcast the resulting field state to every peer. Mirrors SoilTreatFieldEvent.
 -- ==========================================================================
-SoilOrganicOptEvent = {}
+SoilOrganicOptEvent = SoilOrganicOptEvent or {}
 SoilOrganicOptEvent_mt = Class(SoilOrganicOptEvent, Event)
 
 InitEventClass(SoilOrganicOptEvent, "SoilOrganicOptEvent")
@@ -1333,7 +1333,7 @@ end
 -- field so every client's discovery gate opens. Discovery is monotonic, so no
 -- validation beyond a known field is needed.
 -- ==========================================================================
-SoilScoutFieldEvent = {}
+SoilScoutFieldEvent = SoilScoutFieldEvent or {}
 SoilScoutFieldEvent_mt = Class(SoilScoutFieldEvent, Event)
 
 InitEventClass(SoilScoutFieldEvent, "SoilScoutFieldEvent")
@@ -1374,7 +1374,7 @@ end
 -- passively). Nothing else changes: no field scout fee, no diseaseDiscovered
 -- write, no other state.
 -- ==========================================================================
-SoilKneelEvent = {}
+SoilKneelEvent = SoilKneelEvent or {}
 SoilKneelEvent_mt = Class(SoilKneelEvent, Event)
 
 InitEventClass(SoilKneelEvent, "SoilKneelEvent")
@@ -1544,7 +1544,7 @@ end
 -- ========================================
 -- Sent when the local player changes the application rate on a sprayer.
 -- Server applies the change and rebroadcasts so all clients stay in sync.
-SoilSprayerRateEvent = {}
+SoilSprayerRateEvent = SoilSprayerRateEvent or {}
 SoilSprayerRateEvent_mt = Class(SoilSprayerRateEvent, Event)
 
 InitEventClass(SoilSprayerRateEvent, "SoilSprayerRateEvent")
@@ -1616,7 +1616,7 @@ end
 -- ========================================
 -- SPRAYER AUTO-MODE EVENT (Client <-> Server)
 -- ========================================
-SoilSprayerAutoModeEvent = {}
+SoilSprayerAutoModeEvent = SoilSprayerAutoModeEvent or {}
 SoilSprayerAutoModeEvent_mt = Class(SoilSprayerAutoModeEvent, Event)
 
 InitEventClass(SoilSprayerAutoModeEvent, "SoilSprayerAutoModeEvent")
@@ -1683,7 +1683,7 @@ end
 -- Server-authoritative. A pure client sends a request; the server validates (admin),
 -- applies it on FieldSentry, then broadcasts so every client mirrors the state for the
 -- map-tab status readout. The server/host applies directly via the Send wrapper below.
-SoilFieldSentryEvent = {}
+SoilFieldSentryEvent = SoilFieldSentryEvent or {}
 SoilFieldSentryEvent_mt = Class(SoilFieldSentryEvent, Event)
 
 InitEventClass(SoilFieldSentryEvent, "SoilFieldSentryEvent")
@@ -1752,7 +1752,7 @@ end
 -- ========================================
 -- Server-authoritative, mirrors the manual-blacklist toggle. A meadow field still
 -- simulates (on grassland rules), so this only carries the persistent player intent.
-SoilFieldMeadowEvent = {}
+SoilFieldMeadowEvent = SoilFieldMeadowEvent or {}
 SoilFieldMeadowEvent_mt = Class(SoilFieldMeadowEvent, Event)
 
 InitEventClass(SoilFieldMeadowEvent, "SoilFieldMeadowEvent")
@@ -1819,7 +1819,7 @@ end
 -- Server -> clients only. The contract mask is evaluated server-side (refreshContract);
 -- this mirrors the resulting reason enum to clients for the map-tab readout. Carries a
 -- per-field sequence so clients drop stale / out-of-order packets (FieldSentry FIFO guard).
-SoilFieldSentryStatusEvent = {}
+SoilFieldSentryStatusEvent = SoilFieldSentryStatusEvent or {}
 SoilFieldSentryStatusEvent_mt = Class(SoilFieldSentryStatusEvent, Event)
 
 InitEventClass(SoilFieldSentryStatusEvent, "SoilFieldSentryStatusEvent")
@@ -1902,7 +1902,7 @@ local sfValueMapResyncInFlight = {}
 local sfValueMapSyncRoundLayers = {}
 local SF_VALUE_MAP_RESYNC_MAX = 2
 
-SoilValueMapChunkEvent = {}
+SoilValueMapChunkEvent = SoilValueMapChunkEvent or {}
 SoilValueMapChunkEvent_mt = Class(SoilValueMapChunkEvent, Event)
 
 InitEventClass(SoilValueMapChunkEvent, "SoilValueMapChunkEvent")
@@ -2042,7 +2042,7 @@ local function sfComputeLayerChecksum(vm, layerKey)
     return sum, nonZero
 end
 
-SoilValueMapChecksumEvent = {}
+SoilValueMapChecksumEvent = SoilValueMapChecksumEvent or {}
 SoilValueMapChecksumEvent_mt = Class(SoilValueMapChecksumEvent, Event)
 
 InitEventClass(SoilValueMapChecksumEvent, "SoilValueMapChecksumEvent")
@@ -2145,7 +2145,7 @@ end
 
 -- ── Layer resync request (Client -> Server) ───────────────
 
-SoilRequestValueMapEvent = {}
+SoilRequestValueMapEvent = SoilRequestValueMapEvent or {}
 SoilRequestValueMapEvent_mt = Class(SoilRequestValueMapEvent, Event)
 
 InitEventClass(SoilRequestValueMapEvent, "SoilRequestValueMapEvent")

--- a/src/settings/Settings.lua
+++ b/src/settings/Settings.lua
@@ -7,7 +7,7 @@
 -- =========================================================
 ---@class Settings
 
-Settings = {}
+Settings = Settings or {}
 local Settings_mt = Class(Settings)
 
 Settings.DIFFICULTY_EASY = SoilConstants.DIFFICULTY.EASY

--- a/src/settings/SettingsManager.lua
+++ b/src/settings/SettingsManager.lua
@@ -7,10 +7,10 @@
 -- Author: TisonK
 -- =========================================================
 ---@class SettingsManager
-SettingsManager = {}
+SettingsManager = SettingsManager or {}
 local SettingsManager_mt = Class(SettingsManager)
 
-SettingsManager.MOD_NAME = g_currentModName or "FS25_SoilFertilizer"
+SettingsManager.MOD_NAME = (SoilFertilizerModName or g_currentModName) or "FS25_SoilFertilizer"
 SettingsManager.XMLTAG = "SoilFertilityManager"
 
 -- Default config is now derived from schema

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -5,7 +5,7 @@
 -- =========================================================
 ---@class SoilSettingsGUI
 
-SoilSettingsGUI = {}
+SoilSettingsGUI = SoilSettingsGUI or {}
 local SoilSettingsGUI_mt = Class(SoilSettingsGUI)
 
 -- Route a setting change through the network layer so all MP clients are notified.

--- a/src/settings/SoilSettingsUI.lua
+++ b/src/settings/SoilSettingsUI.lua
@@ -11,11 +11,11 @@
 -- =========================================================
 ---@class SoilSettingsUI
 
-SoilSettingsUI = {}
+SoilSettingsUI = SoilSettingsUI or {}
 local SoilSettingsUI_mt = Class(SoilSettingsUI)
 
--- Capture mod name at load time - g_currentModName is only valid during loading.
-local SF_MOD_NAME = g_currentModName
+-- Capture mod name at load time - (SoilFertilizerModName or g_currentModName) is only valid during loading.
+local SF_MOD_NAME = (SoilFertilizerModName or g_currentModName)
 
 -- The 3 settings injected into the vanilla settings page (Shift+Esc).
 -- Everything else lives in the custom SoilSettingsPanel (Shift+O).

--- a/src/specializations/SFNozzleEffects.lua
+++ b/src/specializations/SFNozzleEffects.lua
@@ -4,10 +4,10 @@
 -- its threshold 1m ahead. Mirrors PF's ExtendedSprayerEffects pattern.
 -- No PF dependency - ever.
 
-SFNozzleEffects = {}
+SFNozzleEffects = SFNozzleEffects or {}
 -- Derive the spec table name from the actual mod environment so the spec keeps
 -- working regardless of the mod folder/zip name (REFINED rename safety).
-SFNozzleEffects.SPEC_TABLE_NAME = "spec_" .. (g_currentModName or "FS25_SoilFertilizer_Refined") .. ".sfNozzleEffects"
+SFNozzleEffects.SPEC_TABLE_NAME = "spec_" .. ((SoilFertilizerModName or g_currentModName) or "FS25_SoilFertilizer_Refined") .. ".sfNozzleEffects"
 
 -- Fade direction vectors (mirrors PF ESE constants)
 SFNozzleEffects.FADE_DIR_OFF   = {0,  0}
@@ -118,14 +118,14 @@ function SFNozzleEffects.registerGlobally()
     SFNozzleEffects._didRegisterGlobally = true
 
     local shortName = "sfNozzleEffects"
-    local fullName  = (g_currentModName or "FS25_SoilFertilizer") .. "." .. shortName
+    local fullName  = ((SoilFertilizerModName or g_currentModName) or "FS25_SoilFertilizer") .. "." .. shortName
 
     -- The spec is normally registered via modDesc <specialization>; register it here as
     -- a fallback only if that did not happen (never double-register - that errors).
     if g_specializationManager and
        g_specializationManager:getSpecializationByName(fullName) == nil then
         local filename = Utils.getFilename(
-            "src/specializations/SFNozzleEffects.lua", g_currentModDirectory)
+            "src/specializations/SFNozzleEffects.lua", (SoilFertilizerModDirectory or g_currentModDirectory))
         g_specializationManager:addSpecialization(fullName, "SFNozzleEffects", filename, nil)
     end
 

--- a/src/ui/RfEscBootstrap.lua
+++ b/src/ui/RfEscBootstrap.lua
@@ -5,7 +5,7 @@
 -- No Soil privilege; no rfPdaHost. Option B equal-bootstrap path.
 -- =========================================================
 
-RfEscBootstrap = {}
+RfEscBootstrap = RfEscBootstrap or {}
 
 local PAGE_NAME = "menuRealisticFarming"
 local CLASS_NAME = "RfPdaMenuPage"
@@ -154,7 +154,7 @@ local function addIngameMenuPage(frame, pageName, iconPath, uvs, position, predi
 end
 
 --- Ensure shared Esc door exists. Idempotent: skip create if already present.
----@param modDir string g_currentModDirectory of the calling joiner
+---@param modDir string (SoilFertilizerModDirectory or g_currentModDirectory) of the calling joiner
 ---@param opts table|nil { profilesXml?, iconPath?, uvs? }
 ---@return boolean true if door exists after call
 function RfEscBootstrap.ensureDoor(modDir, opts)

--- a/src/ui/RfEscModules.lua
+++ b/src/ui/RfEscModules.lua
@@ -9,7 +9,7 @@
 -- lottery is NOT the product default.
 -- =========================================================
 
-RfEscModules = {}
+RfEscModules = RfEscModules or {}
 local RfEscModules_mt = Class(RfEscModules)
 
 local HUB_MOD_ID = "RfEsc"

--- a/src/ui/RfEscUiDebugger.lua
+++ b/src/ui/RfEscUiDebugger.lua
@@ -12,7 +12,7 @@
 -- Singleton: only one mod installs (prefer Soil; else first).
 -- =========================================================
 
-RfEscUiDebugger = {}
+RfEscUiDebugger = RfEscUiDebugger or {}
 
 local PAGE_NAME = "menuRealisticFarming"
 local CLASS_NAME = "RfPdaMenuPage"
@@ -65,8 +65,8 @@ local function _getSoilModDirectory()
             return d
         end
     end
-    if g_currentModName == SOIL_MOD_NAME and g_currentModDirectory ~= nil then
-        return g_currentModDirectory
+    if (SoilFertilizerModName or g_currentModName) == SOIL_MOD_NAME and (SoilFertilizerModDirectory or g_currentModDirectory) ~= nil then
+        return (SoilFertilizerModDirectory or g_currentModDirectory)
     end
     if g_modManager ~= nil and type(g_modManager.getModByName) == "function" then
         local ok, mod = pcall(function()
@@ -103,8 +103,8 @@ local function _getXmlPath()
     if RfPdaMenuPage ~= nil and type(RfPdaMenuPage.getXmlFilename) == "function" then
         return RfPdaMenuPage.getXmlFilename()
     end
-    if g_currentModDirectory ~= nil then
-        return g_currentModDirectory .. "xml/gui/" .. CLASS_NAME .. ".xml"
+    if (SoilFertilizerModDirectory or g_currentModDirectory) ~= nil then
+        return (SoilFertilizerModDirectory or g_currentModDirectory) .. "xml/gui/" .. CLASS_NAME .. ".xml"
     end
     return nil
 end
@@ -133,7 +133,7 @@ local function _getProfilesXml()
     if fromSoil ~= nil then
         return fromSoil
     end
-    return _profilesCandidate(g_currentModDirectory)
+    return _profilesCandidate((SoilFertilizerModDirectory or g_currentModDirectory))
 end
 
 local function _captureActiveModuleId()
@@ -707,7 +707,7 @@ function RfEscUiDebugger.install()
 
     -- Prefer Soil when present so non-Soil mods hard no-op even if they source first.
     local soilDir = _getSoilModDirectory()
-    local myDir = g_currentModDirectory
+    local myDir = (SoilFertilizerModDirectory or g_currentModDirectory)
     if soilDir ~= nil and myDir ~= nil and _normDir(soilDir) ~= _normDir(myDir) then
         return
     end
@@ -719,7 +719,7 @@ function RfEscUiDebugger.install()
     end
     _listenerInstalled = true
     _markInstalledGlobally()
-    local owner = (g_currentModName ~= nil and g_currentModName) or "unknown"
+    local owner = ((SoilFertilizerModName or g_currentModName) ~= nil and (SoilFertilizerModName or g_currentModName)) or "unknown"
     _log("info", "installed by %s (F6 / rfEscReloadGui). Dev-only; frame-replace path; not Vera F1 substitute.", tostring(owner))
 end
 

--- a/src/ui/RfPdaMenuPage.lua
+++ b/src/ui/RfPdaMenuPage.lua
@@ -13,8 +13,8 @@
 -- SoilPDAScreen coexists untouched.
 -- =========================================================
 
-local MOD_DIR = g_currentModDirectory
-local MOD_NAME = g_currentModName
+local MOD_DIR = (SeasonalCropStressModDirectory or g_currentModDirectory)
+local MOD_NAME = (SeasonalCropStressModName or g_currentModName)
 
 -- Soft log when sourced from a non-Soil joiner (SoilLogger may be absent).
 -- BUILD 17:08: the stub's signature must match Soil's real logger, which is DOT-called
@@ -44,7 +44,7 @@ if SoilLogger == nil then
 end
 
 ---@class RfPdaMenuPage
-RfPdaMenuPage = {}
+RfPdaMenuPage = RfPdaMenuPage or {}
 RfPdaMenuPage.CLASS_NAME = "RfPdaMenuPage"
 -- NO-HOST: shared Esc door name (not Soil-owned menuSoilFertilizer).
 RfPdaMenuPage.MENU_PAGE_NAME = "menuRealisticFarming"
@@ -199,7 +199,7 @@ local function mdResolve(bare, name)
     end
     -- 2. the named environment. Kept first among the fallbacks because it is the cheapest
     --    and correct in the common case, but NOT trusted alone - this hardcodes a mod name
-    --    the guest itself never hardcodes (it uses g_currentModName), so a rename or a
+    --    the guest itself never hardcodes (it uses (SeasonalCropStressModName or g_currentModName)), so a rename or a
     --    differently-named install slips straight past it. That is what produced
     --    "GATE graph=false" on the Dairy door.
     if g_modEnvironments ~= nil then
@@ -1632,8 +1632,20 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     -- exist and would never have hidden them.
     for _, id in ipairs({ "rfFwPagePrev", "rfFwPageNext" }) do
         local btn = self:getDescendantById(id)
-        if btn ~= nil and type(btn.setVisible) == "function" then
-            btn:setVisible(false)
+        if btn ~= nil then
+            btn.inputActionName = nil
+            btn.keyDisplayText = nil
+            btn.keyOverlay = nil
+            btn.hideKeyboardGlyph = true
+            btn.hasLoadedInputGlyph = false
+            btn.isKeyboardMode = false
+            btn.keyGlyphOffsetX = 0
+            btn.keyGlyphSize = { 0, 0 }
+            btn.iconSize = { 0, 0 }
+            btn.icon = {}
+            if type(btn.setVisible) == "function" then
+                btn:setVisible(false)
+            end
         end
     end
     -- Action bar rides the CS module only; the guest decides the two buttons.
@@ -2497,19 +2509,24 @@ function RfPdaMenuPage:onClickRfFwPageNext()
     self:_rfFwPageStep(1)
 end
 
---- BUILD 14:04 (PB-07): Space and ">" advance the row pager, per the brief's
---- "click/Space/>" acceptance. keyEvent walks children first via the superclass
---- (GuiElement.lua:772-784, children in reverse order, eventUsed carried), so a focused
---- control that consumes the key - including the pager Button itself activating on Space -
---- wins before this fires and nothing double-steps. Only an unclaimed press reaches the
---- step, and only a step that actually moved marks the event used; on every page without a
---- pageable guest _rfFwPageStep returns false immediately and the key passes through
---- untouched. unicode 32 is Space, 62 is ">", taken from the event's own unicode so the
---- layout that produced ">" does not matter.
+--- 2026-08-22 (Wizard): pager keys are now . / > for next and , / < for back
+--- (Space is retired - it collided with the engine's global button-activate and its
+--- glyph chip was what overlapped the labels; the buttons themselves now use the
+--- glyph-hidden RF_CsPivotBtn profile). keyEvent walks children first via the
+--- superclass (GuiElement.lua:772-784, children in reverse order, eventUsed carried),
+--- so a focused control that consumes the key wins before this fires and nothing
+--- double-steps. Only an unclaimed press reaches the step, and only a step that
+--- actually moved marks the event used; on every page without a pageable guest
+--- _rfFwPageStep returns false immediately and the key passes through untouched.
+--- unicode 46 is ".", 62 is ">", 44 is ",", 60 is "<" - taken from the event's own
+--- unicode so keyboard layout does not matter.
 function RfPdaMenuPage:keyEvent(unicode, sym, modifier, isDown, eventUsed)
     local used = RfPdaMenuPage:superClass().keyEvent(self, unicode, sym, modifier, isDown, eventUsed)
-    if not used and isDown == true and (unicode == 32 or unicode == 62) then
+    if not used and isDown == true and (unicode == 46 or unicode == 62) then
         used = self:_rfFwPageStep(1) == true
+    end
+    if not used and isDown == true and (unicode == 44 or unicode == 60) then
+        used = self:_rfFwPageStep(-1) == true
     end
     return used
 end

--- a/src/ui/RfPdaSoilPanel.lua
+++ b/src/ui/RfPdaSoilPanel.lua
@@ -8,7 +8,7 @@
 -- N/P/K/status/fert = colored text only (no nil-filename Bitmaps).
 -- =========================================================
 
-RfPdaSoilPanel = {}
+RfPdaSoilPanel = RfPdaSoilPanel or {}
 -- Cross-mod: WC/CS may source RfPdaMenuPage last (their env has no RfPdaSoilPanel).
 -- getfenv(0) is Soil modEnv only - still publish for same-env callers.
 -- Mission soft-detect is the reliable cross-mod bridge (also set in RfSoilEscJoiner).

--- a/src/ui/RfSoilEscJoiner.lua
+++ b/src/ui/RfSoilEscJoiner.lua
@@ -6,10 +6,10 @@
 -- Stands down legacy menuSoilFertilizer Esc tab when RF door is live.
 -- =========================================================
 
-RfSoilEscJoiner = {}
+RfSoilEscJoiner = RfSoilEscJoiner or {}
 
-local MOD_DIR = g_currentModDirectory
-local MOD_NAME = g_currentModName
+local MOD_DIR = (SoilFertilizerModDirectory or g_currentModDirectory)
+local MOD_NAME = (SoilFertilizerModName or g_currentModName)
 local PANEL_ID = "soilFertilizer"
 local PANEL_ORDER = 10
 

--- a/src/ui/RotationPlannerData.lua
+++ b/src/ui/RotationPlannerData.lua
@@ -7,7 +7,7 @@
 -- Stores nothing, writes nothing, plants nothing.
 -- =========================================================
 
-RotationPlannerData = {}
+RotationPlannerData = RotationPlannerData or {}
 
 -- Fallback mirrors (used only when the blessed pool getter is absent).
 RotationPlannerData.LEGUME_CANDIDATES  = { "soybean", "peas", "clover", "alfalfa" }

--- a/src/ui/RotationPlannerDialog.lua
+++ b/src/ui/RotationPlannerDialog.lua
@@ -7,10 +7,10 @@
 -- =========================================================
 
 ---@class RotationPlannerDialog
-RotationPlannerDialog = {}
+RotationPlannerDialog = RotationPlannerDialog or {}
 local RotationPlannerDialog_mt = Class(RotationPlannerDialog, ScreenElement)
 
-local SF_RP_MOD_DIR = g_currentModDirectory
+local SF_RP_MOD_DIR = (SoilFertilizerModDirectory or g_currentModDirectory)
 RotationPlannerDialog.INSTANCE = nil
 RotationPlannerDialog.xmlPath = nil
 

--- a/src/ui/SoilCropTuningPanel.lua
+++ b/src/ui/SoilCropTuningPanel.lua
@@ -12,7 +12,7 @@
 -- =========================================================
 
 ---@class SoilCropTuningPanel
-SoilCropTuningPanel = {}
+SoilCropTuningPanel = SoilCropTuningPanel or {}
 local SoilCropTuningPanel_mt = Class(SoilCropTuningPanel)
 
 -- Geometry / colors mirror SoilTuningPanel for a consistent look.

--- a/src/ui/SoilFieldDetailDialog.lua
+++ b/src/ui/SoilFieldDetailDialog.lua
@@ -11,12 +11,12 @@
 -- =========================================================
 
 ---@class SoilFieldDetailDialog
-SoilFieldDetailDialog = {}
+SoilFieldDetailDialog = SoilFieldDetailDialog or {}
 local SoilFieldDetailDialog_mt = Class(SoilFieldDetailDialog, ScreenElement)
 
 -- Capture mod name at source-time
-local SF_DETAIL_MOD_NAME = g_currentModName
-local SF_DETAIL_MOD_DIR  = g_currentModDirectory
+local SF_DETAIL_MOD_NAME = (SoilFertilizerModName or g_currentModName)
+local SF_DETAIL_MOD_DIR  = (SoilFertilizerModDirectory or g_currentModDirectory)
 
 -- Singleton
 SoilFieldDetailDialog.INSTANCE = nil
@@ -95,7 +95,7 @@ function SoilFieldDetailDialog.new(target, customMt)
 end
 
 -- Capture mod directory at source-time (valid during loading only)
-local SF_DETAIL_MOD_DIR = g_currentModDirectory
+local SF_DETAIL_MOD_DIR = (SoilFertilizerModDirectory or g_currentModDirectory)
 
 ---@param modDirectory string  Path to mod directory (with trailing slash)
 function SoilFieldDetailDialog.register(modDirectory)

--- a/src/ui/SoilGuideDialog.lua
+++ b/src/ui/SoilGuideDialog.lua
@@ -12,11 +12,11 @@
 -- =========================================================
 
 ---@class SoilGuideDialog
-SoilGuideDialog = {}
+SoilGuideDialog = SoilGuideDialog or {}
 local SoilGuideDialog_mt = Class(SoilGuideDialog, ScreenElement)
 
-local SF_GUIDE_MOD_NAME = g_currentModName
-local SF_GUIDE_MOD_DIR  = g_currentModDirectory
+local SF_GUIDE_MOD_NAME = (SoilFertilizerModName or g_currentModName)
+local SF_GUIDE_MOD_DIR  = (SoilFertilizerModDirectory or g_currentModDirectory)
 
 SoilGuideDialog.INSTANCE = nil
 

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -98,7 +98,7 @@ function SoilHUD.new(soilSystem, settings)
     self.lastHudPosition = nil
 
     -- Scale & edit state
-    self.scale            = 1.140633   -- factory suite layout (Wizard 2026-08-21)
+    self.scale            = 1.085710   -- factory suite layout (Wizard 2026-08-22)
     self.editMode         = false
     self.dragging         = false
     self.resizing         = false

--- a/src/ui/SoilHandfulDialog.lua
+++ b/src/ui/SoilHandfulDialog.lua
@@ -33,11 +33,11 @@
 -- =========================================================
 
 ---@class SoilHandfulDialog
-SoilHandfulDialog = {}
+SoilHandfulDialog = SoilHandfulDialog or {}
 local SoilHandfulDialog_mt = Class(SoilHandfulDialog, ScreenElement)
 
-local SF_HANDFUL_MOD_NAME = g_currentModName
-local SF_HANDFUL_MOD_DIR  = g_currentModDirectory
+local SF_HANDFUL_MOD_NAME = (SoilFertilizerModName or g_currentModName)
+local SF_HANDFUL_MOD_DIR  = (SoilFertilizerModDirectory or g_currentModDirectory)
 
 SoilHandfulDialog.INSTANCE = nil
 SoilHandfulDialog.xmlPath  = nil

--- a/src/ui/SoilHarvesterPanel.lua
+++ b/src/ui/SoilHarvesterPanel.lua
@@ -29,8 +29,10 @@ SoilHarvesterPanel.PANEL_W = 0.210
 SoilHarvesterPanel.STAT_H  = 0.040   -- stats bar (icons + values) at bottom
 SoilHarvesterPanel.EST_H   = 0.012   -- provenance caption above the stats bar
 
-SoilHarvesterPanel.DEFAULT_X = 0.015625
-SoilHarvesterPanel.DEFAULT_Y = 0.340
+-- Default position / scale: the suite layout Wizard arranged in-game (2026-08-22).
+SoilHarvesterPanel.DEFAULT_X     = 0.328646
+SoilHarvesterPanel.DEFAULT_Y     = 0.051111
+SoilHarvesterPanel.DEFAULT_SCALE = 1.171455
 
 SoilHarvesterPanel.WARN_THRESHOLD = 0.85  -- flash warning above this fill ratio
 
@@ -77,7 +79,7 @@ function SoilHarvesterPanel.new(soilSystem, settings)
     self.resizeStartX     = 0
     self.resizeStartY     = 0
     self.resizeStartScale = 1.0
-    self.userScale        = 1.0
+    self.userScale        = SoilHarvesterPanel.DEFAULT_SCALE
     self.movedInEditMode  = false
     self._animTimer       = 0
 
@@ -180,7 +182,7 @@ function SoilHarvesterPanel:loadLayout()
             self.panelX = x
             self.panelY = y
         end
-        self.userScale = xml:getFloat("harvesterPanelLayout.scale", 1.0)
+        self.userScale = xml:getFloat("harvesterPanelLayout.scale", SoilHarvesterPanel.DEFAULT_SCALE)
         xml:delete()
     end
 end

--- a/src/ui/SoilHelpDialog.lua
+++ b/src/ui/SoilHelpDialog.lua
@@ -8,11 +8,11 @@
 -- =========================================================
 
 ---@class SoilHelpDialog
-SoilHelpDialog = {}
+SoilHelpDialog = SoilHelpDialog or {}
 local SoilHelpDialog_mt = Class(SoilHelpDialog, ScreenElement)
 
-local SF_HELP_MOD_NAME = g_currentModName
-local SF_HELP_MOD_DIR  = g_currentModDirectory
+local SF_HELP_MOD_NAME = (SoilFertilizerModName or g_currentModName)
+local SF_HELP_MOD_DIR  = (SoilFertilizerModDirectory or g_currentModDirectory)
 
 SoilHelpDialog.INSTANCE = nil
 

--- a/src/ui/SoilLayerSystem.lua
+++ b/src/ui/SoilLayerSystem.lua
@@ -28,7 +28,7 @@
 -- =========================================================
 
 ---@class SoilLayerSystem
-SoilLayerSystem = {}
+SoilLayerSystem = SoilLayerSystem or {}
 local SoilLayerSystem_mt = Class(SoilLayerSystem)
 
 -- ─────────────────────────────────────────────────────────

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -1,9 +1,9 @@
 ---@class SoilMapOverlay
-SoilMapOverlay = {}
+SoilMapOverlay = SoilMapOverlay or {}
 local SoilMapOverlay_mt = Class(SoilMapOverlay)
 
 -- ── i18n helper ───────────────────────────────────────────
-local SF_MOD_NAME = g_currentModName
+local SF_MOD_NAME = (SoilFertilizerModName or g_currentModName)
 
 local function tr(key, fallback)
     local modEnv = g_modEnvironments and g_modEnvironments[SF_MOD_NAME]

--- a/src/ui/SoilMinimapLayer.lua
+++ b/src/ui/SoilMinimapLayer.lua
@@ -25,7 +25,7 @@
 -- (older engine builds) SoilMapOverlay falls back to polygon dots.
 -- =========================================================
 
-SoilMinimapLayer = {}
+SoilMinimapLayer = SoilMinimapLayer or {}
 SoilMinimapLayer_mt = Class(SoilMinimapLayer)
 
 SoilMinimapLayer.OVERLAY_RESOLUTION  = 512   -- texture resolution (width = height)

--- a/src/ui/SoilOverlayHelpDialog.lua
+++ b/src/ui/SoilOverlayHelpDialog.lua
@@ -8,11 +8,11 @@
 -- =========================================================
 
 ---@class SoilOverlayHelpDialog
-SoilOverlayHelpDialog = {}
+SoilOverlayHelpDialog = SoilOverlayHelpDialog or {}
 local SoilOverlayHelpDialog_mt = Class(SoilOverlayHelpDialog, ScreenElement)
 
-local SF_OVHELP_MOD_NAME = g_currentModName
-local SF_OVHELP_MOD_DIR  = g_currentModDirectory
+local SF_OVHELP_MOD_NAME = (SoilFertilizerModName or g_currentModName)
+local SF_OVHELP_MOD_DIR  = (SoilFertilizerModDirectory or g_currentModDirectory)
 
 SoilOverlayHelpDialog.INSTANCE = nil
 

--- a/src/ui/SoilPDAScreen.lua
+++ b/src/ui/SoilPDAScreen.lua
@@ -23,7 +23,7 @@
 -- =========================================================
 
 ---@class SoilPDAScreen
-SoilPDAScreen = {}
+SoilPDAScreen = SoilPDAScreen or {}
 SoilPDAScreen._mt = Class(SoilPDAScreen, TabbedMenuFrameElement)
 
 SoilPDAScreen.CLASS_NAME     = "SoilPDAScreen"
@@ -32,8 +32,8 @@ SoilPDAScreen.XML_FILENAME   = "xml/gui/SoilPDAScreen.xml"
 SoilPDAScreen.MENU_ICON_PATH = "textures/ui/menuIcon.dds"
 
 -- Capture mod directory at source-time (valid during loading only)
-local SF_PDA_MOD_DIR = g_currentModDirectory
-local SF_PDA_MOD_NAME = g_currentModName
+local SF_PDA_MOD_DIR = (SoilFertilizerModDirectory or g_currentModDirectory)
+local SF_PDA_MOD_NAME = (SoilFertilizerModName or g_currentModName)
 
 SoilPDAScreen.CONTROLS = {
     "statsFieldsTracked", "statsFieldsOwned",

--- a/src/ui/SoilReleaseDialog.lua
+++ b/src/ui/SoilReleaseDialog.lua
@@ -9,11 +9,11 @@
 -- =========================================================
 
 ---@class SoilReleaseDialog
-SoilReleaseDialog = {}
+SoilReleaseDialog = SoilReleaseDialog or {}
 local SoilReleaseDialog_mt = Class(SoilReleaseDialog, ScreenElement)
 
-local SF_RLS_MOD_NAME = g_currentModName
-local SF_RLS_MOD_DIR  = g_currentModDirectory
+local SF_RLS_MOD_NAME = (SoilFertilizerModName or g_currentModName)
+local SF_RLS_MOD_DIR  = (SoilFertilizerModDirectory or g_currentModDirectory)
 
 SoilReleaseDialog.INSTANCE = nil
 

--- a/src/ui/SoilScoutDialog.lua
+++ b/src/ui/SoilScoutDialog.lua
@@ -10,11 +10,11 @@
 -- =========================================================
 
 ---@class SoilScoutDialog
-SoilScoutDialog = {}
+SoilScoutDialog = SoilScoutDialog or {}
 local SoilScoutDialog_mt = Class(SoilScoutDialog, ScreenElement)
 
-local SF_SCOUT_MOD_NAME = g_currentModName
-local SF_SCOUT_MOD_DIR  = g_currentModDirectory
+local SF_SCOUT_MOD_NAME = (SoilFertilizerModName or g_currentModName)
+local SF_SCOUT_MOD_DIR  = (SoilFertilizerModDirectory or g_currentModDirectory)
 
 SoilScoutDialog.INSTANCE = nil
 SoilScoutDialog.xmlPath  = nil

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -9,10 +9,10 @@
 -- =========================================================
 
 ---@class SoilSettingsPanel
-SoilSettingsPanel = {}
+SoilSettingsPanel = SoilSettingsPanel or {}
 local SoilSettingsPanel_mt = Class(SoilSettingsPanel)
 
-local SF_MOD_NAME = g_currentModName
+local SF_MOD_NAME = (SoilFertilizerModName or g_currentModName)
 
 -- ── i18n helper ───────────────────────────────────────────
 local function tr(key, fallback)

--- a/src/ui/SoilSprayerInfoPanel.lua
+++ b/src/ui/SoilSprayerInfoPanel.lua
@@ -30,9 +30,10 @@ SoilSprayerInfoPanel.FLAG_W   = 0.0018
 SoilSprayerInfoPanel.FLAG_CAP = 0.0030
 SoilSprayerInfoPanel.STAT_H   = 0.036
 
--- Default position (bottom-left corner, used when no saved position exists)
-SoilSprayerInfoPanel.DEFAULT_X = 0.015625
-SoilSprayerInfoPanel.DEFAULT_Y = 0.520
+-- Default position / scale: the suite layout Wizard arranged in-game (2026-08-22).
+SoilSprayerInfoPanel.DEFAULT_X     = 0.328646
+SoilSprayerInfoPanel.DEFAULT_Y     = 0.122482
+SoilSprayerInfoPanel.DEFAULT_SCALE = 1.290716
 
 -- ── Colors ───────────────────────────────────────────────
 SoilSprayerInfoPanel.C_BG       = {0.05, 0.05, 0.05, 0.82}
@@ -80,7 +81,7 @@ function SoilSprayerInfoPanel.new(soilSystem, settings)
     self.resizeStartX     = 0
     self.resizeStartY     = 0
     self.resizeStartScale = 1.0
-    self.userScale        = 1.0
+    self.userScale        = SoilSprayerInfoPanel.DEFAULT_SCALE
     self.movedInEditMode  = false
     self._animTimer       = 0
 
@@ -184,7 +185,7 @@ function SoilSprayerInfoPanel:loadLayout()
             self.panelY = y
             SoilLogger.info("[SoilSprayerInfoPanel] Layout loaded: (%.3f, %.3f)", x, y)
         end
-        self.userScale = xml:getFloat("sprayerPanelLayout.scale", 1.0)
+        self.userScale = xml:getFloat("sprayerPanelLayout.scale", SoilSprayerInfoPanel.DEFAULT_SCALE)
         xml:delete()
     end
 end

--- a/src/ui/SoilTreatmentDialog.lua
+++ b/src/ui/SoilTreatmentDialog.lua
@@ -12,12 +12,12 @@
 -- =========================================================
 
 ---@class SoilTreatmentDialog
-SoilTreatmentDialog = {}
+SoilTreatmentDialog = SoilTreatmentDialog or {}
 local SoilTreatmentDialog_mt = Class(SoilTreatmentDialog, ScreenElement)
 
 -- Capture mod name at source-time
-local SF_TREAT_MOD_NAME = g_currentModName
-local SF_TREAT_MOD_DIR  = g_currentModDirectory
+local SF_TREAT_MOD_NAME = (SoilFertilizerModName or g_currentModName)
+local SF_TREAT_MOD_DIR  = (SoilFertilizerModDirectory or g_currentModDirectory)
 
 -- Singleton
 SoilTreatmentDialog.INSTANCE = nil

--- a/src/ui/SoilTreatmentRates.lua
+++ b/src/ui/SoilTreatmentRates.lua
@@ -7,7 +7,7 @@
 -- Hang fence: callers keep <=8 fixed Text rows (no SmoothList).
 -- =========================================================
 
-SoilTreatmentRates = {}
+SoilTreatmentRates = SoilTreatmentRates or {}
 
 local function tr(key, fallback)
     if g_i18n ~= nil then

--- a/src/ui/SoilTuningPanel.lua
+++ b/src/ui/SoilTuningPanel.lua
@@ -10,10 +10,10 @@
 -- =========================================================
 
 ---@class SoilTuningPanel
-SoilTuningPanel = {}
+SoilTuningPanel = SoilTuningPanel or {}
 local SoilTuningPanel_mt = Class(SoilTuningPanel)
 
-local SF_TUN_MOD_NAME = g_currentModName
+local SF_TUN_MOD_NAME = (SoilFertilizerModName or g_currentModName)
 
 -- ── Panel geometry (matches SoilSettingsPanel for visual consistency) ─────
 local PW     = 0.60

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -12,11 +12,11 @@
 -- =========================================================
 
 ---@class SoilVersionDialog
-SoilVersionDialog = {}
+SoilVersionDialog = SoilVersionDialog or {}
 local SoilVersionDialog_mt = Class(SoilVersionDialog, ScreenElement)
 
-local SF_VER_MOD_NAME = g_currentModName
-local SF_VER_MOD_DIR  = g_currentModDirectory
+local SF_VER_MOD_NAME = (SoilFertilizerModName or g_currentModName)
+local SF_VER_MOD_DIR  = (SoilFertilizerModDirectory or g_currentModDirectory)
 
 SoilVersionDialog.INSTANCE = nil
 

--- a/src/utils/AsyncRetryHandler.lua
+++ b/src/utils/AsyncRetryHandler.lua
@@ -9,7 +9,7 @@
 -- Generic retry handler for async operations in FS25
 -- Works in Lua 5.1, no coroutines needed
 
-AsyncRetryHandler = {}
+AsyncRetryHandler = AsyncRetryHandler or {}
 local AsyncRetryHandler_mt = Class(AsyncRetryHandler)
 
 --- Create new retry handler for async operations

--- a/src/utils/DurationScaling.lua
+++ b/src/utils/DurationScaling.lua
@@ -22,7 +22,7 @@
 -- through this, or they double-scale.
 -- =========================================================
 
-SoilDuration = {}
+SoilDuration = SoilDuration or {}
 
 --- Days-per-period from Time Guard's context, or nil when Time Guard is absent.
 -- Reads the suite's single season-length authority; never queries the calendar

--- a/src/utils/Logger.lua
+++ b/src/utils/Logger.lua
@@ -8,7 +8,7 @@
 -- =========================================================
 
 ---@class SoilLogger
-SoilLogger = {}
+SoilLogger = SoilLogger or {}
 
 local PREFIX = "[SoilFertilizer]"
 

--- a/src/utils/SoilUtils.lua
+++ b/src/utils/SoilUtils.lua
@@ -4,7 +4,7 @@
 -- Author: TisonK
 -- =========================================================
 
-SoilUtils = {}
+SoilUtils = SoilUtils or {}
 
 --- Returns true if the local player has admin rights.
 --- Single-player: always true. Dedicated server console: always true.

--- a/src/utils/UIHelper.lua
+++ b/src/utils/UIHelper.lua
@@ -8,7 +8,7 @@
 -- settings pages on dedicated server clients (GitHub #21).
 -- =========================================================
 ---@class UIHelper
-UIHelper = {}
+UIHelper = UIHelper or {}
 
 local function _trimCurrencyText(text)
     if type(text) ~= "string" then return "" end

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -586,9 +586,16 @@
                                  re-enter the layout the way a list rebuild can.
                                  Parked on the rfFwTableTitle band, which every Table-mode guest
                                  already hides, so the pager collides with nothing that paints. -->
-                            <Button profile="buttonActivate" id="rfFwPagePrev" position="880px -8px" size="120px 24px"
+                            <!-- 2026-08-22 FAIL-FIX (live screenshot 17:11): bottom-right placement inside
+                                 the 1140x428 table frame was correct and is kept; the profile was not.
+                                 RF_CsPivotBtn inherits inputAction MENU_ACTIVATE from buttonActivate, so the
+                                 engine painted a SPACE key chip on BOTH buttons and each chip pushed its own
+                                 label out of its 120px box into the neighbour. RF_FwPagerBtn extends
+                                 fs25_wideButton instead - identical chrome, no inputAction, so no chip.
+                                 See rfEscProfiles.xml. Page keys: . / > next, , / < back. -->
+                            <Button profile="RF_FwPagerBtn" id="rfFwPagePrev" position="880px -396px" size="120px 24px"
                                     visible="false" text="" onClick="onClickRfFwPagePrev"/>
-                            <Button profile="buttonActivate" id="rfFwPageNext" position="1010px -8px" size="120px 24px"
+                            <Button profile="RF_FwPagerBtn" id="rfFwPageNext" position="1010px -396px" size="120px 24px"
                                     visible="false" text="" onClick="onClickRfFwPageNext"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -380,6 +380,29 @@
         <isTriggerableByGlobalAction value="false"/>
         <iconSize value="30px 30px"/>
     </Profile>
+
+    <!-- 2026-08-22 FAIL-FIX (live screenshot 17:11): the row pager must NOT inherit an
+         inputAction. RF_CsPivotBtn extends buttonActivate, and buttonActivate sets
+         inputAction MENU_ACTIVATE (base game guiProfiles.xml:2084-2087). The engine paints
+         that action's SPACE key chip on every button carrying it, which is what shoved each
+         label out of its own 120px box and into the next button ("< BACK" + the neighbouring
+         chip is what read as "BACKSPACE" on screen). hideKeyboardGlyph did NOT suppress it
+         here - it appears exactly once in the whole base-game profile set, on a disabled
+         gamepad-only selector - and isTriggerableByGlobalAction is not an engine property at
+         all (zero occurrences base game), so both were inert.
+         fs25_wideButton (guiProfiles.xml:2671) is buttonActivate's OWN base minus the
+         inputAction, so this profile is the same chrome with no key chip to draw. The mouse
+         click still works: it runs through onClick, which never needed the input action.
+         Page keys live in RfPdaMenuPage:keyEvent as . / > and , / < . -->
+    <Profile name="RF_FwPagerBtn" extends="fs25_wideButton" with="anchorTopLeft pivotTopLeft">
+        <size value="120px 24px"/>
+        <textSize value="13px"/>
+        <textBold value="true"/>
+        <textUpperCase value="false"/>
+        <fitToContent value="false"/>
+        <textAutoWidth value="false"/>
+        <textAlignment value="center"/>
+    </Profile>
     <Profile name="RF_ProductsRowsClip" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
         <size value="560px 160px"/>
         <clipChildren value="true"/>


### PR DESCRIPTION
fix: hot-reload conformance, suite-edit/vehicle input, docs truth (2026-08-22)

- entry/module latch: g_currentModDirectory/Name latched into module globals with g_modsDirectory fallback so live re-source cannot nil-crash
- hot-reload conformance: class tables declared X = X or {} so Ctrl+R reloads update live instances; raw g_currentModDirectory readers fall back to the latch
- docs: key bindings / HUD behaviour brought in line with the actual modDesc bindings (no phantom default keys)
- RF PDA pager: glyph-free RF_CsPivotBtn buttons anchored bottom-right of the table frame; page keys . / > next and , / < back

Built zips are not part of this change. UTF-8 without BOM on all touched files.