### PR TITLE
fix(burn): sample amendment/scorch crop gate at the boom point (#842)

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -5426,7 +5426,11 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
             if fsField and fsField.posX and fsField.posZ then
                 local ok, fs = pcall(function()
                     local s = FieldState.new()
-                    s:update(fsField.posX, fsField.posZ)
+                    -- Sample at the boom point (#842), not the field's stored reference
+                    -- point: on a part-harvested field the reference cell can read crop
+                    -- while the boom is over stubble (or the reverse), firing the wrong
+                    -- burn verdict. Read the ground actually under the applicator.
+                    s:update(spx, spz)
                     return s
                 end)
                 if ok and fs and fs.fruitTypeIndex ~= nil and fs.fruitTypeIndex ~= FruitType.UNKNOWN then
@@ -6670,7 +6674,10 @@ function SoilFertilitySystem:applyScorchEffect(fieldId, fillTypeName)
         if fsField and fsField.posX and fsField.posZ then
             local ok, fs = pcall(function()
                 local s2 = FieldState.new()
-                s2:update(fsField.posX, fsField.posZ)
+                -- Sample at the boom point (#842), not the field's stored reference
+                -- point, so a part-harvested field reads the crop actually under the
+                -- applicator (see the matching gate in applyFertilizer).
+                s2:update(spx, spz)
                 return s2
             end)
             if ok and fs and fs.fruitTypeIndex ~= nil and fs.fruitTypeIndex ~= FruitType.UNKNOWN then

--- a/tools/test/lua/scorch_cd14_test.lua
+++ b/tools/test/lua/scorch_cd14_test.lua
@@ -233,3 +233,25 @@ do
   T.ok("scorch: N docks toward but never below the floor",
        low.nitrogen >= SoilConstants.NUTRIENT_LIMITS.MIN)
 end
+
+-- ── #842: the crop gate samples under the BOOM, not the field reference ───────
+-- A part-harvested field: its stored reference cell (posX/posZ) can carry a crop
+-- the boom is nowhere near. The scorch/burn crop gate must read the ground under
+-- the applicator (_lastSprayX/_lastSprayZ), or it judges a crop that is not there.
+do
+  stubWorld(SULFUR_CERTAIN, WHEAT)
+  -- Put the field's stored reference point well away from the boom (100, 200).
+  g_fieldManager.farmlandIdFieldMapping = { [5] = { posX = 777, posZ = 888 } }
+  local sampledX, sampledZ
+  FieldState.new = function()
+    return {
+      update = function(_self, x, z) sampledX, sampledZ = x, z end,
+      fruitTypeIndex = WHEAT.fruitTypeIndex,
+      growthState    = WHEAT.growthState,
+    }
+  end
+  local sys = newSys({ pH = 7.0, nitrogen = 60 })   -- _lastSprayX=100, _lastSprayZ=200
+  at(0); sys:applyScorchEffect(1, "SULFUR")
+  T.eq("scorch: crop gate samples at the boom X (#842), not the field reference", sampledX, 100)
+  T.eq("scorch: crop gate samples at the boom Z (#842), not the field reference", sampledZ, 200)
+end


### PR DESCRIPTION
## What

Both the amendment-burn gate (`applyFertilizer`) and the heat-scorch gate (`applyScorchEffect`) resolved the standing crop by sampling `FieldState` at the field's **stored reference cell** (`fsField.posX/posZ`) instead of the **boom position** (`_lastSprayX/_lastSprayZ`), which is already in scope at both sites.

On a part-harvested field the reference cell can carry a crop the boom is nowhere near — or read stubble while the boom is over standing crop — firing the wrong burn/scorch verdict. This is the second, still-open half of #842 (part one, exempting cut/withered states, shipped in `e2416bed`).

## Fix

Sample at the boom point `(spx, spz)` in both gates, so the verdict reflects the ground actually under the applicator.

The two **field-centre** reads that are *meant* to be representative of the whole field are deliberately left on the reference point:
- `_getFieldGrowthFraction` (per-field growth-stage probe)
- `_sampleFieldWeedFactor` (its "Centre read" that gates a ring sample around the field centre)

## Verification

- `FieldState:update(x, z)` samples the fruit/ground density maps *at the passed world position* (decompiled `field/FieldState.lua:86`), so passing the boom point reads the crop under the boom.
- `scorch_cd14_test` extended: it now separates the field reference point (777/888) from the boom point (100/200) and asserts the gate samples at the boom point. **Fails on the old code** (`got 777 want 100`), passes on the fix.
- Full suite: **3062 assertions, 0 failed across 78 files.**

Gate: Sasha review → Tyson merge.