### PR TITLE
feat(soil): SF-22 farm-private walked-mask visibility

### DIFF
--- a/docs/playtest/LIME-ESC-PH-FINDINGS.md
+++ b/docs/playtest/LIME-ESC-PH-FINDINGS.md
@@ -1,0 +1,60 @@
+---
+title: "Pack 03 findings — what was wrong and what we fixed"
+owner: Wizard
+created: 2026-08-29
+audience: "Testers (plain English) + PR / ledger reviewers"
+---
+
+# What was wrong, and what we did
+
+This is the story of the Auto lime + Esc pH map polish wave in plain English. You do not need code to use it.
+
+## Player symptoms we were chasing
+
+1. **Esc pH map looked “one flat green”** even when the second pass over the same ground had actually raised pH again. Mid-pass and overlap looked the same.
+2. **Yellow / amber “teeth” or stripes** across a freshly limed strip (boom banding), so a single up-the-field pass did not look like one clean treatment.
+3. **Whole headland looked hot** (or nothing looked specially hot), instead of only the places where the headland **crosses** the up/down passes — the way a real double coverage would look.
+4. **Auto rate freezing or dropping** when you hired a helper and walked away (earlier in the wave; fixed before the final colour work).
+5. **Over-limed orange/red** appearing when we did not want normal needy liming to hit that band.
+6. **Colours too washed out** — pale greens that hid real variation under the Esc map blend.
+
+## Root causes (plain English)
+
+### A. Dose vs legend
+
+For a while the **numbers in the log were already right** (first touch ~6.3, re-hit ~6.6) but the **map colours** used coarse bands and a soft two-step gradient. Mid and overlap sat in colours that looked almost the same through Esc’s semi-transparent overlay. Turning the lime rate alone could not fix “I cannot see the difference.”
+
+### B. Accidental double paint inside one straight pass
+
+To kill yellow boom seams we had briefly painted more often (half a map-cell of travel between stamps). That made consecutive boom stamps **overlap themselves** on the way up the field. The same ground got a second full dose mid-pass. Logs showed alternating ~6.29 and ~6.60 **while still going straight**. After we improved the colours, those doubles showed up as **amber teeth on green**.
+
+### C. Soft ceiling too tight for real crossings
+
+A safety ceiling near ~6.6 meant any second hit — whether a bad mid-pass double or a real headland cross — stopped at the same tint. Once mid-pass was already full of false doubles, **true crossings could not look uniquely hotter**.
+
+### D. Wizard intent lock (final)
+
+Hot colour should appear **only where the headland pass crosses the up/down passes** (true double coverage). The whole headland must not glow end to end. Mid up/down must read as a **single** treatment. Optimal should be a **deeper green**, bad ends a **deeper red**, with **more colour stages** so real spreader variation shows.
+
+## What we changed (this playtest build)
+
+| Change | Why |
+|---|---|
+| Per-pass pH cap set so first pass lands below the “looks optimal” band and a real second hit can cross it | Mid stays visibly different from a true double without slamming Over-limed |
+| Soft ceiling raised enough that a genuine double (~6.7) can show, still under Over-limed | True crossings can read hotter than a single mid-pass |
+| Boom travel gate restored to **one full map cell** (removed the half-step self-overlap) | Stops mid-pass double stamps that caused amber teeth |
+| Continuous pH value→colour ramp + a **four-stop** deeper pH gradient on the Esc map (and matching legend) | Washed flat green → readable amber / green stages |
+| Auto rate kept live for helper / unseated play (earlier fixes in the same wave) | Helper liming still meters while you walk away |
+| Additive paint + ceiling clamp (no “fill to target” second pass that overshot) | Offered dose matches applied; no silent overshoot |
+
+## What Wizard already accepted
+
+On the workshop save, Wizard said the Esc map **looks perfect**. This pack asks other testers to confirm on their setups. If your map looks wrong, that is still a real report — say which job id and attach a screenshot.
+
+## What “PASS” should feel like
+
+- Straight limed lanes: **clean**, mostly one treatment colour (amber / early green for needy ground moving up) — **not** repeating amber zebra teeth.
+- Where headland **crosses** those lanes: **clearly hotter / deeper green** only in the crossing footprints.
+- Untreated acidic ground: deeper red / amber stages easy to tell apart.
+- No surprise Over-limed orange from a normal Auto pass on needy ground.
+- After **H** and walking away: Auto stays on and does not collapse below the needy floor while the field still needs lime.

--- a/docs/playtest/LIME-ESC-PH-PACK-README.md
+++ b/docs/playtest/LIME-ESC-PH-PACK-README.md
@@ -1,0 +1,74 @@
+---
+title: "Playtest Pack 03 — Soil Fertilizer lime / Esc pH map"
+owner: Wizard
+status: ISSUED
+created: 2026-08-29
+build: "Soil Fertilizer wizard/lime-esc-ph-playtest-20260829 (PR into development) — use the zip or loose folder from that PR, not an older pre"
+closes: "When Wizard calls the wave done or issues Pack 04"
+---
+
+# Playtest Pack 03 — Soil Fertilizer: Auto lime and Esc pH map
+
+Thank you for helping. This pack is **only** about liming with Auto rate and reading the result on the Esc soil pH map. You do not need to know how the mod is coded.
+
+## What this pack is checking
+
+We spent a long workshop session fixing Auto lime so that:
+
+- One straight pass of the spreader looks like a **single** treatment on the map (not striped “teeth”).
+- Where a **headland pass crosses** an up/down pass, that crossing looks **hotter** (double coverage), like real life — **not** the whole headland glowing end to end.
+- The Esc pH colours are **deeper and clearer** (stronger reds and greens, more steps), so real spreader variation is obvious.
+- Auto rate keeps working after you hire a helper and walk away.
+- The game does not paint “Over-limed” orange/red by mistake during normal needy liming.
+
+Wizard eyes-on on the workshop save already called the map **perfect**. Your job is to confirm that holds on **your** machine, map, and play style, and to catch anything we missed.
+
+## Two rounds
+
+| Round | File | Jobs | Focus |
+|---|---|---|---|
+| **1** | [ROUND-1.md](ROUND-1.md) | **P3-01 … P3-12** | Happy path: Auto lime, mid-pass clean, true crossings hotter, colours, helper |
+| **2** | [ROUND-2.md](ROUND-2.md) | **P3-13 … P3-24** | Edges: Precision Pack off/on, save/reload, MP if you can, empty tank, night, different boom |
+
+Do **Round 1 first**. Only start Round 2 if Round 1 is mostly PASS / PASS WITH NOTES.
+
+## Findings (please read once)
+
+[FINDINGS.md](FINDINGS.md) explains in plain English **what was wrong** and **what we changed**. Use it if a result looks odd — it tells you what we already know so you do not re-report closed issues as brand new.
+
+## Build to install
+
+1. Install the Soil Fertilizer build from the **lime Esc pH playtest PR** (branch `wizard/lime-esc-ph-playtest-20260829`) — zip or loose mods folder as your team usually does.
+2. Version on this wave is in the **2.5.0.x** line; confirm the PR description if unsure.
+3. Prefer a **copy** of a save you can afford to lime hard on (acidic / needy field).
+4. For Auto tests: use a lime spreader the mod supports, with Auto rate available.
+
+## How to report
+
+For each job, fill the result table:
+
+| Outcome | Means |
+|---|---|
+| **PASS** | Did what the job asks |
+| **PASS WITH NOTES** | Worked, but something felt off |
+| **FAIL** | Did not do what the job asks, or crashed |
+
+For anything that is not a PASS:
+
+1. Note the job id (for example `P3-04`).
+2. Say what you did, what you expected, what you saw.
+3. Screenshot the Esc **Soil Layers → pH** map when the problem is visual.
+4. Copy `Documents\My Games\FarmingSimulator2025\log.txt` **right after** the problem (the game overwrites it on next launch).
+5. Open or comment on a GitHub issue on Soil Fertilizer and paste that report.
+
+## Please do not re-report these as new bugs
+
+| Already known / accepted | Notes |
+|---|---|
+| Wizard workshop save already looked “perfect” on Esc pH after this build | Still useful if **your** map looks different |
+| Tiny offered vs applied differences of about one raw step | Quantisation; only fail if gaps are large or paint looks wrong |
+| Precision Farming active stands Soil Fertilizer down | Expected; Round 2 has a job for that |
+
+## Owner note (not for testers)
+
+Pack issued by Ash on Wizard ask 2026-08-29. Ledger + PR carry the engineering findings. Lime repair DESIGN 19:50 was superseded by Wizard eyes-on PASS; this pack is confirmation for the wider tester group.

--- a/docs/playtest/LIME-ESC-PH-ROUND-1.md
+++ b/docs/playtest/LIME-ESC-PH-ROUND-1.md
@@ -1,0 +1,334 @@
+---
+title: "Pack 03 Round 1 — twelve core jobs"
+owner: Wizard
+status: ISSUED
+created: 2026-08-29
+items: P3-01 … P3-12
+---
+
+# Round 1 — twelve core jobs
+
+Do these in order if you can. Each job is written for a player, not a programmer.
+
+**Before you start:** read [README.md](README.md) and skim [FINDINGS.md](FINDINGS.md). Install the playtest Soil Fertilizer build from the PR. Use a needy (acidic) field you can lime. Have a lime spreader ready. Esc → soil layers → **pH** is how you judge almost every visual job.
+
+---
+
+## P3-01 — Load and open the pH map
+
+**What you need:** The playtest build installed; any save with fields.
+
+**Steps**
+
+1. Start the game and load your test save.
+2. Confirm Soil Fertilizer is active (no Precision Farming taking over soil if you can help it for this round — Round 2 covers PF).
+3. Open Esc (or your usual map / soil layers route) and select the **pH** soil layer.
+4. Pan over untreated ground and over any already-worked ground.
+
+**Expect**
+
+- Map opens without a freeze or blank layer.
+- Untreated acidic ground looks clearly warmer (deeper red / amber) than healthier ground — colours should feel richer than “all pale green.”
+
+**Fail if**
+
+- Crash, blank map, or every field looks the same washed colour.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-02 — Turn Auto lime on and see it stick
+
+**What you need:** Lime spreader in cab; needy field.
+
+**Steps**
+
+1. Sit in the spreader on the field.
+2. Turn **Auto** rate on the way you normally do for Soil Fertilizer (same control you use in day-to-day play).
+3. Confirm the HUD / rate readout shows Auto is on (not stuck on a manual low gear).
+4. Drive a few metres spreading.
+
+**Expect**
+
+- Auto engages and stays on while you drive.
+- Rate does not instantly fall to “off” or an empty-looking zero while the field still needs lime.
+
+**Fail if**
+
+- Auto will not engage, or drops off as soon as you move.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-03 — First straight pass looks like one treatment
+
+**What you need:** Auto on; Esc pH map open (second screen or pause-check mid-pass is fine).
+
+**Steps**
+
+1. Lime a long **straight** up (or down) pass across needy ground. Avoid overlapping your own previous tracks for this job.
+2. Stop. Open Esc pH and look **only** at that strip.
+
+**Expect**
+
+- The strip reads as a **clean** band — mostly one treatment stage (often amber / early green on needy ground).
+- You should **not** see repeating horizontal amber/yellow “teeth” or zebra stripes across the boom width of that single pass.
+
+**Fail if**
+
+- Clear repeating teeth / zebra across the straight pass, or the strip looks randomly speckled hot and cold every boom width.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-04 — Mid-pass is not already “max hot”
+
+**What you need:** Same strip from P3-03 (or a new clean straight pass).
+
+**Steps**
+
+1. On Esc pH, compare the middle of that single pass to untouched ground beside it.
+2. Mentally note: mid-pass should look **treated but not finished** — not the hottest green on the field yet.
+
+**Expect**
+
+- Mid-pass is clearly improved vs untreated, but **not** the same deep hot green you would reserve for a true double coverage.
+
+**Fail if**
+
+- A single pass already looks maxed-out hot green everywhere along the strip (with no second pass yet).
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-05 — Headland crossing is hotter only at the cross
+
+**What you need:** At least one finished up/down strip; room to run a headland along the ends.
+
+**Steps**
+
+1. Run a **headland** pass that crosses the ends of your up/down strips (the way you would finish a field).
+2. Open Esc pH.
+3. Look carefully at (a) the crossing footprints, (b) the middle of the headland where it did **not** cross an up/down strip, (c) the mid straight passes.
+
+**Expect**
+
+- **Crossing footprints** look hotter / deeper green than the single mid-pass.
+- The rest of the headland that only got one pass should **not** glow hot end-to-end.
+- This matches real life: double coverage only where passes actually overlap.
+
+**Fail if**
+
+- Whole headland is uniformly hot, **or** crossings look no different from mid-pass, **or** mid-pass is already as hot as the crossings (so crossings cannot stand out).
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-06 — Helper stays liming after you walk away
+
+**What you need:** Helper / course hire you trust; Auto on.
+
+**Steps**
+
+1. With Auto on and product in the tank, start the helper on the needy field (**H** or your usual hire).
+2. Get out and walk away so you are not in the seat.
+3. Watch the helper continue for at least one full length of the field (or two minutes of active spreading).
+4. Glance at rate / Auto state when you can (HUD, or re-enter briefly).
+
+**Expect**
+
+- Helper keeps spreading.
+- Auto does not die the moment you leave the seat.
+- While the field is still needy, rate should not collapse below the needy floor you are used to (workshop used “never under about 0.60× while needy” as a guide).
+
+**Fail if**
+
+- Spreading stops for no tank reason, Auto clears on exit, or rate sits uselessly low while ground is still needy.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-07 — No false Over-limed on needy Auto work
+
+**What you need:** Esc pH; normal Auto liming on needy ground (not dumping for fun).
+
+**Steps**
+
+1. After one or two sensible passes (including a headland cross if you did P3-05), scan the worked area on Esc pH.
+2. Look for orange / red **Over-limed** style cells in the middle of normal work.
+
+**Expect**
+
+- Needy Auto liming should **not** paint Over-limed blotches across the strip.
+- Untreated very acidic ground can still look “bad” red — that is fine.
+
+**Fail if**
+
+- Large Over-limed patches appear from ordinary Auto passes on ground that still needed lime.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-08 — Colour stages are easy to tell apart
+
+**What you need:** A field with untreated + partly limed + crossed areas (after P3-03…P3-05).
+
+**Steps**
+
+1. On Esc pH, without zooming into numbers, judge by eye:
+   - untreated needy
+   - single-pass mid
+   - true crossing
+2. Also glance at the on-map legend / colour bar if shown.
+
+**Expect**
+
+- Those three stages are **obviously different** — deeper reds/ambers on the bad side, deeper greens toward good / double.
+- Not everything collapsed into one pale green.
+
+**Fail if**
+
+- You cannot tell single-pass from untreated, or single-pass from crossing, even when you know where you drove.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-09 — Second up/down lap beside the first (adjacent, not stacked)
+
+**What you need:** Room for a second straight pass **beside** the first (normal field pattern), not deliberately on top of it.
+
+**Steps**
+
+1. Lime the next bout beside the first, boom just kissing or with your normal overlap habit.
+2. Check Esc pH along both bouts and the thin join.
+
+**Expect**
+
+- Each bout still reads mostly as a single treatment in its centre.
+- Only the intentional boom overlap join may look a little hotter — that is normal physical overlap, not “teeth every few metres.”
+
+**Fail if**
+
+- Every bout is full of zebra teeth, or the whole pair cooks to max green after one pair of passes with no headland.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-10 — Tank empty behaviour is honest
+
+**What you need:** Nearly empty lime tank (or run until empty).
+
+**Steps**
+
+1. Keep Auto on and spread until the tank is empty mid-field.
+2. Watch HUD / spreading / map for a short moment after empty.
+
+**Expect**
+
+- Spreading stops or clearly shows empty — no silent “ghost liming” that keeps painting the map with no product.
+- Auto may stay armed, but the ground should not keep rising with an empty tank.
+
+**Fail if**
+
+- Map keeps improving with a confirmed empty tank, or the game hard-crashes on empty.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-11 — Pause / Esc map while helper runs
+
+**What you need:** Helper spreading; Esc pH.
+
+**Steps**
+
+1. With the helper liming, open Esc pH several times over a minute.
+2. Close Esc and confirm the helper is still working.
+
+**Expect**
+
+- Map updates in a believable way (new paint appears where the boom went).
+- Opening Esc does not permanently stall the helper or freeze the client.
+
+**Fail if**
+
+- Freeze/hang on Esc, or helper dead after closing the map.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-12 — Round 1 gut check (Wizard bar)
+
+**What you need:** Everything you have limed this session.
+
+**Steps**
+
+1. Stand back on Esc pH and ask: “Does this look like a real spreader job — clean passes, hotter only where I truly overlapped, colours I can read?”
+2. Write a short plain-English note either way.
+
+**Expect**
+
+- Same feeling Wizard had on the workshop save: map looks **right**.
+
+**Fail if**
+
+- You would not show this map to another farmer as “working as intended.”
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## Round 1 summary
+
+| Job | Result (PASS / NOTES / FAIL) | Issue link |
+|---|---|---|
+| P3-01 |  |  |
+| P3-02 |  |  |
+| P3-03 |  |  |
+| P3-04 |  |  |
+| P3-05 |  |  |
+| P3-06 |  |  |
+| P3-07 |  |  |
+| P3-08 |  |  |
+| P3-09 |  |  |
+| P3-10 |  |  |
+| P3-11 |  |  |
+| P3-12 |  |  |
+
+Tester name: _______________  
+Date: _______________  
+Save / map: _______________

--- a/docs/playtest/LIME-ESC-PH-ROUND-2.md
+++ b/docs/playtest/LIME-ESC-PH-ROUND-2.md
@@ -1,0 +1,296 @@
+---
+title: "Pack 03 Round 2 — twelve edge / regression jobs"
+owner: Wizard
+status: ISSUED
+created: 2026-08-29
+items: P3-13 … P3-24
+depends_on: "Finish Round 1 first unless Wizard says otherwise"
+---
+
+# Round 2 — twelve edge and regression jobs
+
+Only start this round when Round 1 is mostly clear. These jobs try to break the happy path.
+
+---
+
+## P3-13 — Save, quit to menu, reload
+
+**Steps**
+
+1. After a visible liming session (ideally with a crossing), save.
+2. Quit to the main menu (or fully exit the game once).
+3. Reload the same save.
+4. Open Esc pH and find the same field.
+
+**Expect**
+
+- Painted pH pattern is still there (not wiped blank, not randomly reshuffled).
+- Colours still readable.
+
+**Fail if**
+
+- Liming progress vanished, corrupted, or the map layer is gone.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-14 — Manual rate vs Auto on the same field
+
+**Steps**
+
+1. On a needy patch, run a short pass with Auto **off** at a fixed manual rate you choose.
+2. On a neighbouring needy patch, run Auto.
+3. Compare Esc pH behaviour and whether Auto still only “works while seated” (it should work either way for paint; Auto should meter).
+
+**Expect**
+
+- Both paint the map.
+- Auto still shows living rate changes; manual stays where you set it.
+
+**Fail if**
+
+- Manual paints but Auto does not (or the reverse) with no other explanation (empty tank, wrong product).
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-15 — Precision Farming present (stand-down)
+
+**Steps**
+
+1. If you can, enable Precision Farming with Soil Fertilizer still installed (or use a save that already has both).
+2. Check whether Soil Fertilizer soil / lime behaviour stands down as designed for your build.
+3. Note what the pH map / liming does.
+
+**Expect**
+
+- Document what happens honestly. Designed stand-down is a **PASS** if Soil Fertilizer clearly yields and does not fight PF.
+- If both fight and corrupt the map, that is a **FAIL**.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-16 — Multiplayer client eyes (if you have a partner)
+
+**Steps**
+
+1. Host or join with two players.
+2. One player liming with Auto; the other watches Esc pH (or the field).
+3. Confirm the watcher sees paint appear in a believable way.
+
+**Expect**
+
+- Client sees liming progress without needing a full relog for every metre.
+- No desync where host map is limed and client stays barren forever.
+
+**Fail if**
+
+- Permanent desync, or client crash on paint.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-17 — Dedicated server (if you use one)
+
+**Steps**
+
+1. Same liming routine on dedicated.
+2. Open Esc pH as a connecting client after some helper liming has happened.
+
+**Expect**
+
+- Join sees the field state without a long broken blank layer.
+- No server hitch that kicks everyone when Esc opens.
+
+**Fail if**
+
+- Join never receives soil paint, or server dies when someone opens pH.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-18 — Night / rain / poor visibility
+
+**Steps**
+
+1. Lime a short pass at night or in heavy rain.
+2. Check Esc pH (map lighting is separate from world lighting).
+
+**Expect**
+
+- Map colours still readable in the Esc UI.
+- Spreading still functions.
+
+**Fail if**
+
+- Esc pH unreadable black/blank only at night, or spreading broken only in rain with no other cause.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-19 — Different boom width
+
+**Steps**
+
+1. If you own two lime tools with clearly different working widths, repeat a short Auto straight pass with each.
+2. Compare Esc pH strip width and cleanliness.
+
+**Expect**
+
+- Wider boom paints a wider strip; both should stay free of zebra teeth on a single pass.
+
+**Fail if**
+
+- Only one width looks correct and the other is striped or over-hot mid-pass.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-20 — Deliberate triple overlap stress
+
+**Steps**
+
+1. On a small patch, drive over the **same** ground three times on purpose with Auto.
+2. Watch Esc pH and whether Over-limed appears.
+
+**Expect**
+
+- Ground gets hotter each sensible re-hit until the soft ceiling / Over-limed rules kick in.
+- Over-limed is allowed here if you truly stacked too much — say so in notes.
+- Should not explode into random checkerboards far off the path you drove.
+
+**Fail if**
+
+- Paint splatters far outside your tracks, or the game crashes.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-21 — Courseplay / Autodrive helper (if you use it)
+
+**Steps**
+
+1. Send a CP/AD job with Auto lime on a needy field.
+2. Watch one headland + one up/down in Esc pH afterward.
+
+**Expect**
+
+- Same visual rules as Round 1: clean mid, hotter true crosses.
+- Helper does not leave mysterious untreated stripes that match “teeth” from the old bug.
+
+**Fail if**
+
+- CP/AD uniquely reintroduces zebra teeth or kills Auto every time (with log attached).
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-22 — After refill mid-field
+
+**Steps**
+
+1. Empty or nearly empty mid-pass, refill at the shop/tank, return to the same strip.
+2. Continue Auto liming.
+3. Check Esc pH for a weird doubled scar only at the refill join.
+
+**Expect**
+
+- Work continues cleanly; join may be slightly hotter if you overlapped, but not a broken texture.
+
+**Fail if**
+
+- Huge hot rectangle at refill, or Auto dead after refill until a full restart.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-23 — Log sanity (optional but valuable)
+
+**Steps**
+
+1. Enable or watch whatever Soil debug / log lines your build prints for lime offered vs applied (workshop used paired raw numbers).
+2. During a clean straight pass, note whether offered and applied stay in step.
+
+**Expect**
+
+- No huge lasting gap (offered keeps climbing while applied never moves).
+- Tiny one-step differences can be normal — only fail big lies.
+
+**Fail if**
+
+- Persistent offered≫applied with no map change, or spam errors in `log.txt`.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## P3-24 — Round 2 ship call
+
+**Steps**
+
+1. After Round 1 + Round 2, answer: “Would you ship this lime + Esc pH behaviour to players this week?”
+2. List the top three remaining worries in plain English (or “none”).
+
+**Expect**
+
+- A clear yes / yes-with-notes / no, with reasons.
+
+| Result | Notes / link to issue |
+|---|---|
+|  |  |
+
+---
+
+## Round 2 summary
+
+| Job | Result (PASS / NOTES / FAIL) | Issue link |
+|---|---|---|
+| P3-13 |  |  |
+| P3-14 |  |  |
+| P3-15 |  |  |
+| P3-16 |  |  |
+| P3-17 |  |  |
+| P3-18 |  |  |
+| P3-19 |  |  |
+| P3-20 |  |  |
+| P3-21 |  |  |
+| P3-22 |  |  |
+| P3-23 |  |  |
+| P3-24 |  |  |
+
+Tester name: _______________  
+Date: _______________  
+Save / map: _______________  
+MP / dedicated used?: _______________

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -101,20 +101,38 @@
     <l10n filenamePrefix="translations/translation" />
 
     <inputBinding>
-        <actionBinding action="SF_RATE_UP" />
-        <actionBinding action="SF_RATE_DOWN" />
-        <actionBinding action="SF_TOGGLE_AUTO" />
-        <actionBinding action="SF_CYCLE_MAP_LAYER" />
-        <actionBinding action="SF_OPEN_SETTINGS" />
-        <actionBinding action="SF_VARIABLE_RATE" />
-        <actionBinding action="SF_MINIMAP_ZOOM" />
-        <actionBinding action="SF_SCOUT" />
-        <actionBinding action="SF_TREATMENT" />
-        <!-- API-6 (input convention): no ecosystem mod ships a default binding, so
-             the player assigns keys in the game's control settings and nothing
-             collides out of the box. All nine former defaults were removed; the
-             actions stay registered and rebindable. -->
-        <actionBinding action="SF_HANDFUL" />
+        <!-- In-cab sprayer/spreader (Right Shift + key, same family as HUD toggle/drag). -->
+        <actionBinding action="SF_RATE_UP">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_rightbracket" />
+        </actionBinding>
+        <actionBinding action="SF_RATE_DOWN">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_leftbracket" />
+        </actionBinding>
+        <actionBinding action="SF_TOGGLE_AUTO">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_l" />
+        </actionBinding>
+        <actionBinding action="SF_VARIABLE_RATE">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_v" />
+        </actionBinding>
+        <!-- On-foot / global Soil shortcuts (Right Shift + key). -->
+        <actionBinding action="SF_CYCLE_MAP_LAYER">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_m" />
+        </actionBinding>
+        <actionBinding action="SF_OPEN_SETTINGS">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_s" />
+        </actionBinding>
+        <actionBinding action="SF_SCOUT">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_k" />
+        </actionBinding>
+        <actionBinding action="SF_TREATMENT">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_t" />
+        </actionBinding>
+        <actionBinding action="SF_MINIMAP_ZOOM">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_period" />
+        </actionBinding>
+        <actionBinding action="SF_HANDFUL">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_comma" />
+        </actionBinding>
         <actionBinding action="SF_TOGGLE_HUD">
             <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_o" />
         </actionBinding>

--- a/src/HandfulRead.lua
+++ b/src/HandfulRead.lua
@@ -47,13 +47,16 @@ HandfulRead.CLAUSES = {
 -- =========================================================
 
 local function farmIdOf(ctx)
-    if ctx.farmId and ctx.farmId > 0 then return ctx.farmId end
-    if g_localPlayer and g_localPlayer.farmId and g_localPlayer.farmId > 0 then
+    -- [SF-22] Only an ordinary farm (1..8) may key knowledge. A spectator,
+    -- guided-tour, invalid or unresolved farm returns nil - never farm 1 - so a
+    -- non-farmer viewer composes nothing and the mask stays private.
+    if SpatialScouting.isOrdinaryFarmId(ctx.farmId) then return ctx.farmId end
+    if g_localPlayer and SpatialScouting.isOrdinaryFarmId(g_localPlayer.farmId) then
         return g_localPlayer.farmId
     end
     if g_currentMission and type(g_currentMission.getFarmId) == "function" then
         local ok, id = pcall(function() return g_currentMission:getFarmId() end)
-        if ok and id and id > 0 then return id end
+        if ok and SpatialScouting.isOrdinaryFarmId(id) then return id end
     end
     return nil
 end

--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -1447,11 +1447,42 @@ local function showSensorMsg(name, on)
     end
 end
 
+--- [PACK] Does this machine carry the precision pack (variable rate + section
+--- control)? Checks the sprayer, then its root vehicle, so a trailed unit
+--- answers for its own configuration. Fails CLOSED: no specialization, no pack.
+function SoilFertilityManager:hasPrecisionPack(vehicle)
+    if vehicle == nil then return false end
+    if type(vehicle.sfHasPrecisionPack) == "function" then
+        local ok, has = pcall(function() return vehicle:sfHasPrecisionPack() end)
+        if ok and has then return true end
+    end
+    local root = vehicle.rootVehicle
+    if root and root ~= vehicle and type(root.sfHasPrecisionPack) == "function" then
+        local ok, has = pcall(function() return root:sfHasPrecisionPack() end)
+        if ok and has then return true end
+    end
+    return false
+end
+
 -- ── System 3: Variable Rate input callback ─────────────────
 
 function SoilFertilityManager:onVariableRateInput()
     local vehicle = getSensorVehicle()
     if not vehicle or not self.sensorManager then return end
+    -- [PACK] Hardware gate. Refuse the toggle and say why, rather than flipping a
+    -- flag that the spray path will ignore -- a switch that does nothing is worse
+    -- than one that explains itself.
+    if not self:hasPrecisionPack(vehicle) then
+        local msg = (g_i18n and g_i18n:getText("sf_pack_required"))
+            or "This sprayer does not have the add-on needed for that function. Visit the shop to upgrade your sprayer."
+        if g_currentMission and g_currentMission.hud
+            and g_currentMission.hud.showBlinkingWarning then
+            g_currentMission.hud:showBlinkingWarning(msg, 4000)
+        end
+        SoilLogger.debug("[VariableRate] refused for vehicle %s - no precision pack",
+            tostring(vehicle.id))
+        return
+    end
     local newState = self.sensorManager:toggleVariableRate(vehicle.id)
     showSensorMsg(g_i18n and g_i18n:getText("sf_var_rate_label") or "Variable Rate", newState)
     SoilLogger.debug("[VariableRate] %s for vehicle %d", newState and "ON" or "OFF", vehicle.id)
@@ -1727,6 +1758,35 @@ end
 --- Update loop called every frame
 ---@param dt number Delta time in milliseconds
 function SoilFertilityManager:update(dt)
+    -- [PACK] Tell the player once, per sprayer, that a machine they already owned
+    -- now needs the add-on. Without this the feature simply vanishes on load and
+    -- reads as a broken mod. Throttled to a 2 s poll and remembered per vehicle,
+    -- so it cannot repeat while they sit in the seat.
+    self._packNoticeTimer = (self._packNoticeTimer or 0) + dt
+    if self._packNoticeTimer >= 2000 then
+        self._packNoticeTimer = 0
+        local v = g_localPlayer and type(g_localPlayer.getCurrentVehicle) == "function"
+            and g_localPlayer:getCurrentVehicle() or nil
+        if v ~= nil and type(v.sfIsLegacyNoPack) == "function" then
+            self._packNoticeShown = self._packNoticeShown or {}
+            local key = v.id or tostring(v)
+            if not self._packNoticeShown[key] then
+                local ok, legacy = pcall(function() return v:sfIsLegacyNoPack() end)
+                if ok and legacy then
+                    self._packNoticeShown[key] = true
+                    local msg = (g_i18n and g_i18n:getText("sf_pack_legacy_notice"))
+                        or "Variable rate and section control now need the Precision Pack. "
+                        .. "This sprayer does not have it - visit the shop to upgrade."
+                    if g_currentMission and g_currentMission.hud
+                        and g_currentMission.hud.showBlinkingWarning then
+                        g_currentMission.hud:showBlinkingWarning(msg, 5000)
+                    end
+                    SoilLogger.info("[PACK] legacy sprayer %s has no precision pack - player notified",
+                        tostring(key))
+                end
+            end
+        end
+    end
     -- REFINED: periodic value-map checksum broadcast (MP drift detection).
     -- Server-only, every 5 real minutes, only when clients are connected.
     if g_server and g_currentMission and g_currentMission.missionDynamicInfo
@@ -2111,9 +2171,53 @@ function SoilFertilityManager:updateAutoRates(dt)
     -- Find the player's active applicator vehicle
     local vehicle = getApplicatorVehicle()
     if not vehicle then
-        SoilLogger.debug("Auto-rate trace: bail - no applicator vehicle (not in one, or rootVehicle nil)")
+        -- [SF-39] AI helper run (George CLOSED DESIGN 09:48, the 0.01x holes).
+        -- getPlayerVehicle() is nil the moment the player steps out, so this
+        -- function bailed every tick for the WHOLE helper run and the dial froze
+        -- at whatever index it last held - including 0.01x from the player
+        -- standing on done ground when they pressed H. The min-boom sampling
+        -- below never even ran, which is why two rounds of sampling fixes could
+        -- not cure it. Find the AI-driven applicator with auto engaged instead;
+        -- getIsAIActive is already relied on in HookManager, SFNozzleEffects and
+        -- SoilFertilitySystem, so nothing invented.
+        if g_currentMission and g_currentMission.vehicles then
+            for _, v in pairs(g_currentMission.vehicles) do
+                local root = v.rootVehicle or v
+                if root == v and type(v.getIsAIActive) == "function" then
+                    local aOk, active = pcall(v.getIsAIActive, v)
+                    -- (self.sprayerRateManager directly: `rm` is declared below)
+                    if aOk and active and self.sprayerRateManager
+                       and self.sprayerRateManager:getAutoMode(v.id) then
+                        vehicle = v
+                        break
+                    end
+                end
+            end
+        end
+    end
+    if not vehicle then
+        SoilLogger.debug("Auto-rate trace: bail - no applicator vehicle (not in one, no AI applicator with auto ON)")
         return
     end
+
+    self:recalcAutoRateFor(vehicle)
+end
+
+--- [SF-41] Core auto-rate recalc for ONE vehicle (George CLOSED DESIGN 11:23,
+--- fix 3). Split out of updateAutoRates so it has TWO drivers: the player
+--- update path above, and the boom-strip work tick in HookManager - the tick
+--- that demonstrably keeps running after H + walk away. The SF-39 scan found
+--- the helper's machine but something in the seated update chain still starved
+--- it; wiring the recalc to the same cycle that paints means the dial updates
+--- exactly as long as product is going on the ground, seated or not. Own 5 s
+--- throttle per vehicle so the per-tick call from the paint path stays cheap.
+---@param vehicle table  root vehicle of the applicator
+function SoilFertilityManager:recalcAutoRateFor(vehicle)
+    if vehicle == nil or vehicle.id == nil then return end
+    local nowT = (g_currentMission and g_currentMission.time) or 0
+    self._sfAutoNext = self._sfAutoNext or {}
+    if (self._sfAutoNext[vehicle.id] or 0) > nowT then return end
+    self._sfAutoNext[vehicle.id] = nowT + 5000
 
     -- Only act when auto mode is engaged for this vehicle
     local rm = self.sprayerRateManager
@@ -2126,10 +2230,21 @@ function SoilFertilityManager:updateAutoRates(dt)
         return
     end
 
-    -- Use the HUD's cached field id (updated every frame in SoilHUD:update)
-    local fieldId = self.soilHUD.cachedFieldId
+    -- Use the HUD's cached field id (updated every frame in SoilHUD:update).
+    -- [SF-41] nil-safe: the paint-path driver can call this before/without a HUD.
+    local fieldId = self.soilHUD and self.soilHUD.cachedFieldId
     if not fieldId or fieldId <= 0 then
-        SoilLogger.debug("Auto-rate trace: bail - cachedFieldId nil/0 (field detection not resolving)")
+        -- [SF-39] The HUD caches the PLAYER's field. During a helper run the
+        -- player may be standing off-field, so resolve the field under the
+        -- MACHINE instead - same lookup the VR hook uses per section.
+        local pOk, vx, _, vz = pcall(getWorldTranslation, vehicle.rootNode)
+        if pOk and vx and HookManager and type(HookManager.getFieldIdAtWorldPosition) == "function" then
+            local fOk, fid = pcall(function() return HookManager:getFieldIdAtWorldPosition(vx, vz) end)
+            if fOk then fieldId = fid end
+        end
+    end
+    if not fieldId or fieldId <= 0 then
+        SoilLogger.debug("Auto-rate trace: bail - no field under player or machine")
         return
     end
 
@@ -2145,7 +2260,7 @@ function SoilFertilityManager:updateAutoRates(dt)
     end
 
     -- Get the fill type currently loaded in the vehicle
-    local fillType = self.soilHUD:getSprayerFillType(vehicle)
+    local fillType = self.soilHUD and self.soilHUD:getSprayerFillType(vehicle)
     if not fillType then
         SoilLogger.debug("Auto-rate trace: bail - getSprayerFillType nil for vehicle %d (field %s)",
             vehicle.id, tostring(fieldId))
@@ -2153,7 +2268,137 @@ function SoilFertilityManager:updateAutoRates(dt)
     end
 
     -- Calculate the ideal index and send if it changed
-    local newIdx = self:calculateAutoRateIndex(fieldData, fillType)
+    -- [FIX-8] Sense the ground UNDER the machine, not the field average.
+    --
+    -- Auto-rate read fieldData.pH, which climbs as you lime -- so the rate fell
+    -- away through the pass and whatever was covered last got almost nothing.
+    -- Measured over one field: 0.94x at 21:45 decaying to 0.20x by 22:02, which
+    -- is exactly why the last-worked strips came out pale. The machine should
+    -- answer the question "what does THIS ground need", not "how is the field
+    -- doing on average".
+    local localVals
+    do
+        local soilSys = self.soilSystem
+        if soilSys and soilSys.vmAvailable and soilSys:vmAvailable() then
+            local vm = soilSys.valueMaps
+
+            -- [FIX-14] Sense the WHOLE boom, and ALL FIVE soil values.
+            --
+            -- One sample under the tractor starved the headland edge: the tractor
+            -- sits over ground already done, the rate fell for the whole boom, and
+            -- the untouched edge got nothing. Sampling every ~2 m along the boom
+            -- and sizing for the NEEDIEST ground fixes that -- and it must apply
+            -- to nitrogen, phosphorus, potassium and organic matter exactly as to
+            -- pH, or spreading fertiliser and manure keeps the bug lime had.
+            local positions = {}
+            local line = nil
+            if HookManager ~= nil and type(HookManager.getBoomLineEndpoints) == "function" then
+                local lok, l = pcall(function() return HookManager:getBoomLineEndpoints(vehicle) end)
+                if lok then line = l end
+            end
+            if line and line.ax and line.bx then
+                local dx, dz = line.bx - line.ax, line.bz - line.az
+                local boomLen = math.sqrt(dx * dx + dz * dz)
+                local steps = math.max(4, math.min(24, math.ceil(boomLen / 2)))
+                for i = 0, steps do
+                    local f = i / steps
+                    positions[#positions + 1] = { x = line.ax + dx * f, z = line.az + dz * f }
+                end
+            else
+                -- [SF-38] The old fallback was ONE sample under the vehicle root
+                -- (George CLOSED DESIGN 09:04). Whenever the boom-line hook came
+                -- back nil, the tractor was usually sitting on ground it had just
+                -- limed, the single reading said "at target", and the dial
+                -- collapsed to 0.01x while the boom tips hung over needy ground -
+                -- Brian's yellow boom holes. Reuse the last known boom line for
+                -- this vehicle first; failing that, sample a lateral line through
+                -- the vehicle (+-9 m, 7 points) via localToWorld, so the minimum
+                -- is always taken across the working width, never one wheel track.
+                self._sfLastBoomLine = self._sfLastBoomLine or {}
+                local cached = self._sfLastBoomLine[vehicle.id]
+                if cached then
+                    local dx, dz = cached.bx - cached.ax, cached.bz - cached.az
+                    local steps = math.max(4, math.min(24, math.ceil(math.sqrt(dx * dx + dz * dz) / 2)))
+                    for i = 0, steps do
+                        local f = i / steps
+                        positions[#positions + 1] = { x = cached.ax + dx * f, z = cached.az + dz * f }
+                    end
+                else
+                    for off = -9, 9, 3 do
+                        local lOk, lx, _, lz = pcall(localToWorld, vehicle.rootNode, off, 0, 0)
+                        if lOk and lx then positions[#positions + 1] = { x = lx, z = lz } end
+                    end
+                    if #positions == 0 then
+                        local vOk, vx, _, vz = pcall(getWorldTranslation, vehicle.rootNode)
+                        if vOk and vx then positions[#positions + 1] = { x = vx, z = vz } end
+                    end
+                end
+            end
+            if line and line.ax and line.bx then
+                -- Remember the good line so the nil-hook ticks between work areas
+                -- keep sampling the true width instead of degrading to the root.
+                self._sfLastBoomLine = self._sfLastBoomLine or {}
+                self._sfLastBoomLine[vehicle.id] = { ax = line.ax, az = line.az, bx = line.bx, bz = line.bz }
+            end
+            if #positions > 0 then
+                localVals = {}
+                for _, key in ipairs({ "pH", "nitrogen", "phosphorus", "potassium", "organicMatter" }) do
+                    local minV = nil
+                    for _, pt in ipairs(positions) do
+                        local sOk, v = pcall(function() return vm:readValueAtWorld(key, pt.x, pt.z) end)
+                        -- [SF-43] pH sentinel/edge clamp (George CLOSED DESIGN
+                        -- 12:32): reads AT the scale floor (5.0) or ceiling (7.5)
+                        -- on boom tips hanging over edges/sentinel pixels are map
+                        -- artefacts, not soil. Folding a 5.0 into the minimum
+                        -- inflated the dial, then a 7.5 overlap read collapsed it
+                        -- - the flicker behind the yellow holes. Open interval
+                        -- only; when no valid sample remains, minV stays nil and
+                        -- the field average wins, exactly as for unwritten cells.
+                        if key == "pH" and sOk and v ~= nil then
+                            local lim  = SoilConstants.NUTRIENT_LIMITS
+                            local pmin = (lim and lim.PH_MIN) or 5.0
+                            local pmax = (lim and lim.PH_MAX) or 7.5
+                            if v <= pmin or v >= pmax then v = nil end
+                        end
+                        if sOk and v ~= nil and (minV == nil or v < minV) then minV = v end
+                    end
+                    localVals[key] = minV   -- nil where unwritten: field average wins
+                end
+            end
+        end
+    end
+    -- [FIX-16] Hold the neediest reading seen in the last 15 s, per vehicle.
+    --
+    -- Single-tick sampling flickered: crossing a just-painted strip or the
+    -- boom clipping done ground for one tick collapsed the rate (measured
+    -- 1.00x -> 0.50x -> 1.00x -> 0.01x tick to tick), and every swing painted
+    -- a differently dosed band -- the striping across the worker's field. A
+    -- rolling minimum keeps the rate sized to the neediest ground seen
+    -- recently: transients cannot drop it, and it recovers within 15 s once
+    -- the ground really is done everywhere.
+    if localVals then
+        self._sfSenseWin = self._sfSenseWin or {}
+        local now = (g_currentMission and g_currentMission.time) or 0
+        local win = self._sfSenseWin[vehicle.id]
+        if not win then win = {} self._sfSenseWin[vehicle.id] = win end
+        win[#win + 1] = { t = now, v = localVals }
+        while #win > 0 and (now - win[1].t) > 15000 do table.remove(win, 1) end
+        local held = {}
+        for _, entry in ipairs(win) do
+            for k, v in pairs(entry.v) do
+                if held[k] == nil or v < held[k] then held[k] = v end
+            end
+        end
+        localVals = held
+    end
+    local newIdx = self:calculateAutoRateIndex(fieldData, fillType, localVals)
+    -- [SF-34] George constraint 3: with the Precision Pack, prescription paint
+    -- already varies the dose per 2 m cell, so the auto dial must not fight it.
+    -- Pin the dial at 1.0x and let the prescription do the per-cell work; the
+    -- close-the-gap dial is the tool for flat-broadcast machines only.
+    if self:hasPrecisionPack(vehicle) then
+        newIdx = SoilConstants.SPRAYER_RATE.DEFAULT_INDEX   -- 1.0x
+    end
     local currentIdx = rm:getIndex(vehicle.id)
     if newIdx ~= currentIdx then
         rm:setIndex(vehicle.id, newIdx)
@@ -2191,7 +2436,12 @@ end
 ---@param fieldData table  Return value of SoilFertilitySystem:getFieldInfo()
 ---@param fillType  table  FillType object (has .name string)
 ---@return number          1-based index into SoilConstants.SPRAYER_RATE.STEPS
-function SoilFertilityManager:calculateAutoRateIndex(fieldData, fillType)
+function SoilFertilityManager:calculateAutoRateIndex(fieldData, fillType, localVals)
+    -- [FIX-14] localVals: the neediest (minimum) soil values sampled along the
+    -- boom, keyed pH / nitrogen / phosphorus / potassium / organicMatter. Any
+    -- nil falls back to the field average. A bare number still means {pH = n}.
+    if type(localVals) == "number" then localVals = { pH = localVals } end
+    local lv = localVals or {}
     local steps    = SoilConstants.SPRAYER_RATE.STEPS
     local defaults = SoilConstants.SPRAYER_RATE.AUTO_RATE_TARGETS
     local ct       = fieldData.cropTargets
@@ -2202,11 +2452,15 @@ function SoilFertilityManager:calculateAutoRateIndex(fieldData, fillType)
         pH = defaults.pH,
         OM = defaults.OM,
     } or defaults
-    local limits  = SoilConstants.NUTRIENT_LIMITS
-    local phMin   = limits and limits.PH_MIN or 5.0
+    -- [SF-34] limits/phMin gone with the proportional formula: close-the-gap
+    -- works in absolute gap units, so the PH_MIN normalisation range is unused.
 
     -- Safe multiplier bounds - never exceed BURN_RISK_THRESHOLD
-    local MULT_MIN = 0.20
+    -- Floor is 0.01, not 0.20: on ground already at target the old floor kept
+    -- applying a fifth of base rate, which for lime means driving pH past optimum
+    -- on a field that needed nothing. 0.01 keeps the machine visibly working
+    -- without meaningfully changing the soil.
+    local MULT_MIN = 0.01
     local MULT_MAX = 1.20
 
     local multiplier = 1.0  -- default fallback
@@ -2223,73 +2477,110 @@ function SoilFertilityManager:calculateAutoRateIndex(fieldData, fillType)
             multiplier = 1.0
 
         else
-            -- Weighted nutrient deficit across the profile's N/P/K/pH (and optionally OM).
-            -- Each nutrient's deficit is weighted by its coefficient in the product profile,
-            -- so a product is sized by the nutrients it actually carries. Returns nil when the
-            -- profile contributes no weighted nutrients.
-            local function weightedNutrientDeficit(includeOM)
-                local totalWeight     = 0
-                local weightedDeficit = 0
+            -- [SF-34] Close-the-gap sizing (George CLOSED DESIGN 00:13).
+            --
+            -- The old formula mapped deficit FRACTION linearly onto the dial:
+            -- proportional control whose gain was too low to ever close a real
+            -- gap. Measured live on field 82 at pH 5.9 it held ~0.50x (~+0.20
+            -- pH/pass) - the yellow zebra banding. Ask the real question
+            -- instead: what multiplier makes ONE pass close this gap?
+            --
+            --     required = gap / (coeff * BASE_RATE / 1000)
+            --
+            -- FERTILIZER_PROFILES are calibrated per 1,000 L (kg) applied and
+            -- BASE_RATES is the calibrated 1.0x rate, so coeff*base/1000 is the
+            -- per-pass effect at 1.0x. LIQUIDLIME: 1.07 * 374/1000 = +0.400 pH,
+            -- which at the 1.20x cap is George's ~+0.48, under SF_PASS_MAX.pH
+            -- 0.60. Nothing invented; both numbers come from Constants.lua.
+            -- A compound product is sized by its BIGGEST carried need, and the
+            -- clamp below keeps the result inside the STEPS table and under
+            -- BURN_RISK_THRESHOLD (1.25).
+            local baseRow = SoilConstants.SPRAYER_RATE.BASE_RATES
+                            and SoilConstants.SPRAYER_RATE.BASE_RATES[fillType.name]
+            local perThousand = (baseRow and baseRow.value and baseRow.value > 0)
+                                and (baseRow.value / 1000.0) or nil
 
-                if profile.N and profile.N > 0 then
-                    local deficit = math.max(0, targets.N - fieldData.nitrogen.value) / targets.N
-                    weightedDeficit = weightedDeficit + deficit * profile.N
-                    totalWeight     = totalWeight     + profile.N
-                end
-                if profile.P and profile.P > 0 then
-                    local deficit = math.max(0, targets.P - fieldData.phosphorus.value) / targets.P
-                    weightedDeficit = weightedDeficit + deficit * profile.P
-                    totalWeight     = totalWeight     + profile.P
-                end
-                if profile.K and profile.K > 0 then
-                    local deficit = math.max(0, targets.K - fieldData.potassium.value) / targets.K
-                    weightedDeficit = weightedDeficit + deficit * profile.K
-                    totalWeight     = totalWeight     + profile.K
-                end
-                if profile.pH and profile.pH > 0 then
-                    -- pH: how far below target normalised to the possible range [PH_MIN, target]
-                    local phRange = targets.pH - phMin
-                    if phRange > 0 then
-                        local deficit = math.max(0, targets.pH - fieldData.pH) / phRange
-                        weightedDeficit = weightedDeficit + deficit * profile.pH
-                        totalWeight     = totalWeight     + profile.pH
-                    end
-                end
-                if includeOM and profile.OM and profile.OM > 0 then
-                    local deficit = math.max(0, targets.OM - fieldData.organicMatter) / targets.OM
-                    weightedDeficit = weightedDeficit + deficit * profile.OM
-                    totalWeight     = totalWeight     + profile.OM
-                end
+            -- [SF-35] Fraction-of-gap retune (George CLOSED DESIGN 00:46).
+            -- Closing the WHOLE gap in one pass slammed the dial to 1.20x and,
+            -- combined with pass overlap, over-limed (Wizard/Brian TEST 00:26
+            -- FAIL). One pass now attempts HALF the remaining gap, capped at the
+            -- per-pass physical maximum, so a typical 0.6 pH gap asks ~0.75x and
+            -- converges over passes instead of overshooting. Keep these caps in
+            -- step with SF_PASS_MAX in SoilFertilitySystem's paintBoomStrip.
+            local AUTO_PASS_MAX = {
+                -- [SF-48] pH synced 0.30 -> 0.40 with SF_PASS_MAX (paint side).
+                pH = 0.40, nitrogen = 60, phosphorus = 60, potassium = 60,
+                organicMatter = 2.0,
+            }
 
-                if totalWeight > 0 then
-                    return weightedDeficit / totalWeight
+            --- Multiplier that applies 0.50 of `gap` (capped at `passMax`) in
+            --- one pass via `coeff`. [SF-42] fraction 0.75 -> 0.50 (George
+            --- CLOSED DESIGN 11:23): with the ~6.6 soft ceiling, 0.75 pushed the
+            --- first pass straight to the ceiling and the whole field plateaued
+            --- uniformly. Half-gap leaves headroom (~5.9 -> ~6.2), so only
+            --- OVERLAP climbs to the ceiling and reads brighter. nil when the
+            --- product does not carry this nutrient or has no calibrated base
+            --- rate; 0 when no gap to close.
+            local function gapMult(gap, coeff, passMax)
+                if perThousand == nil or coeff == nil or coeff <= 0 then return nil end
+                if gap == nil or gap <= 0 then return 0 end
+                local boost = gap * 0.50
+                if passMax and boost > passMax then boost = passMax end
+                return boost / (coeff * perThousand)
+            end
+
+            --- [SF-44] Effective gap with a field-average FLOOR (George TRACE,
+            --- CLOSED DESIGN 13:13). The boom minimum is still the primary
+            --- signal ([FIX-8]), but a local-only read taken while the boom
+            --- crosses a limed overlap cell reported "at target" and zeroed the
+            --- dial - Brian's 0.01x windows with applied=0.0000 while needy
+            --- pixels under the same boom sat unchanged. The sizing gap is now
+            --- never less than HALF the field-average gap, so a transient
+            --- at-target sample cannot starve ground the field still needs:
+            --- effectiveGap = max(localGap, fieldGap * 0.5).
+            local function effGap(localV, fieldV, target)
+                local localGap = target - (localV or fieldV or target)
+                local fieldGap = target - (fieldV or target)
+                return math.max(localGap, fieldGap * 0.5)
+            end
+
+            --- Largest close-the-gap multiplier across the nutrients this
+            --- product carries. nil when the product carries nothing we can size.
+            local function requiredMultiplier(includeOM)
+                local req = nil
+                local function consider(m)
+                    if m ~= nil and (req == nil or m > req) then req = m end
                 end
-                return nil
+                consider(gapMult(effGap(lv.nitrogen,   fieldData.nitrogen.value,   targets.N),  profile.N,  AUTO_PASS_MAX.nitrogen))
+                consider(gapMult(effGap(lv.phosphorus, fieldData.phosphorus.value, targets.P),  profile.P,  AUTO_PASS_MAX.phosphorus))
+                consider(gapMult(effGap(lv.potassium,  fieldData.potassium.value,  targets.K),  profile.K,  AUTO_PASS_MAX.potassium))
+                consider(gapMult(effGap(lv.pH,         fieldData.pH,               targets.pH), profile.pH, AUTO_PASS_MAX.pH))
+                if includeOM then
+                    consider(gapMult(effGap(lv.organicMatter, fieldData.organicMatter, targets.OM), profile.OM, AUTO_PASS_MAX.organicMatter))
+                end
+                return req
             end
 
             -- Check if this is an OM-primary product (manure, compost, digestate, etc.)
             local omPrimary = SoilConstants.SPRAYER_RATE.OM_PRIMARY_PRODUCTS
             if omPrimary and omPrimary[fillType.name] and profile.OM and profile.OM > 0 then
-                -- Organic product. Size the pass by whichever need is bigger: organic matter
-                -- OR the N/P/K it carries. Driving off OM deficit alone starved a nutrient-rich
-                -- organic (chicken / pelletized manure) on a field that was already high in OM
-                -- but low in N/P/K - the exact situation a player reaches for it (#668).
-                local omDeficit  = math.max(0, targets.OM - fieldData.organicMatter) / math.max(0.01, targets.OM)
-                local npkDeficit = weightedNutrientDeficit(false) or 0
-                local effective  = math.max(omDeficit, npkDeficit)
-                multiplier = MULT_MIN + effective * (MULT_MAX - MULT_MIN)
+                -- Organic product. Size the pass by whichever need is bigger: organic
+                -- matter OR the N/P/K it carries (#668 - a nutrient-rich organic on an
+                -- OM-rich, N/P/K-poor field is the exact case a player reaches for it).
+                local omReq  = gapMult(effGap(lv.organicMatter, fieldData.organicMatter, targets.OM), profile.OM, AUTO_PASS_MAX.organicMatter) or 0
+                local npkReq = requiredMultiplier(false) or 0
+                multiplier = math.max(omReq, npkReq)
                 SoilLogger.debug(
-                    "Auto-rate calc (organic): %s | omDeficit=%.3f | npkDeficit=%.3f | using=%.3f | target multiplier=%.3f",
-                    fillType.name, omDeficit, npkDeficit, effective, multiplier)
+                    "Auto-rate calc (organic, close-the-gap): %s | omReq=%.3f | npkReq=%.3f | target multiplier=%.3f",
+                    fillType.name, omReq, npkReq, multiplier)
             else
-                -- Nutrient fertilizer: weighted deficit across all profile nutrients (incl. OM).
-                local deficitFraction = weightedNutrientDeficit(true)
-                if deficitFraction then
-                    -- Map [0, 1] deficit fraction → [0.20, 1.20] multiplier
-                    multiplier = MULT_MIN + deficitFraction * (MULT_MAX - MULT_MIN)
+                -- Nutrient fertilizer: close the biggest gap this product can serve.
+                local req = requiredMultiplier(true)
+                if req then
+                    multiplier = req
                     SoilLogger.debug(
-                        "Auto-rate calc: %s | deficit=%.3f | target multiplier=%.3f",
-                        fillType.name, deficitFraction, multiplier)
+                        "Auto-rate calc (close-the-gap): %s | required=%.3f | target multiplier=%.3f",
+                        fillType.name, req, multiplier)
                 end
             end
         end
@@ -2306,6 +2597,18 @@ function SoilFertilityManager:calculateAutoRateIndex(fieldData, fillType)
             -- is visible in a debug run (#809).
             SoilLogger.debug("Auto-rate calc: %s NOT in FERTILIZER_PROFILES - holding 1.0x (pinned rate)",
                 tostring(fillType.name))
+        end
+    end
+
+    -- [SF-45] Hard needy floor (George TRACE DESIGN 13:32): while the FIELD
+    -- AVERAGE pH is still below target, a lime product never dials under 0.60x,
+    -- whatever the local sample momentarily says. The effGap field-average
+    -- floor stays as the secondary, proportional defence; this is the blunt
+    -- one that makes 0.01x zero-apply windows on a needy field impossible.
+    if profile and profile.pH and profile.pH > 0 then
+        local fieldPH = fieldData and fieldData.pH
+        if fieldPH ~= nil and fieldPH < targets.pH and multiplier < 0.60 then
+            multiplier = 0.60
         end
     end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -1144,12 +1144,20 @@ function SoilFertilitySystem:onSowing(fieldId, area, seedsFruitType, cropBiomass
         if tx and tz then
             local zone = SoilConstants.ZONE
             local cellFactor = areaHa / zone.CELL_AREA_HA
-            self:vmLocalBump(tx, tz, {
-                nitrogen      = ri.N  * cellFactor,
-                phosphorus    = ri.P  * cellFactor,
-                potassium     = ri.K  * cellFactor,
-                organicMatter = ri.OM * cellFactor,
-            }, zone.CELL_SIZE * 0.5)
+            -- [SF-23] PF-shaped positional paint (Wizard ruling, supersedes the
+            -- [SF-22] whole-field shift). Colour the ground actually worked this
+            -- tick as a swept ~2 m strip: a partial pass must leave unworked
+            -- ground alone. FULL-PASS values are passed deliberately, see
+            -- paintTillageStrip - the strip carries the whole per-pass delta so a
+            -- completed pass lands exactly on the scalar's field average.
+            -- cellFactor stays live: the zoneData pressure writes below still run
+            -- on the coarse 10 m grid, which constraint 5 explicitly permits.
+            self:paintTillageStrip(fieldId, field, areaHa, {
+                nitrogen      = ri.N,
+                phosphorus    = ri.P,
+                potassium     = ri.K,
+                organicMatter = ri.OM,
+            })
 
             -- Weed reduction per zone cell (pressures stay on the coarse grid)
             if self.settings.weedPressure then
@@ -1202,6 +1210,7 @@ function SoilFertilitySystem:resetSessionCoverage(fieldId, reason)
     field.sessionCoverageHa       = 0
     field.sessionCoverageFraction = 0
     field.sessionCoverageCells    = {}
+    field._covCells2m             = {}   -- [FIX-10] same lifetime
     field.sessionLastProduct      = nil
     field._farmlandAreaConfirmed  = nil
     field._geometricCoverageOwner = nil  -- #753: re-detect geometric path each session
@@ -1233,18 +1242,16 @@ function SoilFertilitySystem:_applyCropIncorporation(fieldId, field, profile, bi
     field.phosphorus = math.min(limits.MAX, (field.phosphorus or 0) + profile.P * scale)
     field.potassium  = math.min(limits.MAX, (field.potassium  or 0) + profile.K * scale)
 
-    -- REFINED: local per-pixel bump at the tillage position on the value maps
-    local tx, tz = self._lastTillageX, self._lastTillageZ
-    if tx and tz then
-        local zone = SoilConstants.ZONE
-        local cellScale = ((areaHa or 0) / zone.CELL_AREA_HA) * biomass
-        self:vmLocalBump(tx, tz, {
-            organicMatter = profile.OM * cellScale,
-            nitrogen      = profile.N  * cellScale,
-            phosphorus    = profile.P  * cellScale,
-            potassium     = profile.K  * cellScale,
-        }, zone.CELL_SIZE * 0.5)
-    end
+    -- [SF-23] Positional paint on the worked strip (supersedes [SF-22]). The
+    -- full-pass value here is `profile.X * biomass`: `scale` is that times the
+    -- field fraction, and the field fraction is what the STRIP GEOMETRY already
+    -- expresses, so multiplying by it again would apply the mass twice.
+    self:paintTillageStrip(fieldId, field, areaHa, {
+        organicMatter = profile.OM * biomass,
+        nitrogen      = profile.N  * biomass,
+        phosphorus    = profile.P  * biomass,
+        potassium     = profile.K  * biomass,
+    })
 
     SoilLogger.debug("Crop incorporation field %d: +OM%.3f +N%.3f (biomass=%.2f factor=%.4f)",
         fieldId or -1, profile.OM * scale, profile.N * scale, biomass, factor)
@@ -1254,32 +1261,30 @@ end
 --- #738 no-till OM: apply a tillage pass's organic-matter OXIDATION loss (deep
 --- disturbance aerating buried humus). Shared by the plough/cultivator/strip-till
 --- hooks with each type's own gradient value. Reduces the field-average OM (floored
---- at DECAY_FLOOR), and mirrors the loss positionally onto the OM value map at the
---- pass location - the same scalar-uses-`factor`, VM-uses-`cellFactor` split the
---- residue-incorporation writes use, degrading to scalar-only when no value map is
+--- at DECAY_FLOOR), and mirrors that same loss onto the OM value map as a UNIFORM
+--- whole-field shift ([SF-22]). It used to write a positional blob at the tool,
+--- which is what printed AB-line bands on the OM layer; the scalar and the map now
+--- move by one identical number, degrading to scalar-only when no value map is
 --- present. Returns true if the field OM changed.
+---@param fieldId number The field being tilled (resolves the field polygon)
 ---@param field table The field data table
 ---@param oxid number OM lost per full pass (OM_DYNAMICS.OXIDATION.*)
 ---@param factor number Field-fraction processed this tick (areaHa / fieldAreaHa)
----@param areaHa number Area processed this tick, for the per-cell VM intensity
+---@param areaHa number Area processed this tick (kept for call-site symmetry)
 ---@return boolean changed
-function SoilFertilitySystem:_applyTillageOxidation(field, oxid, factor, areaHa)
+function SoilFertilitySystem:_applyTillageOxidation(fieldId, field, oxid, factor, areaHa)
     if not oxid or oxid <= 0 or not field then return false end
     local omDyn  = SoilConstants.OM_DYNAMICS
     local floor  = (omDyn and omDyn.DECAY_FLOOR) or SoilConstants.NUTRIENT_LIMITS.MIN
-    -- SF-56: scale oxidation by the tillage class at the pass location
-    local tx, tz = self._lastTillageX, self._lastTillageZ
-    local tillMult = 1.0
-    if tx and tz then tillMult = self:_tillageDecompMult(tx, tz) end
     local before = field.organicMatter or SoilConstants.FIELD_DEFAULTS.organicMatter
-    local after  = math.max(floor, before - oxid * tillMult * factor)
+    local after  = math.max(floor, before - oxid * factor)
     if after >= before then return false end
     field.organicMatter = after
-    if tx and tz then
-        local zone = SoilConstants.ZONE
-        local cellFactor = areaHa / zone.CELL_AREA_HA
-        self:vmLocalBump(tx, tz, { organicMatter = -(oxid * tillMult * cellFactor) }, zone.CELL_SIZE * 0.5)
-    end
+    -- [SF-23] Positional OM loss on the worked strip (supersedes the [SF-22]
+    -- whole-field shift). `-oxid` is the FULL-PASS loss, so a completed pass
+    -- takes every worked cell down by oxid and matches the scalar's floored
+    -- field average, while a partial pass burns only the ground driven over.
+    self:paintTillageStrip(fieldId, field, areaHa, { organicMatter = -oxid })
     return true
 end
 
@@ -1341,7 +1346,7 @@ function SoilFertilitySystem:onPlowing(fieldId, area, isAlsoSprayer, cropBiomass
         -- write + floored scalar). Steepest of the gradient - deep inversion burns the
         -- most buried humus, so a residue-poor plough nets slightly negative on OM.
         local omDyn = SoilConstants.OM_DYNAMICS
-        if self:_applyTillageOxidation(field, omDyn and omDyn.OXIDATION and omDyn.OXIDATION.PLOW, factor, areaHa) then
+        if self:_applyTillageOxidation(fieldId, field, omDyn and omDyn.OXIDATION and omDyn.OXIDATION.PLOW, factor, areaHa) then
             changed = true
         end
 
@@ -1357,6 +1362,18 @@ function SoilFertilitySystem:onPlowing(fieldId, area, isAlsoSprayer, cropBiomass
         if phAfter ~= phBefore then
             field.pH = phAfter
             changed = true
+            -- [SF-23] pH normalisation had NO value-map write at all before
+            -- [SF-22], so the pH layer disagreed with the PDA for the life of every
+            -- save. Now written positionally like the rest. Dividing the scalar's
+            -- clamped step by `factor` recovers the full-pass magnitude and keeps
+            -- the sign, so the strip carries the same mass the scalar took.
+            -- Approximation worth knowing: this is an ADDITIVE step toward 7.0, so
+            -- individual pixels converge on the target rather than clamping to it
+            -- exactly the way the field scalar does.
+            if factor and factor > 0 then
+                self:paintTillageStrip(fieldId, field, areaHa,
+                    { pH = (phAfter - phBefore) / factor })
+            end
         end
     end
 
@@ -1417,12 +1434,20 @@ function SoilFertilitySystem:onPlowing(fieldId, area, isAlsoSprayer, cropBiomass
             local zone = SoilConstants.ZONE
             -- Cell-factor: area processed in THIS tick relative to one cell area (usually 0.01 ha)
             local cellFactor = areaHa / zone.CELL_AREA_HA
-            self:vmLocalBump(tx, tz, {
-                nitrogen      = ri.N  * cellFactor,
-                phosphorus    = ri.P  * cellFactor,
-                potassium     = ri.K  * cellFactor,
-                organicMatter = ri.OM * cellFactor,
-            }, zone.CELL_SIZE * 0.5)
+            -- [SF-23] PF-shaped positional paint (Wizard ruling, supersedes the
+            -- [SF-22] whole-field shift). Colour the ground actually worked this
+            -- tick as a swept ~2 m strip: a partial pass must leave unworked
+            -- ground alone. FULL-PASS values are passed deliberately, see
+            -- paintTillageStrip - the strip carries the whole per-pass delta so a
+            -- completed pass lands exactly on the scalar's field average.
+            -- cellFactor stays live: the zoneData pressure writes below still run
+            -- on the coarse 10 m grid, which constraint 5 explicitly permits.
+            self:paintTillageStrip(fieldId, field, areaHa, {
+                nitrogen      = ri.N,
+                phosphorus    = ri.P,
+                potassium     = ri.K,
+                organicMatter = ri.OM,
+            })
 
             local cellKey = tostring(math.floor(tx / zone.CELL_SIZE) * 10000 + math.floor(tz / zone.CELL_SIZE))
             if not field.zoneData then field.zoneData = {} end
@@ -1559,7 +1584,7 @@ function SoilFertilitySystem:onCultivation(fieldId, area, isAlsoSprayer, cropBio
         -- #738: cultivator oxidation (topsoil mixing aerates humus). Netted against the
         -- residue gain above, cultivation still adds OM but less than strip-till/no-till.
         local omDyn = SoilConstants.OM_DYNAMICS
-        if self:_applyTillageOxidation(field, omDyn and omDyn.OXIDATION and omDyn.OXIDATION.CULTIVATOR, factor, areaHa) then
+        if self:_applyTillageOxidation(fieldId, field, omDyn and omDyn.OXIDATION and omDyn.OXIDATION.CULTIVATOR, factor, areaHa) then
             changed = true
         end
 
@@ -1569,12 +1594,20 @@ function SoilFertilitySystem:onCultivation(fieldId, area, isAlsoSprayer, cropBio
         if tx and tz then
             local zone = SoilConstants.ZONE
             local cellFactor = areaHa / zone.CELL_AREA_HA
-            self:vmLocalBump(tx, tz, {
-                nitrogen      = ri.N  * cellFactor,
-                phosphorus    = ri.P  * cellFactor,
-                potassium     = ri.K  * cellFactor,
-                organicMatter = ri.OM * cellFactor,
-            }, zone.CELL_SIZE * 0.5)
+            -- [SF-23] PF-shaped positional paint (Wizard ruling, supersedes the
+            -- [SF-22] whole-field shift). Colour the ground actually worked this
+            -- tick as a swept ~2 m strip: a partial pass must leave unworked
+            -- ground alone. FULL-PASS values are passed deliberately, see
+            -- paintTillageStrip - the strip carries the whole per-pass delta so a
+            -- completed pass lands exactly on the scalar's field average.
+            -- cellFactor stays live: the zoneData pressure writes below still run
+            -- on the coarse 10 m grid, which constraint 5 explicitly permits.
+            self:paintTillageStrip(fieldId, field, areaHa, {
+                nitrogen      = ri.N,
+                phosphorus    = ri.P,
+                potassium     = ri.K,
+                organicMatter = ri.OM,
+            })
 
             local cellKey = tostring(math.floor(tx / zone.CELL_SIZE) * 10000 + math.floor(tz / zone.CELL_SIZE))
             if not field.zoneData then field.zoneData = {} end
@@ -1735,7 +1768,7 @@ function SoilFertilitySystem:onStripTill(fieldId, area)
         -- bands are disturbed). Netted with the residue gain, strip-till nets clearly
         -- positive, second only to no-till on the season OM trajectory.
         local omDyn = SoilConstants.OM_DYNAMICS
-        if self:_applyTillageOxidation(field, omDyn and omDyn.OXIDATION and omDyn.OXIDATION.STRIP_TILL, factor, areaHa) then
+        if self:_applyTillageOxidation(fieldId, field, omDyn and omDyn.OXIDATION and omDyn.OXIDATION.STRIP_TILL, factor, areaHa) then
             changed = true
         end
 
@@ -1753,12 +1786,20 @@ function SoilFertilitySystem:onStripTill(fieldId, area)
             local zone = SoilConstants.ZONE
             local cellFactor = areaHa / zone.CELL_AREA_HA
             -- REFINED: local per-pixel bump at the strip-till position
-            self:vmLocalBump(tx, tz, {
-                nitrogen      = ri.N  * cellFactor,
-                phosphorus    = ri.P  * cellFactor,
-                potassium     = ri.K  * cellFactor,
-                organicMatter = ri.OM * cellFactor,
-            }, zone.CELL_SIZE * 0.5)
+            -- [SF-23] PF-shaped positional paint (Wizard ruling, supersedes the
+            -- [SF-22] whole-field shift). Colour the ground actually worked this
+            -- tick as a swept ~2 m strip: a partial pass must leave unworked
+            -- ground alone. FULL-PASS values are passed deliberately, see
+            -- paintTillageStrip - the strip carries the whole per-pass delta so a
+            -- completed pass lands exactly on the scalar's field average.
+            -- cellFactor stays live: the zoneData pressure writes below still run
+            -- on the coarse 10 m grid, which constraint 5 explicitly permits.
+            self:paintTillageStrip(fieldId, field, areaHa, {
+                nitrogen      = ri.N,
+                phosphorus    = ri.P,
+                potassium     = ri.K,
+                organicMatter = ri.OM,
+            })
 
             local cellKey = tostring(math.floor(tx / zone.CELL_SIZE) * 10000 + math.floor(tz / zone.CELL_SIZE))
             if not field.zoneData then field.zoneData = {} end
@@ -4132,6 +4173,219 @@ function SoilFertilitySystem:vmLocalBump(worldX, worldZ, deltas, radius)
     end
 end
 
+-- [SF-23] Tillage footprint bounds. The worked width is DERIVED (area / travel)
+-- because the tillage hooks report an area per tick, never a tool line the way
+-- the sprayer reports a boom. The clamps only catch nonsense (a stalled area
+-- counter, a one-frame area spike); mass is preserved across them by rescaling.
+local TILL_MIN_WIDTH_M  = 1.0
+local TILL_MAX_WIDTH_M  = 30.0
+local TILL_TELEPORT_M   = 40.0
+
+--- [SF-23] Mark the nutrient value maps as visually stale.
+--- Cheap and safe to call per work tick: the minimap layer already dirty-flags,
+--- and the PDA gets a flag rather than a rebuild, so no DMV work happens here.
+function SoilFertilitySystem:_soilMapsMutated()
+    -- [SF-33] Bump the write generation so any cached spatial rollup is stale.
+    -- Cheap here (one integer) and it means getFieldSpatialSummary never has to
+    -- guess whether its samples still describe the map, which is what George
+    -- asked for when he approved the sampling pass.
+    self._vmWriteGen = (self._vmWriteGen or 0) + 1
+    local sfm = g_SoilFertilityManager
+    if not sfm then return end
+    if sfm.soilMinimapLayer then sfm.soilMinimapLayer:markDirty() end
+    local ov = sfm.soilMapOverlay
+    if ov then ov._pdaValueMapsDirty = true end
+end
+
+--- [SF-23] Paint one tillage tick as a PF-shaped swept strip on the ~2 m value
+--- maps. Wizard's ruling on BUILD 22:12: worked ground changes colour, unworked
+--- ground does not, so a partial pass must NOT move the whole field.
+---
+--- Geometry mirrors paintBoomStrip: a parallelogram from the previous tillage
+--- point to the current one. The sprayer knows its boom line; tillage does not,
+--- so the footprint width is derived as areaM2 / travel, which is exact whenever
+--- the area counter and the position agree.
+---
+--- `deltas` carry FULL-PASS values (`ri.N`, `-oxid`, ...), NOT the per-tick
+--- `value * factor` the scalar uses. That is the whole trick: painting the
+--- ground worked this tick with the full-pass value means a COMPLETE pass leaves
+--- every cell +value, which is exactly the field average the scalar arrives at,
+--- while half a pass colours half the field and leaves the rest untouched. It
+--- also keeps each write far above the layer's raw quantisation step, which a
+--- per-tick `value * factor` would round to zero and lose entirely.
+---
+--- Ticks that cannot paint (no anchor yet, stationary, teleport) bank their area
+--- in `field._vmTillPendArea` so the next moving tick paints the full mass.
+---@param fieldId number
+---@param field table
+---@param areaHa number Area worked this tick, hectares
+---@param deltas table  { nitrogen = fullPassDelta, ... }
+function SoilFertilitySystem:paintTillageStrip(fieldId, field, areaHa, deltas)
+    if not field or not deltas or not self:vmAvailable() then return end
+    if not areaHa or areaHa <= 0 then return end
+
+    local cx, cz = self._lastTillageX, self._lastTillageZ
+    if not cx or not cz then return end
+
+    -- [SF-25] Several sim paths call this in the SAME work tick: oxidation, then
+    -- residue incorporation, then crop incorporation. The 23:55 build let whichever
+    -- call landed FIRST consume the travel and advance the anchor, so every later
+    -- call in that tick saw travel 0, banked its area and returned without
+    -- painting. Live proof from one plough on field 90: 162 SF-24 lines, every one
+    -- of them organicMatter (the oxidation call), and not a single nitrogen line.
+    -- N/P/K never painted at all. The same bug also double counted area, because
+    -- each starved call still banked its own areaHa, which is why the derived width
+    -- pinned to the 30 m clamp instead of the tool's real ~12 m.
+    --
+    -- So collect the whole tick and paint it once: deltas merge, area counts ONCE
+    -- per tick however many callers fire, and the paint runs when the NEXT tick
+    -- opens, by which point the previous tick's delta set is complete.
+    local nowMs = (g_currentMission and g_currentMission.time) or 0
+    local pend  = field._vmTillPend
+    if not pend then
+        pend = { keys = {}, tickKeys = {}, area = 0, tick = -1 }
+        field._vmTillPend = pend
+    end
+    pend.tickKeys = pend.tickKeys or {}
+
+    if pend.tick ~= nowMs then
+        -- [SF-26] The 00:05 build wiped pend.keys unconditionally after a flush
+        -- attempt, so whenever _flushTillageStrip returned early (travel < one
+        -- pixel) the whole completed delta set was DISCARDED. Ash caught this.
+        -- Two separate buckets fix it properly:
+        --   tickKeys - sums the contributions of every caller WITHIN one tick
+        --              (oxidation, residue, crop incorporation).
+        --   keys     - the last COMPLETE tick's set, waiting to be painted.
+        -- A completed tick REPLACES keys rather than adding to it, because every
+        -- tick reports the same full-pass rates; summing them across ticks would
+        -- multiply the dose by however many ticks the sweep took to reach a pixel.
+        -- keys is cleared only when the paint actually happened.
+        if next(pend.tickKeys) ~= nil then
+            pend.keys = pend.tickKeys
+            pend.tickKeys = {}
+        end
+        pend.tick = nowMs
+        pend.area = (pend.area or 0) + areaHa
+
+        if next(pend.keys) ~= nil then
+            if self:_flushTillageStrip(fieldId, field, pend, cx, cz) then
+                pend.keys = {}
+            end
+        end
+    end
+    for k, v in pairs(deltas) do
+        if v and v ~= 0 then pend.tickKeys[k] = (pend.tickKeys[k] or 0) + v end
+    end
+end
+
+--- [SF-25] Paint one COMPLETE tick's accumulated tillage deltas as a swept strip.
+--- Split out of paintTillageStrip so that every caller in a tick has contributed
+--- before any pixel is touched.
+function SoilFertilitySystem:_flushTillageStrip(fieldId, field, pend, cx, cz)
+    local deltas = pend.keys
+    local areaHa = pend.area or 0
+    if areaHa <= 0 then return false end
+
+    local anchor = field._vmLastTillagePt
+    if not anchor then
+        -- First tick of a pass: nothing to sweep from yet, keep the banked area.
+        field._vmLastTillagePt = { x = cx, z = cz }
+        return false
+    end
+
+    local dx, dz  = cx - anchor.x, cz - anchor.z
+    local travel  = math.sqrt(dx * dx + dz * dz)
+
+    -- [SF-24] THE reason BUILD 23:20 painted nothing visible. The value maps are
+    -- ~2 m/px (resolution = terrainSize/2). A work tick advances the tool a few
+    -- centimetres, so the swept quad was a sliver far THINNER THAN ONE PIXEL and
+    -- covered no pixel centres: addPaintStrip still returned a nonzero semantic
+    -- delta, so it looked like it worked, while the map never changed. The old
+    -- 5 m-radius vmLocalBump always covered 5x5 px, which is exactly why the
+    -- original bug was visible stripes and this replacement was invisible.
+    --
+    -- So accumulate: hold the anchor and bank the area until the sweep is at
+    -- least one pixel long, then paint one quad that really covers pixels. Mass
+    -- is preserved because the banked area rides along with the geometry.
+    local mpp = 2.0
+    local vmaps = self.valueMaps
+    if vmaps and (vmaps.terrainSize or 0) > 0 and (vmaps.resolution or 0) > 0 then
+        mpp = vmaps.terrainSize / vmaps.resolution
+    end
+
+    if travel < mpp then
+        -- Not yet a pixel's worth of new ground. Keep the anchor, keep the banked
+        -- area AND keep pend.keys (returning false is what preserves them now).
+        return false
+    end
+    if travel > TILL_TELEPORT_M then
+        -- Teleport or field switch: never span the gap with a huge quad.
+        field._vmLastTillagePt = { x = cx, z = cz }
+        return false
+    end
+
+    local areaM2 = areaHa * 10000
+    -- Width must also clear a pixel, or a narrow tool paints a sub-pixel ribbon
+    -- and disappears the same way. Mass is held by the realArea/quadArea rescale.
+    local width  = math.max(TILL_MIN_WIDTH_M, mpp,
+                            math.min(TILL_MAX_WIDTH_M, areaM2 / travel))
+    local half   = width * 0.5
+    local ux, uz = -dz / travel, dx / travel   -- unit normal to travel
+
+    local sx, sz = anchor.x - ux * half, anchor.z - uz * half
+    local wx, wz = anchor.x + ux * half, anchor.z + uz * half
+    local hx, hz = cx - ux * half,       cz - uz * half
+
+    -- Parallelogram area = |(w-s) x (h-s)| (2D cross), same as paintBoomStrip.
+    local quadM2 = math.abs((wx - sx) * (hz - sz) - (wz - sz) * (hx - sx))
+    if quadM2 < 0.01 then
+        field._vmLastTillagePt = { x = cx, z = cz }
+        return false
+    end
+
+    -- Conserve mass when a clamp made the painted quad differ from the real area.
+    local scale = areaM2 / quadM2
+    local vm = self.valueMaps
+    -- [SF-24] Proof of write. addPaintStrip's return value is NOT evidence: it
+    -- reports the semantic delta it intended even when the region covered no
+    -- pixel centres, which is precisely how 23:20 looked healthy while painting
+    -- nothing. Read a real pixel at the sweep midpoint before and after instead.
+    -- Gate on debugMode itself, not on the function existing: SoilLogger.debug is
+    -- always defined, so testing it would run two pixel reads per key per paint
+    -- for everyone. These reads are diagnostics, not part of the write path.
+    local sfmDbg = g_SoilFertilityManager
+    local dbg = (sfmDbg and sfmDbg.settings and sfmDbg.settings.debugMode) and true or false
+    if dbg then
+        -- [SF-26] Name the WHOLE set being painted. Three rounds were lost to
+        -- reasoning about which keys were in the bucket; this prints it instead.
+        local names = {}
+        for k, v in pairs(deltas) do names[#names + 1] = string.format("%s=%.4f", k, v) end
+        table.sort(names)
+        SoilLogger.debug("[SF-26] flush f%s keys{%s} area=%.5fha travel=%.2fm",
+            tostring(fieldId), table.concat(names, " "), areaHa, travel)
+    end
+    local midX = (anchor.x + cx) * 0.5
+    local midZ = (anchor.z + cz) * 0.5
+    for key, v in pairs(deltas) do
+        if v and v ~= 0 then
+            local before = dbg and vm:readValueAtWorld(key, midX, midZ) or nil
+            local applied = vm:addPaintStrip(key, sx, sz, wx, wz, hx, hz, v * scale)
+            if dbg then
+                local after = vm:readValueAtWorld(key, midX, midZ)
+                SoilLogger.debug(
+                    "[SF-24] tillage strip f%s %s: applied=%.4f pixel %s -> %s (travel %.2fm width %.2fm mpp %.2f)",
+                    tostring(fieldId), tostring(key), applied or 0,
+                    tostring(before), tostring(after), travel, width, mpp)
+            end
+        end
+    end
+
+    field._vmLastTillagePt = { x = cx, z = cz }
+    pend.area = 0   -- consumed by this quad
+    self:_soilMapsMutated()
+    return true
+end
+
 --- Paint the sprayer's real boom strip into the value maps additively as a
 --- SWEPT QUAD (RSF-762). Each frame with a valid dose paints the parallelogram
 --- between the last PAINTED boom line and the current boom line, then advances
@@ -4155,7 +4409,105 @@ end
 ---   derived in the vehicle's own frame (see HookManager:getBoomLineEndpoints).
 ---   When present the painted line runs tip to tip at any heading. The array ends
 ---   are only a defensive fallback for a caller that supplies no line.
-function SoilFertilitySystem:paintBoomStrip(fieldId, boomPoints, _fillTypeName, boomLine)
+--- [FIX-3] World-coordinate vertices of a field's polygon, or nil.
+function SoilFertilitySystem:_fieldPolygonVerts(fieldId)
+    local fsField
+    if g_fieldManager and g_fieldManager.fields then
+        for _, f in ipairs(g_fieldManager.fields) do
+            if f and f.farmland and f.farmland.id == fieldId then fsField = f break end
+        end
+    end
+    if not fsField then return nil end
+    local polyNodes = fsField.polygonPoints
+    if type(fsField.getPolygonPoints) == "function" then
+        local ok, pts = pcall(function() return fsField:getPolygonPoints() end)
+        if ok and pts then polyNodes = pts end
+    end
+    if not polyNodes or #polyNodes == 0 then return nil end
+    local verts = {}
+    for i = 1, #polyNodes do
+        local nodeId = polyNodes[i]
+        if nodeId and nodeId ~= 0 then
+            local ok, wx, _, wz = pcall(getWorldTranslation, nodeId)
+            if ok and wx then verts[#verts + 1] = { x = wx, z = wz } end
+        end
+    end
+    return (#verts >= 3) and verts or nil
+end
+
+
+--- [FIX-3] Make the per-pixel map the single source of truth for a field average.
+---
+--- The scalar used to be its own ledger: applyFertilizer credited it, then the
+--- paint refunded whatever the ground refused. Each step is defensible and the
+--- pair still drifts, because the ledger has no way back to reality. Measured on
+--- field 82 with the map genuinely at 6.5 across 99% of its area, the scalar sat
+--- at 5.606 and would not move -- "offered=1.4038 applied=0.0038" every tick, so
+--- 99.7% of each credit was clawed straight back. The map said Optimal while the
+--- PDA and Soil Monitor said FAIR / IN NEED, because they read different numbers.
+---
+--- Reading the average back off the map removes the second ledger entirely. It is
+--- throttled because it is an engine-side polygon read over the whole field, not
+--- something to do every tick.
+function SoilFertilitySystem:resyncFieldFromMap(fieldId, field, keys)
+    if not field or not self:vmAvailable() then return false end
+    local now = (g_currentMission and g_currentMission.time) or 0
+    if field._lastMapResync and (now - field._lastMapResync) < 3000 then return false end
+
+    local verts = self:_fieldPolygonVerts(fieldId)
+    if not verts then return false end
+    field._lastMapResync = now
+
+    local vm = self.valueMaps
+    local limits = SoilConstants.NUTRIENT_LIMITS
+    local changed = false
+    for _, key in ipairs(keys) do
+        local avg = vm:readAverageOfPolygon(key, verts)
+        -- nil means no written pixels yet: leave the loaded value alone rather
+        -- than stamping a field to zero because nothing has been sprayed on it.
+        if avg ~= nil and type(field[key]) == "number" then
+            if key == "pH" and limits then
+                avg = math.max(limits.PH_MIN or 5.0, math.min(limits.PH_MAX or 7.5, avg))
+            end
+            if math.abs(avg - field[key]) > 0.0005 then
+                field[key] = avg
+                changed = true
+            end
+        end
+    end
+    return changed
+end
+
+
+--- @param capToTarget boolean|nil  true = prescription mode (per-cell, capped at
+---        target); false = flat mode (uniform dose across the boom, over-application
+---        possible). nil defaults to TRUE so existing callers are unchanged.
+---
+--- [GATE] Prescription capping is the variable-rate feature, and it was running
+--- unconditionally -- every machine got per-cell rate control whether the player
+--- had the equipment for it or not. That made the VR toggle do nothing visible and
+--- removed the reason to own the kit. Flat mode is the honest default: one rate
+--- across the whole boom, changed by hand, and yes you can over-lime with it.
+--- [FIX-12] Does a geometric measurement currently own coverage for this field?
+---
+--- The claim used to be a sticky boolean: once a geometric path had measured
+--- once, both fallbacks stood down for the rest of the session. If that path then
+--- stopped running (value maps gone, implement swapped, an early return) coverage
+--- froze silently and nothing took over. A claim that cannot expire is not a
+--- handover, it is a single point of failure.
+---
+--- So it is a timestamp now. Geometry owns coverage only while it is actually
+--- measuring; go quiet for a few seconds and the fallbacks resume on their own.
+function SoilFertilitySystem.geometryOwnsCoverage(field)
+    local stamp = field and field._geometricCoverageOwner
+    if not stamp then return false end
+    if stamp == true then return true end   -- legacy boolean, still honoured
+    local now = (g_currentMission and g_currentMission.time) or 0
+    return (now - stamp) < 5000
+end
+
+function SoilFertilitySystem:paintBoomStrip(fieldId, boomPoints, _fillTypeName, boomLine, capToTarget)
+    if capToTarget == nil then capToTarget = true end
     if not fieldId or not boomPoints or #boomPoints < 2 then return end
     local field = self.fieldData and self.fieldData[fieldId]
     if not field then return end
@@ -4180,9 +4532,73 @@ function SoilFertilitySystem:paintBoomStrip(fieldId, boomPoints, _fillTypeName, 
     local boomLen = math.sqrt((bx - ax) * (bx - ax) + (bz - az) * (bz - az))
     if boomLen < 0.01 then return end
 
+    -- [SF-27] Bank this tick's dose as MASS before any geometry decision, and
+    -- consume sd straight away so the second HookManager site in the same tick
+    -- cannot re-apply it. Whether we paint this frame is a geometry question;
+    -- dropping the dose because the boom has not yet crossed a pixel is the exact
+    -- bug tillage carried until BUILD 00:15, and the boom path had it too.
+    -- Mass (units) rather than concentration (units/ha) is banked, so the quad
+    -- that eventually paints divides by ITS own area and the total stays exact.
+    local pend = field._vmBoomPend
+    if not pend then
+        pend = { mass = {}, area = 0 }
+        field._vmBoomPend = pend
+    end
+    pend.mass = pend.mass or {}
+    pend.scalar = pend.scalar or {}
+    local function bankDose(key, perHa)
+        if perHa and perHa ~= 0 then
+            pend.mass[key] = (pend.mass[key] or 0) + perHa * sd.area
+            -- [SF-32] Bank the FIELD-SCALAR credit too. applyFertilizer added
+            -- exactly `perHa` to field[key] for this tick, so summing it here is
+            -- the only honest record of what the average was given while the
+            -- strip waited to paint. Deriving it later from mass and area gets
+            -- the units wrong by field-area over sprayed-area, which would claw
+            -- the average down enormously.
+            pend.scalar[key] = (pend.scalar[key] or 0) + perHa
+        end
+    end
+    bankDose("nitrogen",      sd.dN)
+    bankDose("phosphorus",    sd.dP)
+    bankDose("potassium",     sd.dK)
+    bankDose("pH",            sd.dPH)
+    bankDose("organicMatter", sd.dOM)
+    pend.area = (pend.area or 0) + sd.area
+    sd.dN, sd.dP, sd.dK, sd.dPH, sd.dOM = 0, 0, 0, 0, 0
+
+    -- Value-map pixel size: a sweep shorter than this covers no pixel centres.
+    local mpp = 2.0
+    local vmaps0 = self.valueMaps
+    if vmaps0 and (vmaps0.terrainSize or 0) > 0 and (vmaps0.resolution or 0) > 0 then
+        mpp = vmaps0.terrainSize / vmaps0.resolution
+    end
+
     local anchor = field._vmLastBoomLine
     local sx, sz, wx, wz, hx, hz
     local areaM2
+    local travel = 0
+
+    -- [SF-38] Resume anchor (George CLOSED DESIGN 09:04). When the helper stops
+    -- and resumes (refill, turn, player takeover), the stale anchor is tens of
+    -- metres behind the boom but still under the 3x-boom teleport guard, so the
+    -- first strip after resume swept a 24-44 m parallelogram and spread one
+    -- tick's dose over it - a near-invisible diluted band, Brian's zero-apply
+    -- gap. More than a second since the last paint means the sweep chain broke:
+    -- reseed the anchor at the current tips, keep the dose banked, and let the
+    -- next moving tick paint a strip of honest size.
+    if anchor and (nowMs - (field._vmLastBoomPaintMs or 0)) > 1000 then
+        field._vmLastBoomLine = { ax = ax, az = az, bx = bx, bz = bz }
+        field._vmLastBoomPaintMs = nowMs
+        return
+    end
+
+    if not anchor then
+        -- First frame of a pass: nothing to sweep from. Seed the anchor and keep
+        -- the dose banked rather than painting a sub-pixel seed strip.
+        field._vmLastBoomLine = { ax = ax, az = az, bx = bx, bz = bz }
+        field._vmLastBoomPaintMs = nowMs
+        return
+    end
 
     if anchor then
         -- Tip-swap guard (RSF-836): the endpoint derivation is unordered, so the
@@ -4195,19 +4611,47 @@ function SoilFertilitySystem:paintBoomStrip(fieldId, boomPoints, _fillTypeName, 
         local dzW = (az - anchor.bz) + (bz - anchor.az)
         local straightSq = dxS * dxS + dzS * dzS
         local swappedSq = dxW * dxW + dzW * dzW
-        local travX, travZ
-        if swappedSq < straightSq then
-            travX = dxW * 0.5
-            travZ = dzW * 0.5
-        else
-            travX = dxS * 0.5
-            travZ = dzS * 0.5
-        end
-        local travel = math.sqrt(travX * travX + travZ * travZ)
-        if travel < 0.05 then
-            anchor = nil   -- no forward progress this frame: seed instead
+        -- [FIX-2] Travel is the FURTHEST either tip moved, not the mean of the two.
+        --
+        -- The mean cancels on a pivot: one tip advances while the other retreats,
+        -- so the lateral components sum to zero and only the centre's crawl
+        -- survives. Modelled on a 54 m boom with the centre advancing 0.30 m, the
+        -- mean reads a flat 0.30 m at 0deg, 5deg and 15deg of pivot -- while the
+        -- tips are actually travelling 0.30 m, 2.39 m and 7.09 m. So on a headland
+        -- turn the 2 m gate below never clears: dose banks tick after tick and then
+        -- lands in one quad, which is why measured per-tick doses ranged from 0.112
+        -- to 6.050 pH -- a 54x spread with no geometric pattern to it.
+        --
+        -- The swept-area formula itself is sound (parallelogram 377.4 m2 vs true
+        -- 379.5 m2 at 15deg, within 0.5%), so it is left alone. Only the gate was
+        -- blind to rotation.
+        -- Pairing is decided HERE rather than trusting straightSq/swappedSq above.
+        -- Those two sum the tip displacements before squaring, and for a pure
+        -- translation both pairings sum to 2x the translation -- identical, so the
+        -- comparison cannot discriminate. Taking whichever pairing yields the
+        -- SMALLER worst-case tip movement is self-correcting: the wrong pairing
+        -- always looks like both tips jumped the width of the boom.
+        local straightTrav = math.max(
+            math.sqrt((ax - anchor.ax) ^ 2 + (az - anchor.az) ^ 2),
+            math.sqrt((bx - anchor.bx) ^ 2 + (bz - anchor.bz) ^ 2))
+        local swappedTrav = math.max(
+            math.sqrt((ax - anchor.bx) ^ 2 + (az - anchor.bz) ^ 2),
+            math.sqrt((bx - anchor.ax) ^ 2 + (bz - anchor.az) ^ 2))
+        travel = math.min(straightTrav, swappedTrav)
+        -- [SF-50] Full-cell gate RESTORED (George CLOSED DESIGN 19:12,
+        -- reverting SF-47's half-step): firing quads every half pixel made
+        -- consecutive strips overlap themselves, double-painting MID-PASS
+        -- ground - the amber in-pass teeth. One quad per pixel of travel means
+        -- a single pass touches each cell once, and only genuine headland /
+        -- lap crossings dose twice.
+        if travel < mpp then
+            -- [SF-27] Not a pixel's worth of new ground yet. Hold the anchor AND
+            -- the banked dose; the first frame that clears the gate paints the lot.
+            return
         elseif travel > boomLen * 3 then
-            anchor = nil   -- teleport: never span the gap, seed fresh
+            -- Teleport or a fresh pass: reseed, keep the dose banked.
+            field._vmLastBoomLine = { ax = ax, az = az, bx = bx, bz = bz }
+            return
         else
             -- Quad between the previous boom line (base) and this one (travel edge).
             sx, sz = anchor.ax, anchor.az
@@ -4218,35 +4662,269 @@ function SoilFertilitySystem:paintBoomStrip(fieldId, boomPoints, _fillTypeName, 
         end
     end
 
-    if anchor == nil then
-        -- Seed: a thin strip centred on the current boom line.
-        local ux, uz = -(bz - az) / boomLen, (bx - ax) / boomLen
-        local h = math.max(0.5, boomLen * 0.02)
-        sx, sz = ax - ux * h, az - uz * h
-        wx, wz = bx - ux * h, bz - uz * h
-        hx, hz = ax + ux * h, az + uz * h
-        areaM2 = boomLen * (h * 2)
+    if not areaM2 or areaM2 < 0.01 then
+        field._vmLastBoomLine = { ax = ax, az = az, bx = bx, bz = bz }
+        return
     end
 
-    local minArea = boomLen * 0.02
-    if areaM2 and areaM2 > minArea then
-        local areaHa = areaM2 / 10000
-        local scale = sd.area / areaHa
-        local vm = self.valueMaps
-        if sd.dN  ~= 0 then vm:addPaintStrip("nitrogen",      sx, sz, wx, wz, hx, hz, sd.dN  * scale) end
-        if sd.dP  ~= 0 then vm:addPaintStrip("phosphorus",    sx, sz, wx, wz, hx, hz, sd.dP  * scale) end
-        if sd.dK  ~= 0 then vm:addPaintStrip("potassium",     sx, sz, wx, wz, hx, hz, sd.dK  * scale) end
-        if sd.dPH ~= 0 then vm:addPaintStrip("pH",            sx, sz, wx, wz, hx, hz, sd.dPH * scale) end
-        if sd.dOM ~= 0 then vm:addPaintStrip("organicMatter", sx, sz, wx, wz, hx, hz, sd.dOM * scale) end
+    local areaHa = areaM2 / 10000
+    local vm     = self.valueMaps
+    local sfmDbg = g_SoilFertilityManager
+    local dbg    = (sfmDbg and sfmDbg.settings and sfmDbg.settings.debugMode) and true or false
+    -- Centroid of the swept quad, for the before/after pixel probe.
+    local midX = (sx + wx + hx) / 3
+    local midZ = (sz + wz + hz) / 3
 
-        -- Advance the anchor to the line this quad actually painted.
-        field._vmLastBoomLine = { ax = ax, az = az, bx = bx, bz = bz }
-        -- Mark a recent boom paint so the narrow-tool dot fallback defers (see applyFertilizer).
-        field._vmBoomPaintTime = nowMs
-        -- Consume so the second HookManager site in the same tick can't re-apply.
-        sd.dN, sd.dP, sd.dK, sd.dPH, sd.dOM = 0, 0, 0, 0, 0
-        local minimapLayer = g_SoilFertilityManager and g_SoilFertilityManager.soilMinimapLayer
-        if minimapLayer then minimapLayer:markDirty() end
+    -- [SF-32] Prescription rule: sense the 2 m cell under the boom and apply
+    -- exactly what THAT cell is short of, nothing more, and nothing at all to a
+    -- cell already at or above target. Replaces the old behaviour of adding the
+    -- same amount everywhere, which could only shift a field's existing pattern
+    -- upward - over-liming the good ground while the poor ground stayed poor.
+    --
+    -- Only quantities with a meaningful ceiling are capped. Organic matter has no
+    -- "enough" in this model, so it stays additive.
+    local vrCfgT   = SoilConstants.VARIABLE_RATE
+    local limitsT  = SoilConstants.NUTRIENT_LIMITS
+    -- [FLAT] What ONE metered pass can physically deliver, per key. A machine
+    -- without rate-control hardware cannot prescribe, but it also cannot put
+    -- down more than flows through it in a single pass: the design figure for
+    -- lime is ~0.40 pH per pass at base rate, so 0.60 allows the 1.5x dial and
+    -- nothing more. This ceiling is what lets flat mode run UNCAPPED-to-target
+    -- safely: overlap accumulates one honest pass at a time (the headland
+    -- double-up a real spreader produces), while a banking hiccup can no
+    -- longer slam a pixel across the whole scale in one tick.
+    -- [SF-47] pH 0.60 -> 0.30 (George CLOSED DESIGN 14:08, confirming the
+    -- floor-vs-fraction fight): with the auto floor pinned at 0.60x, a 0.60
+    -- pass-max let one strip land +0.33 and mid-pass finished at ~6.5, half a
+    -- colour state from the 6.6 ceiling - the uniform plateau. At 0.30 the
+    -- first pass lands ~6.2 pale, overlap ~6.5 visibly brighter, and further
+    -- overlap clamps at ~6.6. Keep in step with AUTO_PASS_MAX in
+    -- SoilFertilityManager.
+    -- [SF-48] pH 0.30 -> 0.40 (George CLOSED DESIGN 15:50): 0.30 kept mid-pass
+    -- and overlap inside the SAME Esc legend band, so the contrast the plateau
+    -- fix bought never showed. At 0.40 a first pass lands ~6.29 (below the
+    -- ~6.5 band edge) and overlap clamps ~6.60 (across it) - the legend does
+    -- the work of showing double coverage.
+    local SF_PASS_MAX = {
+        pH = 0.40, nitrogen = 60, phosphorus = 60, potassium = 60,
+        organicMatter = 2.0,
+    }
+    local SF_TARGETS = {
+        nitrogen   = vrCfgT and vrCfgT.NUTRIENT_TARGET or 70,
+        phosphorus = vrCfgT and vrCfgT.NUTRIENT_TARGET or 70,
+        potassium  = vrCfgT and vrCfgT.NUTRIENT_TARGET or 70,
+        pH         = (limitsT and limitsT.PH_OPTIMAL) or (vrCfgT and vrCfgT.PH_OPTIMAL) or 6.5,
+    }
+    local painted = false
+    for key, mass in pairs(pend.mass) do
+        if mass ~= 0 then
+            -- [SF-27] Concentration for THIS quad = banked mass / this quad's
+            -- area. However many frames the dose waited, the total applied over
+            -- the pass is unchanged, which is the same conservation rule the old
+            -- `sd.dX * (sd.area / areaHa)` expressed for a single frame.
+            local delta   = mass / areaHa
+            local before  = dbg and vm:readValueAtWorld(key, midX, midZ) or nil
+            -- [GATE] No target in flat mode: the dose goes on uniformly and ground
+            -- already at target takes it anyway. That IS the behaviour of a machine
+            -- without rate control, and over-application is the honest consequence.
+            local target  = capToTarget and SF_TARGETS[key] or nil
+            local applied
+            local cappedRun = false
+            if target ~= nil and delta > 0 then
+                -- [SF-32] Per-cell and capped: short cells get what they lack,
+                -- cells at or over target get nothing at all.
+                -- [SF-43] Per-pass physical cap here too (George CLOSED DESIGN
+                -- 12:32): this was the ONLY ToTarget call without it, so a
+                -- banked-dose flush could exceed what one metered pass can put
+                -- down. Same cap, same reason as the flat path below.
+                local passMaxP = SF_PASS_MAX[key]
+                if passMaxP and delta > passMaxP then delta = passMaxP end
+                applied = vm:addPaintStripToTarget(key, sx, sz, wx, wz, hx, hz, delta, target)
+                cappedRun = true
+            else
+                -- [SF-36] Flat broadcast is ADDITIVE again (George CLOSED DESIGN
+                -- 07:03, reverting the SF-35 target ceiling). The moving ceiling
+                -- skipped cells already near target, which painted random yellow
+                -- rectangular HOLES into an otherwise limed field - and Wizard's
+                -- lock is that overlap must double-lime like a real spreader:
+                -- headlands and lap joints running hotter is a PASS, not a bug.
+                -- So the dose lands uniformly and accumulates. The one thing that
+                -- must never survive is the [SF-30] saturation band parking pH
+                -- pixels at RAW_MAX (decodes 7.5, sticks forever): the sentinel
+                -- repair below pulls exactly those pixels back to the agronomic
+                -- target and touches nothing else, so it cannot re-create the
+                -- skip-holes.
+                local passMax = SF_PASS_MAX[key]
+                if passMax and delta > passMax then delta = passMax end
+                if key == "pH" and SF_TARGETS.pH then
+                    -- [SF-40] Flat pH paints ToTarget at PH_TARGET + 0.3 (~6.8)
+                    -- (George CLOSED DESIGN 10:41, superseding 09:48's bare
+                    -- addPaintStrip). The bare add let the [SF-30] saturation
+                    -- band slam a mid-pass 6.44 cell straight to 7.5 Over-limed
+                    -- in one tick (TEST 10:03). With the 6.8 ceiling: needy 5.9
+                    -- ground takes the full delta, cells at target still absorb
+                    -- overlap up to 6.8 (visibly brighter than ~6.5 mid-pass,
+                    -- and NOT the yellow holes - those came from ceiling AT
+                    -- target, where at-target cells took nothing), and nothing
+                    -- can reach RAW_MAX, so no sentinel is needed.
+                    -- [SF-42] soft ceiling lowered +0.3 -> +0.1 (~6.6, George
+                    -- CLOSED DESIGN 11:23): at 6.8 the whole field plateaued
+                    -- uniformly bright. With ~6.6 and the 0.50 fraction, a first
+                    -- pass lands ~6.2-6.3 pale and only overlap climbs to the
+                    -- ceiling, so heat marks actual double-coverage.
+                    -- [SF-45] ToTarget DROPPED from the flat path (George TRACE
+                    -- DESIGN 13:32; smoking gun offered=0.60 applied=0.71).
+                    -- ToTarget's Pass 2 re-processes the very pixels Pass 1 just
+                    -- moved: a 5.90 cell took +0.60, landed inside the fill
+                    -- band, and was SET to 6.60 - +0.70 total, past the
+                    -- physical cap. My BUILD 13:17 boundedness argument treated
+                    -- the two passes as disjoint; the log proved otherwise.
+                    -- A capped add followed by a ceiling CLAMP cannot compound:
+                    -- applied equals offered, and the clamp only pulls DOWN.
+                    applied = vm:addPaintStrip(key, sx, sz, wx, wz, hx, hz, delta)
+                    -- [SF-50] Headroom +0.1 -> +0.5 (~7.0; George CLOSED DESIGN
+                    -- 19:12): with the 6.6 lid, a genuine headland double
+                    -- (6.29 + 0.40 = 6.69) clamped down to the same tint as a
+                    -- near-target single. At ~7.0 the true double keeps its
+                    -- 6.69 and reads distinctly hotter, while the ceiling still
+                    -- sits under the 7.5 Over-limed line.
+                    vm:clampCeilingInStrip(key, sx, sz, wx, wz, hx, hz, SF_TARGETS.pH + 0.5)
+                else
+                    -- Other keys: additive. Nutrient RAW_MAX decodes to 100,
+                    -- which is genuinely "full" and legitimate to hold.
+                    applied = vm:addPaintStrip(key, sx, sz, wx, wz, hx, hz, delta)
+                end
+            end
+            if cappedRun then
+                -- Hand back whatever the ground refused. applyFertilizer already
+                -- credited the field scalar with the FULL offered dose; without
+                -- this the average climbs while the map stays put -- the exact
+                -- scalar-versus-map split SF-32 exists to close. Refund the same
+                -- FRACTION the ground refused against the credit the scalar
+                -- actually received: ratio, not derived mass, so units cannot
+                -- drift apart.
+                local credited = pend.scalar and pend.scalar[key]
+                if credited and credited > 0 and type(field[key]) == "number" and delta > 0 then
+                    local takenFrac = math.max(0, math.min(1, (applied or 0) / delta))
+                    local refund    = credited * (1 - takenFrac)
+                    if refund > 0 then
+                        field[key] = math.max(0, field[key] - refund)
+                    end
+                end
+            end
+            painted = true
+            if dbg then
+                local after = vm:readValueAtWorld(key, midX, midZ)
+                -- [SF-47] raw-step comparison (George item B): offered vs applied
+                -- differing by under one unitsPerRaw is quantisation, not a bug.
+                -- Equal raw integers = clean strip; the ±1-UPR judgement is now
+                -- readable straight off the line.
+                local dbgEntry  = vm.getLayerEntry and vm:getLayerEntry(key)
+                local dbgSpan   = (SoilValueMaps and SoilValueMaps.RAW_SPAN) or 254
+                local dbgUpr    = (dbgEntry and dbgEntry.def)
+                                  and ((dbgEntry.def.maxVal - dbgEntry.def.minVal) / dbgSpan) or 1
+                local dbgOffRaw = math.floor(delta / dbgUpr)
+                local dbgAppRaw = math.floor((applied or 0) / dbgUpr + 0.5)
+                SoilLogger.debug(
+                    "[SF-32] boom strip f%s %s: offered=%.4f applied=%.4f offeredRaw=%d appliedRaw=%d target=%s pixel %s -> %s (travel %.2fm boom %.2fm quad %.1fm2)",
+                    tostring(fieldId), tostring(key), delta, applied or 0,
+                    dbgOffRaw, dbgAppRaw, tostring(target),
+                    tostring(before), tostring(after), travel, boomLen, areaM2)
+            end
+        end
+    end
+
+    -- Advance the anchor to the line this quad actually painted.
+    field._vmLastBoomLine = { ax = ax, az = az, bx = bx, bz = bz }
+    field._vmLastBoomPaintMs = nowMs   -- [SF-38] the resume gate measures from here
+    -- (the narrow-tool dot fallback now defers via geometryOwnsCoverage; the old
+    -- _vmBoomPaintTime timestamp had no remaining readers and was removed)
+    -- [FIX-6] Coverage from the TRUE swept area, measured here.
+    --
+    -- markBoomCells credits whole 10 m cells, and a 24 m boom always touches three
+    -- of them -- 30 m of credit for 24 m of machine -- with the same rounding again
+    -- longitudinally every time 2 m of travel tips into a new row. Measured on
+    -- field 82: 820 strips x 2 m x 23.99 m boom = 3.93 ha actually driven, reported
+    -- as 7.60 ha. Whole-cell counting cannot measure a boom that is not a multiple
+    -- of the cell size; it is fine for dedup, wrong for area.
+    --
+    -- areaM2 above is the real swept quad for this strip, so accumulate that. Cells
+    -- keep doing what they are good at: remembering where we have already been.
+    if painted and areaM2 and areaM2 > 0 then
+        local fieldHa = (field.fieldArea and field.fieldArea > 0) and field.fieldArea or nil
+        if fieldHa then
+            field._geometricCoverageOwner = (g_currentMission and g_currentMission.time) or true
+
+            -- [FIX-10] Dedup at the SAME resolution as the strip.
+            --
+            -- FIX-7 deduped against the 10 m zone cells while crediting 2 m strips,
+            -- and the units did not match: advancing 2 m usually enters no new 10 m
+            -- cell, so four strips in five earned nothing. Measured: 322 strips of
+            -- ~49 m2, 1.58 ha genuinely swept, credited as 0.03 ha. An 80% loss,
+            -- exactly (10 - 2) / 10.
+            --
+            -- The map is 2 m/px and the strip advances 2 m, so dedup on a 2 m grid.
+            -- Each cell is then 4 m2 and a 24 m boom advancing 2 m is 12 cells = 48 m2,
+            -- which is the real swept area with no rounding either way. One field
+            -- being worked is about 21k entries, cleared with the session.
+            local CELL = 2.0
+            local CELL_M2 = CELL * CELL
+            field._covCells2m = field._covCells2m or {}
+            local seen = field._covCells2m
+            local freshCells = 0
+
+            -- Walk the swept quad's leading edge at 2 m: the boom line this tick.
+            local ex, ez = hx - sx, hz - sz          -- travel edge
+            local bxv, bzv = wx - sx, wz - sz        -- boom edge
+            local boomLen2 = math.sqrt(bxv * bxv + bzv * bzv)
+            local steps = math.max(1, math.ceil(boomLen2 / CELL))
+            for i = 0, steps do
+                local f = (steps > 0) and (i / steps) or 0
+                -- midpoint between the previous and current boom line, so a fast
+                -- tick still stamps the ground it actually crossed.
+                local px = sx + bxv * f + ex * 0.5
+                local pz = sz + bzv * f + ez * 0.5
+                local key = math.floor(px / CELL) * 100000 + math.floor(pz / CELL)
+                if not seen[key] then
+                    seen[key] = true
+                    freshCells = freshCells + 1
+                end
+            end
+
+            local addM2 = freshCells * CELL_M2
+            -- Never claim more than the quad actually swept.
+            if addM2 > areaM2 then addM2 = areaM2 end
+            local newFrac = (areaM2 > 0) and (addM2 / areaM2) or 0
+            if newFrac > 0 then
+                local addHa = (areaM2 / 10000) * newFrac
+                field.sessionCoverageHa = math.min(fieldHa,
+                    (field.sessionCoverageHa or 0) + addHa)
+                field.sessionCoverageFraction = math.min(1.0, field.sessionCoverageHa / fieldHa)
+                field.coveredAreaHa = math.min(fieldHa,
+                    (field.coveredAreaHa or 0) + addHa)
+                field.coverageFraction = math.min(1.0, field.coveredAreaHa / fieldHa)
+            end
+        end
+    end
+
+    -- [FIX-3] Pull the field average back off the map now that this strip has
+    -- landed, so the scalar the PDA and Soil Monitor read cannot drift away from
+    -- the pixels the player is looking at. Throttled inside; keys are the ones
+    -- this pass actually touched.
+    if painted then
+        local resyncKeys = {}
+        for key in pairs(pend.mass) do resyncKeys[#resyncKeys + 1] = key end
+        if #resyncKeys > 0 then
+            self:resyncFieldFromMap(fieldId, field, resyncKeys)
+        end
+    end
+    pend.mass   = {}
+    pend.scalar = {}
+    pend.area   = 0
+    if painted then
+        -- [SF-23] Same staleness signal as tillage: minimap dirty AND the PDA
+        -- flagged, so a spray pass shows on Esc without waiting out the 3 s timer.
+        self:_soilMapsMutated()
     end
 end
 
@@ -4361,27 +5039,6 @@ end
 --- converted field settles. Opt-in per field, so normal crops are never touched. The
 --- shared daily housekeeping (buffer/coverage/freeze reset, compaction decay) runs in
 --- _processOneDailyField before this is called. Coefficients live in SoilConstants.MEADOW.
---- SF-56: read the engine's PLOW_LEVEL / STUBBLE_SHRED_LEVEL at (x,z) and
---- return the decomposition multiplier for that cell's tillage class.
---- plowed > 0: 1.0, stubble > 0 (plow not fresher): 0.8, neither: 0.6.
---- Returns 1.0 (the baseline identity) when the read fails or is unavailable.
----@param x number
----@param z number
----@return number multiplier
-function SoilFertilitySystem:_tillageDecompMult(x, z)
-    local fgs = g_currentMission and g_currentMission.fieldGroundSystem
-    if not fgs or not FieldDensityMap then return 1.0 end
-    local td = SoilConstants.OM_DYNAMICS and SoilConstants.OM_DYNAMICS.TILLAGE_DECOMPOSITION
-    if not td then return 1.0 end
-    local ok1, plow = pcall(fgs.getValueAtWorldPos, fgs, FieldDensityMap.PLOW_LEVEL, x, 0, z)
-    local ok2, stub = pcall(fgs.getValueAtWorldPos, fgs, FieldDensityMap.STUBBLE_SHRED_LEVEL, x, 0, z)
-    if not ok1 then plow = 0 end
-    if not ok2 then stub = 0 end
-    if (plow or 0) > 0 then return td.PLOWED or 1.0 end
-    if (stub or 0) > 0 then return td.STUBBLE or 0.8 end
-    return td.UNTILLED or 0.6
-end
-
 ---@param field table
 ---@param timeFactor number  1 / daysPerMonth (Issue #349 month normalization)
 ---@param limits table       SoilConstants.NUTRIENT_LIMITS
@@ -4534,6 +5191,7 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     field.sessionCoverageHa       = 0
     field.sessionCoverageFraction = 0
     field.sessionCoverageCells    = {}
+    field._covCells2m             = {}   -- [FIX-10] same lifetime
     field.sessionLastProduct      = nil
     field._geometricCoverageOwner = nil  -- #753
     field.sprayTrailPts           = nil
@@ -4580,13 +5238,6 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
         return
     end
 
-    -- ── SF-56: tillage-class decomposition multiplier ──────────────────────
-    local fsField = self:_findFieldObject(fieldId)
-    local tillMult = 1.0
-    if fsField and fsField.posX and fsField.posZ then
-        tillMult = self:_tillageDecompMult(fsField.posX, fsField.posZ)
-    end
-
     -- ── Passive organic-matter oxidation (#695) ──────────────────────────────
     -- Humus oxidizes continuously; without organic returns OM slowly declines. Fallow
     -- recovery (below) adds it back so an idle field still nets positive (+0.005/day),
@@ -4596,7 +5247,7 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     local omDyn = SoilConstants.OM_DYNAMICS
     if omDyn and (omDyn.DAILY_DECAY or 0) > 0 then
         local om = field.organicMatter or SoilConstants.FIELD_DEFAULTS.organicMatter
-        field.organicMatter = math.max(omDyn.DECAY_FLOOR or 0, om - omDyn.DAILY_DECAY * tillMult * timeFactor)
+        field.organicMatter = math.max(omDyn.DECAY_FLOOR or 0, om - omDyn.DAILY_DECAY * timeFactor)
     end
 
     -- ── Fallow recovery ──────────────────────────────────────────────────────
@@ -4724,6 +5375,7 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
                     field.sessionCoverageHa       = 0
                     field.sessionCoverageFraction = 0
                     field.sessionCoverageCells    = {}
+                    field._covCells2m             = {}   -- [FIX-10] same lifetime
                     field.sessionLastProduct      = nil
                     field._geometricCoverageOwner = nil  -- #753
                     field.sprayTrailPts           = nil
@@ -5665,9 +6317,19 @@ function SoilFertilitySystem:applyFertilizer(fieldId, fillTypeIndex, liters)
         -- sprayer), so it can't restamp the field average over the correct strip.
         local sprayX = self._lastSprayX
         local sprayZ = self._lastSprayZ
-        local boomRecent = field._vmBoomPaintTime ~= nil
-            and (now - field._vmBoomPaintTime) >= 0 and (now - field._vmBoomPaintTime) < 500
-        if sprayX and sprayZ and self:vmAvailable() and not boomRecent then
+        -- [FIX-18] Defer to boom geometry over a 5 s window, not 500 ms.
+        --
+        -- Boom paints land every ~2 m of travel, which at spreading speed is every
+        -- ~500 ms -- exactly this window. So the dot fired in the gaps BETWEEN
+        -- paints and stamped the FIELD AVERAGE in a 2.5 m blob at the tractor's
+        -- own position: a speckled band of wrong values down the centre of every
+        -- pass, worse in turns where banking widens the gaps. The question this
+        -- gate should ask is "does a boom measure this field at all", and that is
+        -- what the geometry-ownership window already answers. A genuinely narrow
+        -- tool never boom-paints, so the dot still runs for the machines it was
+        -- written for.
+        local boomOwns = SoilFertilitySystem.geometryOwnsCoverage(field)
+        if sprayX and sprayZ and self:vmAvailable() and not boomOwns then
             local vm = self.valueMaps
             if entry.N  then vm:writeValueAtWorld("nitrogen",      sprayX, sprayZ, field.nitrogen,      2.5) end
             if entry.P  then vm:writeValueAtWorld("phosphorus",    sprayX, sprayZ, field.phosphorus,    2.5) end
@@ -5888,16 +6550,38 @@ end
 ---@param liters         number   Raw liters consumed this tick (pre-rateMultiplier)
 ---@param fillTypeName   string|nil
 ---@param updateFractions boolean|nil  false = skip area update, only record product name
-function SoilFertilitySystem:trackSprayerCoverage(fieldId, liters, fillTypeName, updateFractions)
+function SoilFertilitySystem:trackSprayerCoverage(fieldId, liters, fillTypeName, updateFractions, rateMult)
     if not liters or liters <= 0 then return end
     local field = self.fieldData[fieldId]
     if not field then return end
 
     -- Reset session coverage when the product changes (issue #442)
+    --
+    -- [FIX-9] ...but only on a change that STICKS. The fill-type read is not
+    -- perfectly stable: over one measured run it returned LIME 38,981 times and
+    -- something else 3 times, and a single stray reading was enough to wipe the
+    -- counter and its cell memory mid-field. The player saw 5% on a field they had
+    -- just finished, because everything before the blip had been thrown away.
+    --
+    -- Requiring the new product twice in a row costs one tick of latency on a
+    -- genuine change and makes a one-frame misread harmless.
+    local productChanged = false
     if fillTypeName and field.sessionLastProduct and fillTypeName ~= field.sessionLastProduct then
+        if field._pendingProduct == fillTypeName then
+            productChanged = true          -- seen twice: believe it
+            field._pendingProduct = nil
+        else
+            field._pendingProduct = fillTypeName   -- first sighting: wait and see
+        end
+    elseif fillTypeName == field.sessionLastProduct then
+        field._pendingProduct = nil        -- back to normal, forget the blip
+    end
+
+    if productChanged then
         field.sessionCoverageHa       = 0
         field.sessionCoverageFraction = 0
         field.sessionCoverageCells    = {}
+        field._covCells2m             = {}   -- [FIX-10] same lifetime
         field._geometricCoverageOwner = nil  -- #753: re-detect geometric path for new product
         field.sprayTrailPts           = nil
     end
@@ -5913,7 +6597,7 @@ function SoilFertilitySystem:trackSprayerCoverage(fieldId, liters, fillTypeName,
     -- double-counts and pins Pass% at 100% (#726). Use _geometricCoverageOwner
     -- instead of sessionCoverageCells, because overlayOnly mode populates cells for
     -- spray trail dedup but does NOT update coverage fractions (#753).
-    if field._geometricCoverageOwner then return end
+    if SoilFertilitySystem.geometryOwnsCoverage(field) then return end
 
     -- Crop protection fallback: liter-based area estimate (no boom position available).
     local areaInHa = (field.fieldArea and field.fieldArea > 0) and field.fieldArea or 1.0
@@ -5922,7 +6606,13 @@ function SoilFertilitySystem:trackSprayerCoverage(fieldId, liters, fillTypeName,
     local rateEntry = fillTypeName and baseRates and (baseRates[fillTypeName] or baseRates.DEFAULT)
     local ratePerHa = (rateEntry and rateEntry.value and rateEntry.value > 0) and rateEntry.value or 93.5
 
-    local areaThisTick = liters / ratePerHa
+    -- [FIX-13] Divide by the rate actually set on the dial, not the base rate.
+    -- The estimate assumed 374 L/ha regardless of the multiplier, so at 0.5x
+    -- (half the lime per hectare) it reported half the true area, and at 2.0x
+    -- double. Wrong whenever the dial is off 1.0x, which with auto-rate is
+    -- nearly always.
+    local effRate = ratePerHa * math.max(0.05, tonumber(rateMult) or 1.0)
+    local areaThisTick = liters / effRate
     field.coveredAreaHa = (field.coveredAreaHa or 0) + areaThisTick
 
     local prevCoverage = field.coverageFraction or 0
@@ -5944,6 +6634,123 @@ end
 --- Used to bound coverage + overlay stamping to the actual field polygon so that
 --- wide-boom overhang past the headland and turn-row sweeps can't credit off-field
 --- cells (which previously pushed pass% to 100% before the field was done).
+-- [SF-33] Spatial rollup for the Treatment Plan.
+--
+-- The plan used to read field SCALAR averages while the map and tooltip read the
+-- ~2 m value maps, so the two disagreed and players learned to ignore the plan.
+-- This samples the same maps the picture is drawn from, so one truth feeds both.
+--
+-- SAMPLE CAP is George's constraint on DESIGN 16:58: a 2 m grid over a very large
+-- field is hundreds of thousands of reads and would hitch the Esc PDA on open.
+-- The step scales up adaptively to hold the count near the cap, so a big field
+-- loses resolution rather than costing the player a freeze.
+local SPATIAL_MAX_SAMPLES = 50000
+local SPATIAL_BASE_STEP   = 2.0     -- one value-map pixel
+
+-- pH is not a "more is better" quantity, so it needs its own bands rather than
+-- STATUS_THRESHOLDS: too acid is a problem AND too alkaline is a problem.
+local SPATIAL_PH_POOR       = 6.0
+local SPATIAL_PH_FAIR       = 6.5   -- PH_OPTIMAL
+local SPATIAL_PH_OVER_LIMED = 7.2
+
+--- Sample a field's value maps on a grid and roll the cells up per nutrient.
+--- Cells with no data (raw 0) are skipped and do NOT count toward the
+--- denominator, so a partly-seeded field reports on what it actually knows.
+---@param fieldId number
+---@return table|nil  { [key] = { mean, worst, pctBelowPoor, pctBelowFair,
+---                               pctOverLimed, sampleCount }, _step, _samples }
+function SoilFertilitySystem:getFieldSpatialSummary(fieldId)
+    if not fieldId or fieldId <= 0 then return nil end
+    if not self.vmAvailable or not self:vmAvailable() then return nil end
+    local field = self.fieldData and self.fieldData[fieldId]
+    if not field then return nil end
+
+    -- Cache until the maps are written again. _soilMapsMutated bumps the
+    -- generation, so a spray or a tillage pass invalidates this for free.
+    local gen = self._vmWriteGen or 0
+    local cached = field._spatialSummary
+    if cached and cached.gen == gen then return cached.data end
+
+    local verts = self:_getFieldPolyVerts(fieldId, field)
+    if not verts or #verts < 3 then return nil end
+
+    local minX, maxX = math.huge, -math.huge
+    local minZ, maxZ = math.huge, -math.huge
+    for _, v in ipairs(verts) do
+        if v.x < minX then minX = v.x end
+        if v.x > maxX then maxX = v.x end
+        if v.z < minZ then minZ = v.z end
+        if v.z > maxZ then maxZ = v.z end
+    end
+    local wid, hgt = maxX - minX, maxZ - minZ
+    if wid <= 0 or hgt <= 0 then return nil end
+
+    local step = SPATIAL_BASE_STEP
+    local estimate = (wid / step) * (hgt / step)
+    if estimate > SPATIAL_MAX_SAMPLES then
+        step = step * math.sqrt(estimate / SPATIAL_MAX_SAMPLES)
+    end
+
+    local KEYS = { "nitrogen", "phosphorus", "potassium", "pH", "organicMatter" }
+    local acc = {}
+    for _, k in ipairs(KEYS) do
+        acc[k] = { sum = 0, n = 0, worst = nil, poor = 0, fair = 0, over = 0 }
+    end
+
+    local vm = self.valueMaps
+    local inField = 0
+    local z = minZ
+    while z <= maxZ do
+        local x = minX
+        while x <= maxX do
+            if _isPointInPoly(x, z, verts) then
+                inField = inField + 1
+                for _, k in ipairs(KEYS) do
+                    local v = vm:readValueAtWorld(k, x, z)
+                    if v ~= nil then
+                        local a = acc[k]
+                        a.sum = a.sum + v
+                        a.n   = a.n + 1
+                        if a.worst == nil or v < a.worst then a.worst = v end
+                        if k == "pH" then
+                            if v < SPATIAL_PH_POOR then a.poor = a.poor + 1 end
+                            if v < SPATIAL_PH_FAIR then a.fair = a.fair + 1 end
+                            if v > SPATIAL_PH_OVER_LIMED then a.over = a.over + 1 end
+                        else
+                            local th = SoilConstants.STATUS_THRESHOLDS
+                                       and SoilConstants.STATUS_THRESHOLDS[k]
+                            if th then
+                                if v < th.poor then a.poor = a.poor + 1 end
+                                if v < th.fair then a.fair = a.fair + 1 end
+                            end
+                        end
+                    end
+                end
+            end
+            x = x + step
+        end
+        z = z + step
+    end
+
+    local out = { _step = step, _samples = inField }
+    for _, k in ipairs(KEYS) do
+        local a = acc[k]
+        if a.n > 0 then
+            out[k] = {
+                mean         = a.sum / a.n,
+                worst        = a.worst,
+                pctBelowPoor = (a.poor / a.n) * 100,
+                pctBelowFair = (a.fair / a.n) * 100,
+                pctOverLimed = (a.over / a.n) * 100,
+                sampleCount  = a.n,
+            }
+        end
+    end
+
+    field._spatialSummary = { gen = gen, data = out }
+    return out
+end
+
 --- Resolved once per field and cached on field._polyVerts:
 ---   • a verts array (>=3 points) when the polygon is available
 ---   • false when it is not (caller falls back to counting every cell)
@@ -6019,6 +6826,7 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints, overlayOnly)
     local polyVerts = self:_getFieldPolyVerts(fieldId, field)
 
     if not field.sessionCoverageCells then field.sessionCoverageCells = {} end
+    if not field._covCells2m          then field._covCells2m          = {} end
     if not field.dailyCoverageCells   then field.dailyCoverageCells   = {} end
     if not field.zoneData             then field.zoneData             = {} end
 
@@ -6049,7 +6857,13 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints, overlayOnly)
                 if not field.sessionCoverageCells[cellKey] then
                     field.sessionCoverageCells[cellKey] = (g_currentMission and g_currentMission.time) or 0
                     if not overlayOnly then
-                        field.sessionCoverageHa = math.min(areaInHa, (field.sessionCoverageHa or 0) + cellArea)
+                        -- [FIX-6] Only when nothing better is measuring. paintBoomStrip
+                        -- runs first and accumulates the true swept area; adding whole
+                        -- cells on top of that would double-count. Cells still do the
+                        -- dedup and the spray-trail overlay either way.
+                        if not SoilFertilitySystem.geometryOwnsCoverage(field) then
+                            field.sessionCoverageHa = math.min(areaInHa, (field.sessionCoverageHa or 0) + cellArea)
+                        end
                     end
                     -- ── Spray trail (in-view overlay) ──────────────────────────────
                     -- Cache world-center + terrain height for SoilHUD:drawSprayTrail().
@@ -6063,7 +6877,15 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints, overlayOnly)
                 end
                 if not overlayOnly and not field.dailyCoverageCells[cellKey] then
                     field.dailyCoverageCells[cellKey] = true
-                    field.coveredAreaHa = math.min(areaInHa, (field.coveredAreaHa or 0) + cellArea)
+                    -- [FIX-11] Same guard as its sessionCoverageHa twin above, which
+                    -- FIX-6 fixed while missing this line right beside it. Left
+                    -- unguarded, whole 10 m cells were added ON TOP of the geometric
+                    -- measurement, so Coverage read 96% while Pass read 46% for the
+                    -- same driving. The completion notice reads Coverage, which is why
+                    -- it fired on a field that was under half done.
+                    if not SoilFertilitySystem.geometryOwnsCoverage(field) then
+                        field.coveredAreaHa = math.min(areaInHa, (field.coveredAreaHa or 0) + cellArea)
+                    end
                 end
 
                 -- ── Pressure zone stamp (zoneData) ─────────────────────────────────
@@ -6140,7 +6962,7 @@ function SoilFertilitySystem:markBoomCells(fieldId, boomPoints, overlayOnly)
         -- next() is O(1) and sessionCoverageCells is already cleared at every site that
         -- clears _geometricCoverageOwner, so this needs no new state to keep in sync.
         if next(field.sessionCoverageCells) ~= nil then
-            field._geometricCoverageOwner = true
+            field._geometricCoverageOwner = (g_currentMission and g_currentMission.time) or true
         end
         field.coverageFraction        = math.min(1.0, (field.coveredAreaHa  or 0) / areaInHa)
         field.sessionCoverageFraction = math.min(1.0, (field.sessionCoverageHa or 0) / areaInHa)

--- a/src/SoilSensorManager.lua
+++ b/src/SoilSensorManager.lua
@@ -30,7 +30,23 @@ function SoilSensorManager.new()
     self.variableRate = {}
     -- System 3: per-section rate cache - vehicleId → { [sectionRef] = multiplier }
     self.sectionRates = {}
+    -- [SF-28] System 3 TOTAL demand - vehicleId → mean of this pass's section rates.
+    -- sectionRates are redistribution weights and deliberately preserve the total
+    -- (see HookManager #555). This is the separate number that lets the total
+    -- itself fall on ground already at target, so the TANK draws less rather than
+    -- the same product being shuffled toward deficit sections.
+    self.vrDemand = {}
     return self
+end
+
+--- [SF-28] Store the mean section rate for this pass (1.0 = no change to usage).
+function SoilSensorManager:setVrDemand(vehicleId, demand)
+    self.vrDemand[vehicleId] = demand
+end
+
+--- [SF-28] Mean section rate, or 1.0 when variable rate is not driving this vehicle.
+function SoilSensorManager:getVrDemand(vehicleId)
+    return self.vrDemand[vehicleId] or 1.0
 end
 
 --- Returns (creating if needed) the sensor state table for a vehicle.
@@ -126,6 +142,9 @@ end
 --- Clears per-section rates for a vehicle (call at start of each tick).
 function SoilSensorManager:clearSectionRates(vehicleId)
     self.sectionRates[vehicleId] = nil
+    -- [SF-28] Drop the total demand too, so a vehicle that stops running variable
+    -- rate goes straight back to full tank usage instead of holding a stale cut.
+    self.vrDemand[vehicleId] = nil
 end
 
 -- ── Lifecycle ─────────────────────────────────────────────
@@ -135,4 +154,5 @@ function SoilSensorManager:delete()
     self.vehicleSensors = {}
     self.variableRate   = {}
     self.sectionRates   = {}
+    self.vrDemand       = {}   -- [SF-28] clear with the rest, not left behind
 end

--- a/src/SpatialScouting.lua
+++ b/src/SpatialScouting.lua
@@ -53,6 +53,36 @@ function SpatialScouting.cellKey(worldX, worldZ)
     return tostring(cx * 10000 + cz)
 end
 
+-- =========================================================
+-- [SF-22] FARM-PRIVATE AUTHORISATION (pure, testable)
+-- =========================================================
+
+--- An ordinary farm is one of the eight playable farms. The base game pins the
+--- range at FarmManager: SPECTATOR 0, MAX_NUM_FARMS 8, GUIDED_TOUR 14, INVALID
+--- 15. Spectator, guided-tour, invalid, nil and any non-integer reject - only an
+--- ordinary farm may own walked knowledge.
+---@param farmId any
+---@return boolean
+function SpatialScouting.isOrdinaryFarmId(farmId)
+    return type(farmId) == "number"
+        and farmId == math.floor(farmId)
+        and farmId >= 1
+        and farmId <= 8
+end
+
+--- The reveal gate (LAW 2, farm-private). A walk or kneel may write a cell only
+--- when the walking farm owns the land, or is actively contracting the owner's
+--- land. Both ids must be ordinary; an unrelated neighbour reveals nothing.
+---@param playerFarmId any         the walking player's farm (server player record)
+---@param ownerFarmId any          g_farmlandManager:getFarmlandOwner(farmlandId)
+---@param contractingForOwner any  farm:getIsContractingFor(ownerFarmId)
+---@return boolean
+function SpatialScouting.isRevealAuthorized(playerFarmId, ownerFarmId, contractingForOwner)
+    if not SpatialScouting.isOrdinaryFarmId(playerFarmId) then return false end
+    if not SpatialScouting.isOrdinaryFarmId(ownerFarmId) then return false end
+    return playerFarmId == ownerFarmId or contractingForOwner == true
+end
+
 function SpatialScouting.new()
     return setmetatable({
         armed = false,
@@ -137,8 +167,18 @@ function SpatialScouting:noteWalk(farmId, fieldId, cellKey, day, truth, worldX, 
     local field = farm[fieldId]
     if field == nil then field = {}; farm[fieldId] = field end
     local gen = (self.generations[farmId] or {})[fieldId] or 0
-    field[cellKey] = { day = day or 0, truth = truth or 0, x = worldX, z = worldZ, gen = gen }
-    return true
+    -- [SF-22] Report transport-dirty ONLY on a material change: a new cell, or a
+    -- changed walk day, sampled truth or knowledge generation. A re-walk of the
+    -- same cell on the same day with the same truth and generation writes the
+    -- same bytes and must not put a DELTA on the wire.
+    local newDay, newTruth = day or 0, truth or 0
+    local prev = field[cellKey]
+    local changed = prev == nil
+        or prev.day ~= newDay
+        or prev.truth ~= newTruth
+        or (prev.gen or 0) ~= gen
+    field[cellKey] = { day = newDay, truth = newTruth, x = worldX, z = worldZ, gen = gen }
+    return changed
 end
 
 --- THE KNOWLEDGE-GENERATION BOOKKEEPING (acceptance criterion 4). The mask must
@@ -367,15 +407,79 @@ end
 -- The sampler (server-side, on foot only, LAW 1 + LAW 4)
 -- =========================================================
 
+--- Resolve the farmland id under a world position, server-side (LAW 4), from the
+--- authoritative world and never from a client-reported cell. The walked mask
+--- keys on the farmland id, so this is the field key a walk or kneel fills.
+---@param x number
+---@param z number
+---@return number|nil farmlandId
+function SpatialScouting:_resolveFarmlandAt(x, z)
+    local fieldId
+    if g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function" then
+        local ok, f = pcall(function() return g_fieldManager:getFieldAtWorldPosition(x, z) end)
+        if ok and f and f.farmland and f.farmland.id then fieldId = f.farmland.id end
+    end
+    if not fieldId and g_farmlandManager and type(g_farmlandManager.getFarmlandAtWorldPosition) == "function" then
+        local ok, land = pcall(function() return g_farmlandManager:getFarmlandAtWorldPosition(x, z) end)
+        if ok and land and land.id and land.id > 0 then fieldId = land.id end
+    end
+    return fieldId
+end
+
+--- [SF-22] Is a farm allowed to reveal this land? Resolves the land owner and
+--- the walking farm's contract state server-side, then applies the reveal gate.
+--- Every id is the server's own truth; nothing is taken from the wire.
+---@param playerFarmId number  the walking farm (already known ordinary)
+---@param farmlandId number
+---@return boolean
+function SpatialScouting._isWalkAuthorized(playerFarmId, farmlandId)
+    local ownerFarmId = nil
+    if g_farmlandManager and type(g_farmlandManager.getFarmlandOwner) == "function" then
+        local ok, owner = pcall(function() return g_farmlandManager:getFarmlandOwner(farmlandId) end)
+        if ok then ownerFarmId = owner end
+    end
+    local contractingForOwner = false
+    if SpatialScouting.isOrdinaryFarmId(ownerFarmId)
+       and g_farmManager and type(g_farmManager.getFarmById) == "function" then
+        local ok, farm = pcall(function() return g_farmManager:getFarmById(playerFarmId) end)
+        if ok and farm and type(farm.getIsContractingFor) == "function" then
+            local ok2, res = pcall(function() return farm:getIsContractingFor(ownerFarmId) end)
+            if ok2 then contractingForOwner = res == true end
+        end
+    end
+    return SpatialScouting.isRevealAuthorized(playerFarmId, ownerFarmId, contractingForOwner)
+end
+
+--- Sample the disease truth at a spot. The value map answers first; the field
+--- average stands in when the map has no value there (a sampled truth is better
+--- than none and the cell is still walked).
+---@param x number
+---@param z number
+---@param farmlandId number
+---@return number truth
+function SpatialScouting:_sampleTruthAt(x, z, farmlandId)
+    local truth = 0
+    if self.valueMaps then
+        local v = self.valueMaps:readValueAtWorld("diseasePressure", x, z)
+        if v ~= nil then truth = v end
+    end
+    if truth <= 0 then
+        local field = g_SoilFertilityManager and g_SoilFertilityManager.soilSystem
+            and g_SoilFertilityManager.soilSystem.fieldData
+            and g_SoilFertilityManager.soilSystem.fieldData[farmlandId]
+        if field and field.diseasePressure then truth = field.diseasePressure end
+    end
+    return truth
+end
+
 --- Sample one player's on-foot position into the walked mask.
 --- Server-authoritative: the farm comes from the server's player record
---- (player.farmId), never from a wire-supplied value. The truth is read from
---- the value maps at the player's position; when the map has no value there,
---- the field average stands in (a sampled truth is better than none and the
---- cell is still walked).
+--- (player.farmId), never from a wire-supplied value or a farm-1 fallback. The
+--- truth is read only AFTER the reveal gate passes, so an unrelated neighbour
+--- walk reads nothing and writes nothing.
 ---@param player table  a Player from g_currentMission.players
 ---@param currentDay number
----@return boolean walked
+---@return boolean changed, number|nil farmId, number|nil farmlandId, string|nil cellKey
 function SpatialScouting:_samplePlayer(player, currentDay)
     if player == nil then return false end
     -- LAW 1: on foot only.
@@ -395,48 +499,31 @@ function SpatialScouting:_samplePlayer(player, currentDay)
     end
     if px == nil then return false end
 
-    -- Resolve the field under the player (LAW 4: server-side, from the server's
-    -- authoritative world, not client-reported cells).
-    local fieldId
-    if g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function" then
-        local ok, f = pcall(function() return g_fieldManager:getFieldAtWorldPosition(px, pz) end)
-        if ok and f and f.farmland and f.farmland.id then fieldId = f.farmland.id end
-    end
-    if not fieldId and g_farmlandManager and type(g_farmlandManager.getFarmlandAtWorldPosition) == "function" then
-        local ok, land = pcall(function() return g_farmlandManager:getFarmlandAtWorldPosition(px, pz) end)
-        if ok and land and land.id and land.id > 0 then fieldId = land.id end
-    end
-    if not fieldId then return false end   -- not on a field: nothing to scout
+    local farmlandId = self:_resolveFarmlandAt(px, pz)
+    if not farmlandId then return false end   -- not on a field: nothing to scout
 
-    -- Farm from the server's player record.
-    local farmId = player.farmId
-    if farmId == nil or farmId <= 0 then
-        if g_currentMission and type(g_currentMission.getFarmId) == "function" then
-            farmId = g_currentMission:getFarmId()
-        end
-    end
-    if farmId == nil or farmId <= 0 then farmId = 1 end
+    -- [SF-22] The walking farm comes straight from the server's player record.
+    -- No getFarmId() and no farm-1 fallback: an unresolved or non-ordinary farm
+    -- is not a farm that may learn anything.
+    local playerFarmId = player.farmId
+    if not SpatialScouting.isOrdinaryFarmId(playerFarmId) then return false end
 
-    -- Sample the truth at walk time.
-    local truth = 0
-    if self.valueMaps then
-        local v = self.valueMaps:readValueAtWorld("diseasePressure", px, pz)
-        if v ~= nil then truth = v end
-    end
-    if truth <= 0 then
-        local field = g_SoilFertilityManager and g_SoilFertilityManager.soilSystem
-            and g_SoilFertilityManager.soilSystem.fieldData and g_SoilFertilityManager.soilSystem.fieldData[fieldId]
-        if field and field.diseasePressure then truth = field.diseasePressure end
+    -- [SF-22] Authorise BEFORE any truth read (LAW 2).
+    if not SpatialScouting._isWalkAuthorized(playerFarmId, farmlandId) then
+        return false
     end
 
+    local truth = self:_sampleTruthAt(px, pz, farmlandId)
     local key = SpatialScouting.cellKey(px, pz)
-    return self:noteWalk(farmId, fieldId, key, currentDay, truth, px, pz)
+    local changed = self:noteWalk(playerFarmId, farmlandId, key, currentDay, truth, px, pz)
+    return changed, playerFarmId, farmlandId, key
 end
 
 --- Per-frame server sampling. Iterates the server's authoritative player list;
---- each on-foot player who is inside a field fills their farm's mask. When a
---- walk lands, flags the NetworkSync module dirty so the next 1Hz batch carries
---- the fresh cells to that farm's clients (LAW 3).
+--- each on-foot player inside their own (or a contracted) field fills that
+--- farm's mask. Changed cells are grouped by farm and each farm's group is
+--- handed to the DELTA sender, so a farm's fresh cells reach only that farm's
+--- own remote teammates (LAW 3, farm-private). Another farm receives nothing.
 ---@param currentDay number
 ---@return number sampled
 function SpatialScouting:onUpdate(currentDay)
@@ -444,11 +531,21 @@ function SpatialScouting:onUpdate(currentDay)
     local players = g_currentMission and g_currentMission.players
     if players == nil then return 0 end
     local sampled = 0
+    local changedByFarm = nil
     for _, player in pairs(players) do
-        if self:_samplePlayer(player, currentDay) then sampled = sampled + 1 end
+        local changed, farmId, farmlandId, cellKey = self:_samplePlayer(player, currentDay)
+        if changed then
+            sampled = sampled + 1
+            changedByFarm = changedByFarm or {}
+            local list = changedByFarm[farmId]
+            if list == nil then list = {}; changedByFarm[farmId] = list end
+            list[#list + 1] = { fieldId = farmlandId, cellKey = cellKey }
+        end
     end
-    if sampled > 0 and SoilScoutingBridge and SoilScoutingBridge.markDirty then
-        SoilScoutingBridge.markDirty()
+    if changedByFarm and SoilScoutingBridge and SoilScoutingBridge.sendFarmDelta then
+        for farmId, list in pairs(changedByFarm) do
+            SoilScoutingBridge.sendFarmDelta(self, farmId, list)
+        end
     end
     return sampled
 end
@@ -485,43 +582,27 @@ function SpatialScouting:revealCellAt(connection, x, z, currentDay)
     if player == nil then player = g_localPlayer end
     if player == nil then return false end
 
-    -- The field is resolved SERVER-SIDE at the spot, never from the wire.
-    local fieldId
-    if g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function" then
-        local ok, f = pcall(function() return g_fieldManager:getFieldAtWorldPosition(x, z) end)
-        if ok and f and f.farmland and f.farmland.id then fieldId = f.farmland.id end
-    end
-    if not fieldId and g_farmlandManager and type(g_farmlandManager.getFarmlandAtWorldPosition) == "function" then
-        local ok, land = pcall(function() return g_farmlandManager:getFarmlandAtWorldPosition(x, z) end)
-        if ok and land and land.id and land.id > 0 then fieldId = land.id end
-    end
-    if not fieldId then return false end   -- not on a field: nothing to reveal
+    -- The farmland is resolved SERVER-SIDE at the spot, never from the wire.
+    local farmlandId = self:_resolveFarmlandAt(x, z)
+    if not farmlandId then return false end   -- not on a field: nothing to reveal
 
-    -- Farm from the player record, exactly as the walk sampler does.
-    local farmId = player.farmId
-    if farmId == nil or farmId <= 0 then
-        if g_currentMission and type(g_currentMission.getFarmId) == "function" then
-            farmId = g_currentMission:getFarmId()
-        end
+    -- [SF-22] Farm from the player record; no getFarmId() and no farm-1 fallback.
+    local playerFarmId = player.farmId
+    if not SpatialScouting.isOrdinaryFarmId(playerFarmId) then return false end
+
+    -- [SF-22] Authorise BEFORE the truth read, exactly as the walk sampler does:
+    -- the kneeling farm must own this land or be contracting its owner (LAW 2).
+    if not SpatialScouting._isWalkAuthorized(playerFarmId, farmlandId) then
+        return false
     end
-    if farmId == nil or farmId <= 0 then farmId = 1 end
 
     -- Sample the truth server-side at kneel time (LAW 3: sampled at reveal time).
-    local truth = 0
-    if self.valueMaps then
-        local v = self.valueMaps:readValueAtWorld("diseasePressure", x, z)
-        if v ~= nil then truth = v end
-    end
-    if truth <= 0 then
-        local field = g_SoilFertilityManager and g_SoilFertilityManager.soilSystem
-            and g_SoilFertilityManager.soilSystem.fieldData and g_SoilFertilityManager.soilSystem.fieldData[fieldId]
-        if field and field.diseasePressure then truth = field.diseasePressure end
-    end
+    local truth = self:_sampleTruthAt(x, z, farmlandId)
 
     local key = SpatialScouting.cellKey(x, z)
-    local ok = self:noteWalk(farmId, fieldId, key, currentDay, truth, x, z)
-    if ok and SoilScoutingBridge and SoilScoutingBridge.markDirty then
-        SoilScoutingBridge.markDirty()
+    local changed = self:noteWalk(playerFarmId, farmlandId, key, currentDay, truth, x, z)
+    if changed and SoilScoutingBridge and SoilScoutingBridge.sendFarmDelta then
+        SoilScoutingBridge.sendFarmDelta(self, playerFarmId, { { fieldId = farmlandId, cellKey = key } })
     end
-    return ok
+    return changed
 end

--- a/src/SprayerRateManager.lua
+++ b/src/SprayerRateManager.lua
@@ -36,9 +36,14 @@ function SprayerRateManager:getMultiplier(vehicleId)
 end
 
 --- Returns whether Auto-Mode is enabled for a vehicle.
+--- [SF-46] autoForce is the playtest override (rfAutoRateSet console command):
+--- when non-nil it wins for EVERY vehicle, which is what makes it deterministic
+--- as a harness - it survives vehicle changes, helper hand-off and the HUD
+--- toggle alike. nil = no override, normal per-vehicle behaviour.
 ---@param vehicleId number
 ---@return boolean enabled
 function SprayerRateManager:getAutoMode(vehicleId)
+    if self.autoForce ~= nil then return self.autoForce end
     return self.vehicleAutoModes[vehicleId] == true
 end
 

--- a/src/config/Constants.lua
+++ b/src/config/Constants.lua
@@ -993,7 +993,11 @@ SoilConstants.ZONE = {
 -- physically covered before the "fully treated" notification fires.
 -- Coverage is tracked per-field daily via the cell grid shared with ZONE.
 SoilConstants.COVERAGE = {
-    MIN_FULL_CREDIT = 0.70,  -- 70% of field cells must be visited for full-treated notification
+    -- 95%, not 70%: at 70% the game announced "field fully treated" with nearly a
+    -- third of it never driven over, which is what it looks like from the seat.
+    -- Drives the notification, the "Coverage: x% / y%" readout and the colour
+    -- that turns it green, so all three now agree on what finished means.
+    MIN_FULL_CREDIT = 0.95,  -- fraction of the field that must be covered before it counts as treated
     PROTECTION_THRESHOLD = 0.80,  -- 80% session coverage required before crop-protection "active" status is granted (issue #441)
 }
 
@@ -1021,7 +1025,7 @@ SoilConstants.NETWORK = {
 -- SPRAYER APPLICATION RATE
 -- ========================================
 -- 20 stepped rate multipliers (0.10x – 2.00x in 0.10 increments).
--- DEFAULT_INDEX = 10 → 1.0x (no change from base behaviour).
+-- DEFAULT_INDEX = 11 → 1.0x (no change from base behaviour).
 -- The HUD displays real units (gal/ac or L/ha) by multiplying each step
 -- against the BASE_RATE for the currently loaded fertilizer fill type.
 -- Burn effects apply when nutrient-rich fertilizer is over-applied:
@@ -1029,12 +1033,19 @@ SoilConstants.NETWORK = {
 --   >= BURN_GUARANTEED_THRESHOLD: guaranteed burn every application
 SoilConstants.SPRAYER_RATE = {
     STEPS = {
+        -- 0.01 is the "barely spreading" floor auto-rate settles on when a field is
+        -- already at target: still applying, so the machine reads as working, but
+        -- ~1% of base rate rather than the old 0.20 floor that kept pushing pH past
+        -- optimum on ground that was already done. Prepending shifts every index by
+        -- one, hence DEFAULT_INDEX below moving 10 -> 11; rate indices are runtime
+        -- only and never written to a savegame, so nothing stored is invalidated.
+        0.01,
         0.10, 0.20, 0.30, 0.40, 0.50,
         0.60, 0.70, 0.80, 0.90, 1.00,
         1.10, 1.20, 1.30, 1.40, 1.50,
         1.60, 1.70, 1.80, 1.90, 2.00,
     },
-    DEFAULT_INDEX             = 10,    -- 1.0x
+    DEFAULT_INDEX             = 11,    -- 1.0x (was 10; STEPS gained a 0.01 floor)
     BURN_RISK_THRESHOLD       = 1.25,  -- above this: chance of burn
     BURN_GUARANTEED_THRESHOLD = 1.50,  -- at or above this: burn every time
     BURN_PH_DROP_RISK         = 0.15,  -- max pH lost over a full pass in the risk band (scaled by excess)

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -1335,6 +1335,72 @@ end
 -- (pest=0, disease=0, K≥target, or P≥target) the section is temporarily set
 -- to isActive=false. VWW resets it on the next tick - no persistent corruption.
 --
+-- [FIX-13] The multiplier actually in force for this machine, for the litre
+-- estimate. Resolved through rootVehicle the same way the rate HUD does.
+-- (Restored: a comment-block rewrite deleted this function while its three call
+-- sites remained, and every spray tick died with 'attempt to call a nil value'
+-- inside the hook's pcall -- 13,816 silent failures in one session. Product and
+-- money moved, nothing painted or counted.)
+function HookManager.currentRateMult(sprayerSelf)
+    local sfm = g_SoilFertilityManager
+    local rm = sfm and sfm.sprayerRateManager
+    if not rm or not sprayerSelf then return 1.0 end
+    local root = sprayerSelf.rootVehicle
+    local vid = (root and root ~= sprayerSelf) and (root.id or 0) or sprayerSelf.id
+    if not vid then return 1.0 end
+    local ok, mult = pcall(function() return rm:getMultiplier(vid) end)
+    return (ok and tonumber(mult)) or 1.0
+end
+
+-- [GATE] Two paint modes, per the design ruling (Wizard, 2026-08-28):
+--
+--   Precision Pack fitted -> prescription mode: per-cell, capped at target.
+--   The clean map. Section control also shuts nozzles over covered ground.
+--
+--   No pack -> flat mode: the dose goes down across the full width wherever
+--   the machine drives, because a spreader cannot pick and choose. Headland
+--   overlap DOUBLE-APPLIES and shows on the map -- that is the point, not a
+--   bug. The only limit is SF_PASS_MAX in paintBoomStrip: one pass cannot
+--   deliver more than one metered pass, which is what made this safe to
+--   re-enable after the first attempt (uncapped banking spikes could slam a
+--   pixel the full scale in one tick; measured offered=1.4021 -> 7.5).
+---- [PACK] Was this machine bought with the precision pack (variable rate +
+-- section control)? Resolved through the sprayer itself and its root vehicle, so
+-- a trailed sprayer answers for its own configuration rather than the tractor's.
+-- Fails CLOSED: if the specialization is missing the answer is no, which leaves
+-- the machine on flat manual rate rather than silently granting the upgrade.
+function HookManager.hasPrecisionPack(sprayerSelf)
+    if sprayerSelf == nil then return false end
+    if type(sprayerSelf.sfHasPrecisionPack) == "function" then
+        local ok, has = pcall(function() return sprayerSelf:sfHasPrecisionPack() end)
+        if ok and has then return true end
+    end
+    local root = sprayerSelf.rootVehicle
+    if root and root ~= sprayerSelf and type(root.sfHasPrecisionPack) == "function" then
+        local ok, has = pcall(function() return root:sfHasPrecisionPack() end)
+        if ok and has then return true end
+    end
+    return false
+end
+
+-- [GATE] Is prescription (variable-rate) mode active for this machine?
+-- Flat mode is the default: without rate control the boom applies one rate
+-- everywhere, the player sets it by hand, and over-application is possible.
+-- Resolve through rootVehicle so a trailed sprayer answers as its tractor does.
+function HookManager:isPrescriptionMode(sprayerSelf)
+    local sfm = g_SoilFertilityManager
+    if not sfm or not sfm.sensorManager then return false end
+    if sfm.settings and sfm.settings.variableRateEnabled == false then return false end
+    -- [PACK] Hardware first: no precision pack on this machine, no per-cell dosing,
+    -- whatever the toggle says. Application rate (manual and auto) is unaffected --
+    -- that ships on every sprayer.
+    if not HookManager.hasPrecisionPack(sprayerSelf) then return false end
+    local root = sprayerSelf and sprayerSelf.rootVehicle
+    local vid = (root and root ~= sprayerSelf) and (root.id or 0) or (sprayerSelf and sprayerSelf.id)
+    if not vid then return false end
+    return sfm.sensorManager:isVariableRateEnabled(vid) == true
+end
+
 function HookManager:installSectionControlHook()
     if not Sprayer or type(Sprayer.onStartWorkAreaProcessing) ~= "function" then
         SoilLogger.warning("[SectionSensor] Sprayer.onStartWorkAreaProcessing not found - skipping")
@@ -1876,6 +1942,13 @@ function HookManager:installVariableRateHook()
 
             sensorMgr:clearSectionRates(vehicleId)
 
+            -- [SF-28] Mean of this pass's section rates. sectionRates are
+            -- redistribution weights that deliberately preserve the total (#555);
+            -- this is the separate figure that lets the TOTAL fall on ground
+            -- already at target, so the tank draws less instead of the same
+            -- product being shuffled toward the thin sections.
+            local vrRateSum, vrRateCount = 0, 0
+
             for i, section in ipairs(vww.sections) do
                 if section.isActive and not section.isCenter then
                     local tip = tips and tips[i]
@@ -1938,7 +2011,18 @@ function HookManager:installVariableRateHook()
                     -- The manual rate budget is already applied to wap.usage by
                     -- installSprayerStartHook. Capping here caused double-reduction (#555).
                     sensorMgr:setSectionRate(vehicleId, section, rate)
+                    vrRateSum   = vrRateSum + rate
+                    vrRateCount = vrRateCount + 1
                 end
+            end
+
+            -- [SF-28] Publish this pass's mean demand. installSprayerStartHook
+            -- multiplies wap.usage by it, so ground already at target draws
+            -- MIN_RATE (0.30) of the product and an exhausted cell draws MAX_RATE
+            -- (1.50). Nutrient credit and the map paint both derive from that same
+            -- usage, so tank, field scalar and Esc colour cannot drift apart.
+            if vrRateCount > 0 then
+                sensorMgr:setVrDemand(vehicleId, vrRateSum / vrRateCount)
             end
         end
     )
@@ -2022,6 +2106,10 @@ function HookManager:installOverlapPreventionHook()
             local sfm = g_SoilFertilityManager
             if not sfm then return end
             if sfm.settings and sfm.settings.overlapPrevention == false then return end
+            -- [PACK] Section control is upgrade hardware too. Without it every
+            -- nozzle stays on and overlapping the headland double-applies, which
+            -- is exactly what happens on a machine with no section valves.
+            if not HookManager.hasPrecisionPack(sprayerSelf) then return end
 
             local vww = sprayerSelf.spec_variableWorkWidth
             if not vww or not vww.sections or #vww.sections == 0 then return end
@@ -3991,11 +4079,25 @@ function HookManager:installSprayerAreaHook()
                     -- F61: for non-VWW implements using liter-based coverage, clear stale
                     -- _geometricCoverageOwner so a previous VWW session's guard does not
                     -- block the liter path (line 5123 in trackSprayerCoverage).
-                    if not _hasVWWEarly and g_SoilFertilityManager.soilSystem.fieldData
+                    --
+                    -- [FIX-6] ...but ONLY when this machine genuinely has no boom to
+                    -- measure. A dry spreader is non-VWW yet still reports a real boom,
+                    -- and paintBoomStrip is measuring its swept area every strip. Clearing
+                    -- the flag unconditionally wiped that claim once per tick and let the
+                    -- litre estimate back in on top: 350 strips totalling 1.45 ha of real
+                    -- quads were reported as 4.145 ha. Only stand aside when there is
+                    -- actually nothing geometric running.
+                    -- rootX/rootZ are not in scope until later in this function, so
+                    -- resolve the position here rather than reading two nils.
+                    local _bOk, _bx, _, _bz = pcall(getWorldTranslation, self.rootNode)
+                    local _boomEarly = _bOk and _bx
+                        and hookMgrRef:getBoomCellPositions(self, _bx, _bz) or nil
+                    if not _hasVWWEarly and not _boomEarly
+                       and g_SoilFertilityManager.soilSystem.fieldData
                        and g_SoilFertilityManager.soilSystem.fieldData[fieldId] then
                         g_SoilFertilityManager.soilSystem.fieldData[fieldId]._geometricCoverageOwner = nil
                     end
-                    g_SoilFertilityManager.soilSystem:trackSprayerCoverage(fieldId, liters, fillType.name, _useLitCov)
+                    g_SoilFertilityManager.soilSystem:trackSprayerCoverage(fieldId, liters, fillType.name, _useLitCov, hookMgrRef.currentRateMult(self))
                 end
 
                 -- ── Sub-field section attribution (issue #300) ────────────────────
@@ -4142,7 +4244,48 @@ function HookManager:installSprayerAreaHook()
                 -- mod does not hand out free fertilizer.
                 do
                     local multiTankEnabled = hookMgrRef and hookMgrRef._settings and hookMgrRef._settings.multiTankApplication
-                    if multiTankEnabled ~= false then
+                    -- [FIX-17] Classify the machine ONCE: is this actually a combi?
+                    --
+                    -- This block exists for machines with two bins of DIFFERENT
+                    -- products (seed + fert air drills), where the engine drains one
+                    -- bin and the other must be credited by hand. It was running on
+                    -- every machine with the sprayer spec -- which in FS25 includes
+                    -- every lime and manure spreader -- scanning tanks per tick for a
+                    -- situation a spreader can never be in. Harmless until auto-buy
+                    -- added a second same-type unit and gave it something to
+                    -- double-count. A machine that cannot hold two different soil
+                    -- products in two units is not a combi, decided once, said once.
+                    if multiTankEnabled ~= false and self._sfCombiClass == nil then
+                        local capable = 0
+                        local fuSpec0 = self.spec_fillUnit
+                        if fuSpec0 and fuSpec0.fillUnits then
+                            for _, fu0 in ipairs(fuSpec0.fillUnits) do
+                                local holdsProduct = false
+                                if fu0.supportedFillTypes then
+                                    for ftIdx0 in pairs(fu0.supportedFillTypes) do
+                                        local d0 = g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(ftIdx0)
+                                        local nm0 = d0 and d0.name
+                                        if nm0 and SoilConstants.FERTILIZER_PROFILES[nm0] ~= nil then
+                                            holdsProduct = true
+                                            break
+                                        end
+                                    end
+                                end
+                                if holdsProduct then capable = capable + 1 end
+                            end
+                        end
+                        -- Two units minimum, at least one holding a soil product. NOT
+                        -- "two product units": a seed+fert drill has exactly one --
+                        -- seeds are not a soil product -- and it is the machine this
+                        -- feature exists for. The same-type guard below still stops an
+                        -- auto-buy twin from double-crediting.
+                        local totalUnits = (fuSpec0 and fuSpec0.fillUnits and #fuSpec0.fillUnits) or 0
+                        self._sfCombiClass = (totalUnits >= 2 and capable >= 1)
+                        SoilLogger.info("[MultiTank] %s: combi=%s (%d product-capable unit(s))",
+                            tostring(self.getFullName and self:getFullName() or self.id),
+                            tostring(self._sfCombiClass), capable)
+                    end
+                    if multiTankEnabled ~= false and self._sfCombiClass == true then
                         local spraySpec = self.spec_sprayer
                         local fuSpec    = self.spec_fillUnit
                         if spraySpec and fuSpec and fuSpec.fillUnits then
@@ -4158,7 +4301,17 @@ function HookManager:installSprayerAreaHook()
                             end
 
                             for fuIdx, fu in ipairs(fuSpec.fillUnits) do
-                                if fuIdx ~= activeFui and fu.fillLevel > 0 and fu.fillType and fu.fillType > 0 then
+                                -- [FIX-15] Skip secondaries holding the SAME product as the
+                                -- active tank. This feature exists for combi machines (seed +
+                                -- fert in separate bins) where the engine drains only one bin
+                                -- and the other must be credited by hand. When the secondary
+                                -- is the same fill type, the engine's litres already ARE the
+                                -- whole output -- crediting the twin again doubled every dose.
+                                -- Measured: 'Fertilizer: Field 82, LIME, 0.8753L' twice plus
+                                -- 'multi-tank ... 0.8753L' in the same millisecond, 9,199
+                                -- times in one worker session, on a machine with auto-buy.
+                                if fuIdx ~= activeFui and fu.fillLevel > 0 and fu.fillType and fu.fillType > 0
+                                    and fu.fillType ~= fillTypeIndex then
                                     local ft = g_fillTypeManager:getFillTypeByIndex(fu.fillType)
                                     local ftName = ft and ft.name or nil
                                     if ftName then
@@ -4244,18 +4397,28 @@ function HookManager:installSprayerAreaHook()
                                                     -- NOT the ends of the cell sweep array.
                                                     local boomLine = hookMgrRef:getBoomLineEndpoints(self, rootX, rootZ)
                                                     if boomPts then
-                                                        if vww and vww.sections and #vww.sections > 0 then
-                                                            soilSys:markBoomCells(fieldId, boomPts)
-                                                        else
-                                                            soilSys:markBoomCells(fieldId, boomPts, true)
-                                                        end
+                                                        -- [FIX-5] Second copy of the coverage bug, in the multi-tank
+                                                        -- drain path. A spreader has no VWW sections, so it marked
+                                                        -- cells overlay-only -- which never sets the geometric-owner
+                                                        -- flag -- and then the hardcoded `true` below made the litre
+                                                        -- estimate bypass BOTH guards in trackSprayerCoverage.
+                                                        -- Measured: 826 strip paints x 2 m x 23.95 m boom = 3.96 ha
+                                                        -- actually driven, reported as 7.54 ha. Count the ground.
+                                                        soilSys:markBoomCells(fieldId, boomPts)
                                                         -- REFINED: paint the real boom strip on the value maps
                                                         if soilSys.paintBoomStrip then
-                                                            soilSys:paintBoomStrip(fieldId, boomPts, ftName, boomLine)
+                                                            soilSys:paintBoomStrip(fieldId, boomPts, ftName, boomLine, hookMgrRef:isPrescriptionMode(self))
+                                                            -- [SF-41] Auto-rate rides the work cycle, seated or not
+                                                            -- (5 s throttle lives inside recalcAutoRateFor).
+                                                            local sfmAR = g_SoilFertilityManager
+                                                            if sfmAR and sfmAR.recalcAutoRateFor then
+                                                                sfmAR:recalcAutoRateFor(self.rootVehicle or self)
+                                                            end
                                                         end
                                                     end
-                                                    if drainLiters > 0 and isFert2 then
-                                                        soilSys:trackSprayerCoverage(fieldId, drainLiters, ftName, true)
+                                                    -- Litres only when there is no boom geometry to measure.
+                                                    if drainLiters > 0 and isFert2 and not boomPts then
+                                                        soilSys:trackSprayerCoverage(fieldId, drainLiters, ftName, true, hookMgrRef.currentRateMult(self))
                                                     end
                                                 end
 
@@ -4298,31 +4461,57 @@ function HookManager:installSprayerAreaHook()
                 if soilSys and fieldId and fieldId > 0 then
                     local vww = self.spec_variableWorkWidth
                     local hasVWW = vww and vww.sections and #vww.sections > 0
-                    local boomPts = hookMgrRef:getBoomCellPositions(self, rootX, rootZ)
+                    local boomPts, boomMethod = hookMgrRef:getBoomCellPositions(self, rootX, rootZ)
+                    -- [FIX-13] Each machine announces its coverage technique ONCE, so the
+                    -- log names which measurement a given machine is on instead of three
+                    -- systems racing invisibly. "nodes" = real boom span, "width" = swept
+                    -- strip synthesized from the working width, "litres" = last resort.
+                    local covMethod = boomPts and (boomMethod or "nodes") or "litres"
+                    if self._sfCovMethod ~= covMethod then
+                        self._sfCovMethod = covMethod
+                        SoilLogger.info("[Coverage] %s uses method: %s (VWW sections: %s)",
+                            tostring(self.getFullName and self:getFullName() or self.id),
+                            covMethod, tostring(hasVWW))
+                    end
                     -- RSF-836: the true boom line, never the ends of the cell sweep.
                     local boomLine = hookMgrRef:getBoomLineEndpoints(self, rootX, rootZ)
                     -- REFINED: paint the real boom-width strip into the per-pixel
                     -- value maps (continuous PF-style work strips at ~2 m/px).
                     if boomPts and soilSys.paintBoomStrip then
-                        soilSys:paintBoomStrip(fieldId, boomPts, fillType.name, boomLine)
+                        soilSys:paintBoomStrip(fieldId, boomPts, fillType.name, boomLine, hookMgrRef:isPrescriptionMode(self))
+                        -- [SF-41] Auto-rate rides the work cycle, seated or not.
+                        local sfmAR = g_SoilFertilityManager
+                        if sfmAR and sfmAR.recalcAutoRateFor then
+                            sfmAR:recalcAutoRateFor(self.rootVehicle or self)
+                        end
                     end
                     if hasVWW and boomPts then
                         soilSys:markBoomCells(fieldId, boomPts)
+                    elseif boomPts then
+                        -- [FIX-5] Broadcast / dry spreader. These have no VWW sections, but
+                        -- getBoomCellPositions still returns a real spanning boom for them
+                        -- (it falls back to the workArea start/width/height nodes -- the same
+                        -- fix that stopped dry fertilizer painting a zero-width strip). So
+                        -- count coverage from the cells actually driven over, exactly as a
+                        -- VWW machine does.
+                        --
+                        -- It used to mark cells overlay-only and derive coverage from
+                        -- litres / rate-per-hectare instead. That number has nothing to do
+                        -- with where the machine went: spreading lime on a partial headland
+                        -- reported 8.29 of 8.3 ha covered -- "field complete" -- while most
+                        -- of the field had never been touched. Litres measure what left the
+                        -- hopper, not what the ground received.
+                        soilSys:markBoomCells(fieldId, boomPts)
                     else
-                        -- Broadcast / dry spreader (or any vehicle with no spanning boom).
-                        if boomPts then
-                            soilSys:markBoomCells(fieldId, boomPts, true)  -- overlay only
-                        end
-                        -- Fertilizers advance the counter here via the liter estimate. Crop
-                        -- protection products already did so in the trackSprayerCoverage call
-                        -- above (updateFractions = not isFertilizer), so don't double-count.
+                        -- No boom geometry at all: the litre estimate is the only signal
+                        -- left, so it stays as the genuine last resort it was meant to be.
                         if liters > 0 and isFertilizer then
                             -- F61: clear stale geometric owner flag so the liter-based fallback
                             -- is not blocked by a previous VWW session's guard (line 5123).
                             if soilSys.fieldData and soilSys.fieldData[fieldId] then
                                 soilSys.fieldData[fieldId]._geometricCoverageOwner = nil
                             end
-                            soilSys:trackSprayerCoverage(fieldId, liters, fillType.name, true)
+                            soilSys:trackSprayerCoverage(fieldId, liters, fillType.name, true, hookMgrRef.currentRateMult(self))
                         end
                     end
                 end
@@ -6883,14 +7072,34 @@ function HookManager:installSprayerStartHook()
             local root = self.rootVehicle
             local rateVehId = (root and root ~= self) and (root.id or 0) or (self.id or 0)
             local mult = g_SoilFertilityManager.sprayerRateManager:getMultiplier(rateVehId)
-            if mult == 1.0 then return end
+
+            -- [SF-28] Variable rate now cuts the TOTAL as well as redistributing it.
+            -- sectionRates preserve the total by design (#555); vrDemand is the mean
+            -- of those same rates, so a pass over ground already at NUTRIENT_TARGET
+            -- draws MIN_RATE (0.30) of the product rather than a full tank's worth,
+            -- and an exhausted field draws MAX_RATE (1.50). Nutrient credit and the
+            -- map paint both derive from this usage, so tank, field scalar and Esc
+            -- colour move together instead of drifting apart.
+            --
+            -- Ordering note: installVariableRateHook is appended AFTER this hook, so
+            -- it runs later in the same tick and the value read here is the PREVIOUS
+            -- tick's mean. That lag is immaterial beside the 0.6/0.4 smoothing each
+            -- section rate already carries (~0.5 s), and getVrDemand returns 1.0
+            -- whenever variable rate is not driving this vehicle.
+            local sensorMgrRT = g_SoilFertilityManager.sensorManager
+            local vrDemand = 1.0
+            if sensorMgrRT and sensorMgrRT.getVrDemand then
+                vrDemand = sensorMgrRT:getVrDemand(rateVehId) or 1.0
+            end
+            local total = mult * vrDemand
+            if total == 1.0 then return end
 
             local wap = spec.workAreaParameters
             if wap.usage and wap.usage ~= 0 then
-                wap.usage = wap.usage * mult
+                wap.usage = wap.usage * total
             end
             if wap.usagePerMin and wap.usagePerMin ~= 0 then
-                wap.usagePerMin = wap.usagePerMin * mult
+                wap.usagePerMin = wap.usagePerMin * total
             end
         end
     )
@@ -7819,7 +8028,7 @@ function HookManager:getBoomCellPositions(vehicle, rootX, rootZ)
                 end
             end
             table.insert(pts, {x = rootX, z = rootZ})
-            return (#pts > 1) and pts or nil
+            return (#pts > 1) and pts or nil, "width"
         end
         return nil
     end
@@ -7857,7 +8066,7 @@ function HookManager:getBoomCellPositions(vehicle, rootX, rootZ)
     -- The sweep may skip it depending on alignment with the 10 m grid.
     table.insert(pts, {x = rootX, z = rootZ})
 
-    return (#pts > 1) and pts or nil
+    return (#pts > 1) and pts or nil, "nodes"
 end
 
 -- =========================================================

--- a/src/integrations/SoilScoutingBridge.lua
+++ b/src/integrations/SoilScoutingBridge.lua
@@ -195,19 +195,26 @@ function SoilScoutingBridge.loadFallback(spatialScouting)
         local maskXML = xmlFile:getChild("spatialScouting", "masks")
         if maskXML ~= nil then
             for cell in maskXML:getChildren("masks", "cell") do
-                local farmId   = cell:getInt("cell#farmId") or 1
-                local fieldId  = cell:getInt("cell#fieldId") or 0
-                local cellKey  = cell:getString("cell#key") or ""
-                local farm     = masks[farmId] or {}
-                local field    = farm[fieldId] or {}
-                field[cellKey] = {
-                    day   = cell:getInt("cell#day") or 0,
-                    truth = cell:getFloat("cell#truth") or 0,
-                    x     = cell:getFloat("cell#x") or 0,
-                    z     = cell:getFloat("cell#z") or 0,
-                }
-                farm[fieldId] = field
-                masks[farmId] = farm
+                -- [SF-22] A missing/non-ordinary farm id, missing field id or empty
+                -- cell key skips that cell. NEVER `farmId or 1`: a malformed row
+                -- must not deposit stray knowledge under farm 1.
+                local farmId  = cell:getInt("cell#farmId")
+                local fieldId = cell:getInt("cell#fieldId")
+                local cellKey = cell:getString("cell#key")
+                if SpatialScouting.isOrdinaryFarmId(farmId)
+                   and type(fieldId) == "number"
+                   and type(cellKey) == "string" and cellKey ~= "" then
+                    local farm     = masks[farmId] or {}
+                    local field    = farm[fieldId] or {}
+                    field[cellKey] = {
+                        day   = cell:getInt("cell#day") or 0,
+                        truth = cell:getFloat("cell#truth") or 0,
+                        x     = cell:getFloat("cell#x") or 0,
+                        z     = cell:getFloat("cell#z") or 0,
+                    }
+                    farm[fieldId] = field
+                    masks[farmId] = farm
+                end
             end
         end
         delete(xmlFile)
@@ -220,132 +227,339 @@ function SoilScoutingBridge.loadFallback(spatialScouting)
 end
 
 -- =========================================================
--- Network Sync (LAW 3 delivery)
+-- [SF-22] Farm-private mask transport (host-owned event route)
 -- =========================================================
+-- NetworkSync cannot express "send farm X's bytes only to farm X", so the
+-- walked mask rides SoilFertilizer's own server-authoritative event route
+-- (SoilScoutingMaskSyncEvent / SoilScoutingMaskRequestEvent, in
+-- NetworkEvents.lua). This module owns the pure serialisation, the remote-
+-- teammate selector, the client-side apply/buffer, and the pure-client
+-- farm-switch subscriber. Another farm never receives a byte of this mask.
 
-SoilScoutingBridge.SYNC_MODULE_ID = "SoilFertilizer_SpatialScouting_Sync"
-SoilScoutingBridge.CHANNEL        = "SoilFertilizer_SpatialScouting_Sync"
-SoilScoutingBridge.syncActive     = false
+SoilScoutingBridge.MASK_CELLS_PER_EVENT = 32
+SoilScoutingBridge.MASK_MODE_FULL  = 0
+SoilScoutingBridge.MASK_MODE_DELTA = 1
 
-local function getNetworkSync()
-    return (g_currentMission and g_currentMission.networkSync) or g_networkSync
-end
+-- ── Serialisation (pure) ──────────────────────────────────
 
---- The client-side local farm id, used to scope which synced entries this
---- client may compose. On a client the player record is authoritative for the
---- local farm; a different farm's entries are ignored ("a different farm's
---- client sees nothing").
----@return number farmId
-function SoilScoutingBridge.localFarmId()
-    if g_localPlayer and g_localPlayer.farmId and g_localPlayer.farmId > 0 then
-        return g_localPlayer.farmId
-    end
-    if g_currentMission and type(g_currentMission.getFarmId) == "function" then
-        local ok, id = pcall(function() return g_currentMission:getFarmId() end)
-        if ok and id and id > 0 then return id end
-    end
-    return 1
-end
-
---- Flatten the mask into one primitive array. Shape:
----   arr[1] = farm count; then per farm: farmId, cell count, then per cell:
----   fieldId, cellKey, walkDay, sampledTruth, x, z, gen
+--- Flatten ONE farm's mask into an ordered entry list (numeric fieldId, then
+--- string cellKey) so a chunked FULL is deterministic. Only masks[farmId] is
+--- ever read; no other farm's bytes are touched.
 ---@param spatialScouting SpatialScouting|nil
----@return table
-function SoilScoutingBridge.serializeMask(spatialScouting)
-    local arr = { 0 }
-    local farmCount = 0
-    for farmId, farm in pairs(spatialScouting and spatialScouting.masks or {}) do
-        local cells = {}
-        for fieldId, field in pairs(farm) do
-            for cellKey, e in pairs(field) do
-                cells[#cells + 1] = { fieldId, cellKey, e.day, e.truth, e.x, e.z, e.gen or 0 }
-            end
-        end
-        if #cells > 0 then
-            farmCount = farmCount + 1
-            arr[#arr + 1] = farmId
-            arr[#arr + 1] = #cells
-            for _, c in ipairs(cells) do
-                for i = 1, 7 do arr[#arr + 1] = c[i] end
-            end
+---@param farmId number
+---@return table entries  array of { fieldId, cellKey, day, truth, x, z, gen }
+function SoilScoutingBridge.serializeFarmMask(spatialScouting, farmId)
+    local entries = {}
+    if spatialScouting == nil or spatialScouting.masks == nil then return entries end
+    local farm = spatialScouting.masks[farmId]
+    if farm == nil then return entries end
+    local fieldIds = {}
+    for fieldId in pairs(farm) do fieldIds[#fieldIds + 1] = fieldId end
+    table.sort(fieldIds)
+    for _, fieldId in ipairs(fieldIds) do
+        local field = farm[fieldId]
+        local keys = {}
+        for cellKey in pairs(field) do keys[#keys + 1] = cellKey end
+        table.sort(keys)
+        for _, cellKey in ipairs(keys) do
+            local e = field[cellKey]
+            entries[#entries + 1] = {
+                fieldId = fieldId, cellKey = cellKey,
+                day = e.day or 0, truth = e.truth or 0,
+                x = e.x or 0, z = e.z or 0, gen = e.gen or 0,
+            }
         end
     end
-    arr[1] = farmCount
-    return arr
+    return entries
 end
 
---- Rebuild the mask from the flat array. Pure: no painting, no side effects.
----@param arr table
+--- Serialise a specific changed-cell list (for a DELTA) by reading the live
+--- mask. A reference whose cell no longer exists is skipped.
 ---@param spatialScouting SpatialScouting|nil
-function SoilScoutingBridge.deserializeMask(arr, spatialScouting)
-    if spatialScouting == nil or type(arr) ~= "table" then return end
+---@param farmId number
+---@param changedList table  array of { fieldId, cellKey }
+---@return table entries
+function SoilScoutingBridge.serializeEntries(spatialScouting, farmId, changedList)
+    local entries = {}
+    if spatialScouting == nil or spatialScouting.masks == nil or type(changedList) ~= "table" then
+        return entries
+    end
+    local farm = spatialScouting.masks[farmId]
+    if farm == nil then return entries end
+    for _, ref in ipairs(changedList) do
+        local field = ref.fieldId ~= nil and farm[ref.fieldId] or nil
+        local e = field and ref.cellKey ~= nil and field[ref.cellKey] or nil
+        if e ~= nil then
+            entries[#entries + 1] = {
+                fieldId = ref.fieldId, cellKey = ref.cellKey,
+                day = e.day or 0, truth = e.truth or 0,
+                x = e.x or 0, z = e.z or 0, gen = e.gen or 0,
+            }
+        end
+    end
+    return entries
+end
+
+-- ── Remote teammate selection ─────────────────────────────
+
+--- Every remote user connection whose farm equals farmId. Rejects non-ordinary
+--- target farms, and per user: nil / disconnected / not-ready connections, the
+--- LOCAL (listen-host loopback) connection, and any user on a different farm.
+--- The loopback is rejected because a local-stream sendEvent runs the event
+--- in-process on the host, and the host's authoritative state must never be
+--- overwritten by a display payload.
+---@param users table|nil          g_currentMission.userManager:getUsers()
+---@param farmManager table|nil     g_farmManager
+---@param farmId number
+---@return table connections
+function SoilScoutingBridge.selectRemoteConnections(users, farmManager, farmId)
+    local conns = {}
+    if type(users) ~= "table" or farmManager == nil then return conns end
+    if not SpatialScouting.isOrdinaryFarmId(farmId) then return conns end
+    for _, user in ipairs(users) do
+        local conn = (type(user.getConnection) == "function" and user:getConnection()) or user.connection
+        local isLocal = conn ~= nil and type(conn.getIsLocal) == "function" and conn:getIsLocal()
+        if conn ~= nil
+           and conn.isConnected ~= false
+           and conn.isReadyForEvents ~= false
+           and not isLocal then
+            local uid = (type(user.getId) == "function" and user:getId()) or user.id
+            local farm = type(farmManager.getFarmByUserId) == "function"
+                and farmManager:getFarmByUserId(uid) or nil
+            if farm ~= nil and farm.farmId == farmId then
+                conns[#conns + 1] = conn
+            end
+        end
+    end
+    return conns
+end
+
+-- ── Server-side send (server only) ────────────────────────
+
+local function sfNowMs()
+    if type(getTimeSec) == "function" then return getTimeSec() * 1000 end
+    return 0
+end
+
+--- Send one farm's whole mask to one connection as a contiguous chunk sequence.
+--- An empty farm sends exactly one empty chunk. Server only.
+---@param spatialScouting SpatialScouting|nil
+---@param connection table|nil
+---@param farmId number
+function SoilScoutingBridge.sendFarmFull(spatialScouting, connection, farmId)
+    if g_server == nil or connection == nil then return end
+    if not SpatialScouting.isOrdinaryFarmId(farmId) then return end
+    if SoilScoutingMaskSyncEvent == nil then return end
+    local t0 = sfNowMs()
+    local entries    = SoilScoutingBridge.serializeFarmMask(spatialScouting, farmId)
+    local per        = SoilScoutingBridge.MASK_CELLS_PER_EVENT
+    local chunkCount = math.max(1, math.ceil(#entries / per))
+    for chunkIndex = 1, chunkCount do
+        local startI = (chunkIndex - 1) * per + 1
+        local endI   = math.min(chunkIndex * per, #entries)
+        local slice  = {}
+        for i = startI, endI do slice[#slice + 1] = entries[i] end
+        connection:sendEvent(SoilScoutingMaskSyncEvent.newFull(farmId, chunkIndex, chunkCount, slice))
+    end
+    SoilLogger.info("SF22_MASK_FULL_SENT farm=%d entries=%d chunks=%d remotes=1 ms=%d",
+        farmId, #entries, chunkCount, math.floor(sfNowMs() - t0 + 0.5))
+end
+
+--- Send a farm's changed cells as DELTA events to that farm's remote teammates.
+--- Each DELTA event is independently applicable (chunk 1 of 1) and carries at
+--- most MASK_CELLS_PER_EVENT cells. Server only.
+---@param spatialScouting SpatialScouting|nil
+---@param farmId number
+---@param changedList table  array of { fieldId, cellKey }
+function SoilScoutingBridge.sendFarmDelta(spatialScouting, farmId, changedList)
+    if g_server == nil then return end
+    if not SpatialScouting.isOrdinaryFarmId(farmId) then return end
+    if SoilScoutingMaskSyncEvent == nil then return end
+    local entries = SoilScoutingBridge.serializeEntries(spatialScouting, farmId, changedList)
+    if #entries == 0 then return end
+    local users = g_currentMission and g_currentMission.userManager
+        and g_currentMission.userManager:getUsers()
+    local conns = SoilScoutingBridge.selectRemoteConnections(users, g_farmManager, farmId)
+    if #conns == 0 then return end
+    local per   = SoilScoutingBridge.MASK_CELLS_PER_EVENT
+    local total = 0
     local i = 1
-    local farmCount = tonumber(arr[i]) or 0
-    i = i + 1
-    for _ = 1, farmCount do
-        local farmId = arr[i]; i = i + 1
-        local cellCount = tonumber(arr[i]) or 0; i = i + 1
-        if farmId == nil then break end
-        local farm = spatialScouting.masks[farmId] or {}
-        for _ = 1, cellCount do
-            local fieldId = arr[i]; i = i + 1
-            local cellKey = arr[i]; i = i + 1
-            local day     = tonumber(arr[i]) or 0; i = i + 1
-            local truth   = tonumber(arr[i]) or 0; i = i + 1
-            local x       = tonumber(arr[i]) or 0; i = i + 1
-            local z       = tonumber(arr[i]) or 0; i = i + 1
-            local gen     = tonumber(arr[i]) or 0; i = i + 1
-            local field = farm[fieldId] or {}
-            -- The freshest sample wins; a re-walk in the running session beats
-            -- the synced payload for a cell this client also walked.
-            local cur = field[cellKey]
-            if cur == nil or day >= cur.day then
-                field[cellKey] = { day = day, truth = truth, x = x, z = z, gen = gen }
-            end
-            farm[fieldId] = field
+    while i <= #entries do
+        local slice = {}
+        for j = i, math.min(i + per - 1, #entries) do slice[#slice + 1] = entries[j] end
+        for _, conn in ipairs(conns) do
+            conn:sendEvent(SoilScoutingMaskSyncEvent.newDelta(farmId, slice))
         end
-        spatialScouting.masks[farmId] = farm
+        total = total + #slice
+        i = i + per
+    end
+    SoilLogger.info("SF22_MASK_DELTA_SENT farm=%d entries=%d remotes=%d", farmId, total, #conns)
+end
+
+-- ── Client-side apply (client only) ───────────────────────
+
+SoilScoutingBridge._maskBuffer = nil   -- in-flight FULL: { farmId, chunkCount, chunks, received }
+
+local function sfRejectMask(reason)
+    SoilLogger.warning("SF22_MASK_REJECT reason=%s", tostring(reason))
+end
+
+--- Merge entries into one farm's live tables. isFull replaces that farm's slice
+--- atomically (only ever called with a complete, validated chunk set); a DELTA
+--- never clears. Every entry raises the field generation before freshness and
+--- keeps the freshest walk day per cell.
+local function sfApplyEntries(spatialScouting, farmId, entries, isFull)
+    if type(entries) ~= "table" then return end
+    spatialScouting.masks = spatialScouting.masks or {}
+    spatialScouting.generations = spatialScouting.generations or {}
+    if isFull then
+        spatialScouting.masks[farmId] = {}
+        spatialScouting.generations[farmId] = {}
+        if spatialScouting.seenDiscovered then spatialScouting.seenDiscovered[farmId] = {} end
+    end
+    local farm = spatialScouting.masks[farmId]
+    if farm == nil then farm = {}; spatialScouting.masks[farmId] = farm end
+    local gens = spatialScouting.generations[farmId]
+    if gens == nil then gens = {}; spatialScouting.generations[farmId] = gens end
+    for _, e in ipairs(entries) do
+        if e.fieldId ~= nil and e.cellKey ~= nil then
+            local eGen = e.gen or 0
+            if (gens[e.fieldId] or 0) < eGen then gens[e.fieldId] = eGen end
+            local field = farm[e.fieldId]
+            if field == nil then field = {}; farm[e.fieldId] = field end
+            local cur = field[e.cellKey]
+            if cur == nil or (e.day or 0) >= (cur.day or 0) then
+                field[e.cellKey] = { day = e.day or 0, truth = e.truth or 0, x = e.x or 0, z = e.z or 0, gen = eGen }
+            end
+        end
     end
 end
 
---- Register with NetworkSync when present.
+--- Buffer a FULL chunk; apply the whole farm atomically once every index has
+--- arrived exactly once. Chunk 1 (re)starts the buffer; duplicates, gaps,
+--- out-of-range indices and a farm/chunkCount mismatch are rejected without
+--- touching live tables.
+local function sfBufferFullChunk(spatialScouting, localFarmId, payload)
+    local ci, cc = payload.chunkIndex, payload.chunkCount
+    if type(ci) ~= "number" or type(cc) ~= "number" or cc < 1 or ci < 1 or ci > cc then
+        SoilScoutingBridge._maskBuffer = nil; sfRejectMask("chunkrange"); return
+    end
+    if ci == 1 then
+        SoilScoutingBridge._maskBuffer = { farmId = localFarmId, chunkCount = cc, chunks = {}, received = 0 }
+    end
+    local buf = SoilScoutingBridge._maskBuffer
+    if buf == nil or buf.farmId ~= localFarmId or buf.chunkCount ~= cc then
+        SoilScoutingBridge._maskBuffer = nil; sfRejectMask("nostart"); return
+    end
+    if buf.chunks[ci] ~= nil then sfRejectMask("dup"); return end
+    buf.chunks[ci] = payload.entries or {}
+    buf.received = buf.received + 1
+    if buf.received >= buf.chunkCount then
+        local all = {}
+        for idx = 1, buf.chunkCount do
+            local part = buf.chunks[idx]
+            if part == nil then SoilScoutingBridge._maskBuffer = nil; sfRejectMask("incomplete"); return end
+            for _, e in ipairs(part) do all[#all + 1] = e end
+        end
+        SoilScoutingBridge._maskBuffer = nil
+        sfApplyEntries(spatialScouting, localFarmId, all, true)   -- FULL: atomic replace
+    end
+end
+
+--- Apply one received mask event (client side). Rejects a non-ordinary local
+--- farm, a non-table payload, an unknown mode, or a payload for a different
+--- farm, all BEFORE any mutation.
+---@param spatialScouting SpatialScouting|nil
+---@param localFarmId any
+---@param payload table  { mode, farmId, chunkIndex, chunkCount, entries }
+function SoilScoutingBridge.applyMaskEvent(spatialScouting, localFarmId, payload)
+    if spatialScouting == nil then return end
+    if type(payload) ~= "table" then sfRejectMask("payload"); return end
+    if not SpatialScouting.isOrdinaryFarmId(localFarmId) then sfRejectMask("localfarm"); return end
+    if payload.farmId ~= localFarmId then sfRejectMask("wrongfarm"); return end
+    if payload.mode == SoilScoutingBridge.MASK_MODE_DELTA then
+        sfApplyEntries(spatialScouting, localFarmId, payload.entries, false)
+    elseif payload.mode == SoilScoutingBridge.MASK_MODE_FULL then
+        sfBufferFullChunk(spatialScouting, localFarmId, payload)
+    else
+        sfRejectMask("mode")
+    end
+end
+
+-- ── Pure-client farm-switch route ─────────────────────────
+
+--- Classify a local farm-id observation. The first observation and an unchanged
+--- id are no-ops. A later change clears (the old farm's knowledge must not
+--- linger) and requests a fresh FULL only when the new farm is ordinary.
+---@param initialized boolean
+---@param previousFarmId any
+---@param currentFarmId any
+---@return table|nil  nil for no-op, else { clear=true, request=boolean }
+function SoilScoutingBridge.classifyLocalFarmTransition(initialized, previousFarmId, currentFarmId)
+    if not initialized then return nil end
+    if previousFarmId == currentFarmId then return nil end
+    return { clear = true, request = SpatialScouting.isOrdinaryFarmId(currentFarmId) }
+end
+
+SoilScoutingBridge._transition = nil   -- { scouting, lastFarmId, initialized }
+
+--- Pure-client only. Subscribe to PLAYER_FARM_CHANGED so a farm switch drops the
+--- old farm's mask and pulls a fresh FULL for the new one.
 ---@param spatialScouting SpatialScouting|nil
 ---@return boolean registered
-function SoilScoutingBridge.registerSync(spatialScouting)
-    SoilScoutingBridge.syncActive = false
+function SoilScoutingBridge.registerFarmTransitionSubscriber(spatialScouting)
     if spatialScouting == nil then return false end
-
-    local ns = getNetworkSync()
-    if ns == nil or ns.registerModule == nil then
-        SoilLogger.info("[SpatialScouting] NetworkSync not detected - mask is not shared (standalone fallback)")
-        return false
-    end
-
-    local ok, err = pcall(function()
-        ns:registerModule(SoilScoutingBridge.SYNC_MODULE_ID, {
-            channel      = SoilScoutingBridge.CHANNEL,
-            onWriteState = function() return SoilScoutingBridge.serializeMask(spatialScouting) end,
-            onReadState  = function(arr) SoilScoutingBridge.deserializeMask(arr, spatialScouting) end,
-        })
-    end)
-
-    if not ok then
-        SoilLogger.warning("[SpatialScouting] NetworkSync registration failed: %s (mask not shared)", tostring(err))
-        return false
-    end
-
-    SoilScoutingBridge.syncActive = true
-    SoilLogger.info("[OK] SpatialScouting registered with NetworkSync as '%s'",
-        SoilScoutingBridge.SYNC_MODULE_ID)
+    if g_server ~= nil then return false end            -- pure client only
+    if g_messageCenter == nil then return false end
+    if SoilScoutingBridge._transition ~= nil then return false end
+    SoilScoutingBridge._transition = {
+        scouting    = spatialScouting,
+        lastFarmId  = g_localPlayer and g_localPlayer.farmId or nil,
+        initialized = g_localPlayer ~= nil and g_localPlayer.farmId ~= nil,
+    }
+    g_messageCenter:subscribe(MessageType.PLAYER_FARM_CHANGED,
+        SoilScoutingBridge.onPlayerFarmChanged, SoilScoutingBridge)
     return true
 end
 
---- Flag the mask dirty for the next 1Hz NetworkSync batch.
-function SoilScoutingBridge.markDirty()
-    if not SoilScoutingBridge.syncActive then return end
-    local ns = getNetworkSync()
-    if ns ~= nil and ns.markDirty then
-        ns:markDirty(SoilScoutingBridge.SYNC_MODULE_ID)
+--- PLAYER_FARM_CHANGED handler. MessageCenter invokes this as (target, player),
+--- so `self` is SoilScoutingBridge and `player` is the switched player. Only the
+--- LOCAL player's own switch matters; another player's switch does nothing.
+---@param self any
+---@param player any
+function SoilScoutingBridge.onPlayerFarmChanged(self, player)
+    local st = SoilScoutingBridge._transition
+    if st == nil then return end
+    if player == nil or player ~= g_localPlayer then return end
+    local oldFarmId = st.lastFarmId
+    local newFarmId = g_localPlayer and g_localPlayer.farmId
+    local decision  = SoilScoutingBridge.classifyLocalFarmTransition(st.initialized, oldFarmId, newFarmId)
+    st.initialized = true
+    st.lastFarmId  = newFarmId
+    if decision == nil then return end
+    if decision.clear then
+        SoilScoutingBridge._maskBuffer = nil              -- abandon any in-flight FULL
+        local sc = st.scouting
+        if sc ~= nil then
+            sc.masks = {}
+            sc.generations = {}
+            if sc.seenDiscovered then sc.seenDiscovered = {} end
+        end
     end
+    SoilLogger.info("SF22_MASK_TRANSITION old=%s new=%s clear=%s request=%s",
+        tostring(oldFarmId), tostring(newFarmId),
+        decision.clear and "1" or "0", decision.request and "1" or "0")
+    if decision.request and SoilScoutingMaskRequestEvent ~= nil
+       and g_client ~= nil and type(g_client.getServerConnection) == "function" then
+        g_client:getServerConnection():sendEvent(SoilScoutingMaskRequestEvent.new())
+    end
+end
+
+--- Drop the farm-switch subscriber and any in-flight FULL buffer (on unload).
+function SoilScoutingBridge.unregisterFarmTransitionSubscriber()
+    if g_messageCenter ~= nil and type(g_messageCenter.unsubscribeAll) == "function" then
+        g_messageCenter:unsubscribeAll(SoilScoutingBridge)
+    end
+    SoilScoutingBridge._transition = nil
+    SoilScoutingBridge._maskBuffer = nil
 end

--- a/src/main.lua
+++ b/src/main.lua
@@ -353,7 +353,9 @@ local function loadedMission(mission, node)
             SoilScoutingBridge.registerLedger(scouting)
             SoilScoutingBridge.loadFallback(scouting)
             SoilScoutingBridge.registerAccruals(scouting)
-            SoilScoutingBridge.registerSync(scouting)
+            -- [SF-22] The walked mask no longer rides NetworkSync (it cannot scope
+            -- delivery to one farm). Its own host-owned event route handles sharing:
+            -- the pure-client subscriber is registered in the client full-sync block.
         end
     end
 
@@ -595,8 +597,17 @@ local function loadedMission(mission, node)
     -- SoilRequestFullSyncEvent asks the server for all settings + field data.
     -- The retry handler (AsyncRetryHandler) makes up to 3 attempts with delay
     -- in case the server-side soil system hasn't finished initializing yet.
-    if g_client ~= nil and g_server == nil and SoilNetworkEvents_RequestFullSync then
-        SoilNetworkEvents_RequestFullSync()
+    if g_client ~= nil and g_server == nil then
+        -- [SF-22] Pure client: arm the farm-switch subscriber BEFORE the first
+        -- full-sync request, so a switch that lands during the join handshake is
+        -- still classified (drop old farm, pull the new farm's private mask).
+        local scouting = sfm and sfm.soilSystem and sfm.soilSystem.spatialScouting
+        if scouting and SoilScoutingBridge and SoilScoutingBridge.registerFarmTransitionSubscriber then
+            SoilScoutingBridge.registerFarmTransitionSubscriber(scouting)
+        end
+        if SoilNetworkEvents_RequestFullSync then
+            SoilNetworkEvents_RequestFullSync()
+        end
     end
 end
 
@@ -676,6 +687,12 @@ end
 
 -- Unload handler
 local function unload()
+    -- [SF-22] Drop the pure-client farm-switch subscriber and any in-flight FULL
+    -- buffer so a session reload never accumulates a stale subscription. Safe to
+    -- call unconditionally: it no-ops when nothing was registered.
+    if SoilScoutingBridge and SoilScoutingBridge.unregisterFarmTransitionSubscriber then
+        SoilScoutingBridge.unregisterFarmTransitionSubscriber()
+    end
     if sfm ~= nil then
         sfm:delete()
         sfm = nil

--- a/src/maps/SoilValueMaps.lua
+++ b/src/maps/SoilValueMaps.lua
@@ -567,7 +567,218 @@ function SoilValueMaps:addPaintStrip(key, sx, sz, wx, wz, hx, hz, delta)
         self.hasExecuteAdd = false
         return 0
     end
+
+    -- [SF-30] Saturation band: CLAMP the pixels the add had to skip.
+    --
+    -- The filter above deliberately excludes any pixel that would overflow the
+    -- raw range. That protects the no-data sentinel, but it means a LARGE dose
+    -- silently does nothing to ground that is already moderately stocked, while
+    -- addPaintStrip still returns the full semantic delta as if it had landed.
+    -- Measured live on 2026-08-25: liquid MAP painting phosphorus with
+    -- rawDelta=105 set the filter ceiling to 255-105=150, and the sprayed pixels
+    -- sat at raw 180, so every pass was discarded. The log read
+    -- "applied=41.3386 pixel 70.47 -> 70.47" - product left the tank, the field
+    -- scalar rose, and the map quietly kept its old value. Nitrogen in the same
+    -- product had rawDelta=2, cleared the ceiling, and moved correctly, which is
+    -- why one nutrient appeared to work and the other did not.
+    --
+    -- A pixel that cannot take the whole delta should end up AT the ceiling, not
+    -- refuse the paint. Same at the floor for a negative delta.
+    if type(m.executeSet) == "function" then
+        local sok, serr = pcall(function()
+            if rawDelta > 0 then
+                -- Everything from the add's ceiling upward saturates to RAW_MAX.
+                filter:setValueCompareParams(DensityValueCompareType.BETWEEN,
+                    math.max(rawLow, RAW_MAX - rawDelta + 1), RAW_MAX)
+                m:executeSet(RAW_MAX, filter)
+            else
+                -- Mirror at the bottom, never below the layer's own floor.
+                filter:setValueCompareParams(DensityValueCompareType.BETWEEN,
+                    rawLow, math.min(RAW_MAX, rawLow - rawDelta - 1))
+                m:executeSet(rawLow, filter)
+            end
+        end)
+        if not sok then
+            -- Non-fatal: the add already happened, this only tops up the band.
+            SoilLogger.debug("SoilValueMaps: addPaintStrip saturation clamp failed (%s)", tostring(serr))
+        end
+    end
+
     return rawDelta * upr
+end
+
+--- [SF-32] Apply a dose across a swept strip PER 2 m CELL, capped at a target.
+---
+--- This is the prescription-map rule, and it replaces "add the same amount
+--- everywhere and hope the average lands right":
+---   * a cell already AT or ABOVE target receives NOTHING - not a floored
+---     minimum rate, nothing at all;
+---   * a cell below target receives the dose, or exactly the amount that brings
+---     it to target, whichever is SMALLER, so nothing is ever pushed past it.
+---
+--- Two engine passes do it exactly, with no per-pixel loop:
+---   1. every pixel that can absorb the WHOLE dose without crossing target gets
+---      it via the banded add;
+---   2. every pixel still below target that WOULD have overshot is set to the
+---      target value precisely.
+--- Pixels at or above target match neither band and are never written.
+---
+--- The return value is measured FROM THE MAP (mean over the strip, before and
+--- after) rather than assumed from the request, because how much actually lands
+--- depends entirely on how much of this strip was short. That number is what the
+--- caller should credit to the field scalar and charge to the tank, which is how
+--- map, scalar and tank stay reconciled.
+---
+---@param key string          layer key
+---@param sx number           start corner x of the swept quad
+---@param sz number           start corner z
+---@param wx number           width corner x
+---@param wz number           width corner z
+---@param hx number           height corner x
+---@param hz number           height corner z
+---@param delta number        dose offered to this strip, in semantic units
+---@param targetValue number  value no cell may be pushed past
+---@return number             mean semantic change actually written
+--- [SF-36] Ceiling-sentinel repair for a swept strip (George CLOSED DESIGN
+--- 07:03). Plain addPaintStrip's saturation band ([SF-30]) sets pixels it
+--- cannot fully add to straight to RAW_MAX, which on the pH layer decodes to
+--- 7.5 - a value that then STICKS and reads as over-limed forever. Overlap is
+--- supposed to run hot (Wizard: double-pass double-limes, like real life), but
+--- it must never park at the layer ceiling. This scans ONLY the painted
+--- parallelogram for pixels sitting exactly at RAW_MAX and sets them to the
+--- agronomic target. Under-target pixels are untouched, so it cannot create
+--- the skip-holes the target-cap caused.
+---@param key string           layer key
+---@param sx number            start corner x of the swept quad
+---@param sz number            start corner z
+---@param wx number            width corner x
+---@param wz number            width corner z
+---@param hx number            height corner x
+---@param hz number            height corner z
+---@param targetValue number   semantic value RAW_MAX pixels are repaired to
+---@return boolean             true when the repair pass executed
+--- [SF-45] Clamp every pixel in a swept strip DOWN to a ceiling. Unlike the
+--- ToTarget fill (whose Pass 2 re-processed pixels Pass 1 had just moved and
+--- overshot the per-pass cap - the offered=0.60/applied=0.71 smoking gun), a
+--- clamp can only reduce: pixels at or under the ceiling are untouched, pixels
+--- above it (overlap accumulation, saturation) are set exactly to it.
+---@param key string          layer key
+---@param sx number           start corner x of the swept quad
+---@param sz number           start corner z
+---@param wx number           width corner x
+---@param wz number           width corner z
+---@param hx number           height corner x
+---@param hz number           height corner z
+---@param ceilingValue number semantic ceiling pixels are pulled down to
+---@return boolean            true when the clamp pass executed
+function SoilValueMaps:clampCeilingInStrip(key, sx, sz, wx, wz, hx, hz, ceilingValue)
+    if not self.available or ceilingValue == nil then return false end
+    local entry = self.layers[key]
+    if not entry then return false end
+    local m = entry.modifier
+    if type(m.executeSet) ~= "function" then return false end
+    local ceilRaw = encode(ceilingValue, entry.def)
+    if ceilRaw >= RAW_MAX then return false end
+    local ok, err = pcall(function()
+        m:setParallelogramWorldCoords(sx, sz, wx, wz, hx, hz, DensityCoordType.POINT_POINT_POINT)
+        entry.filter:setValueCompareParams(DensityValueCompareType.BETWEEN, ceilRaw + 1, RAW_MAX)
+        m:executeSet(ceilRaw, entry.filter)
+    end)
+    if not ok then
+        SoilLogger.debug("SoilValueMaps: clampCeilingInStrip failed (%s)", tostring(err))
+        return false
+    end
+    return true
+end
+
+function SoilValueMaps:repairCeilingInStrip(key, sx, sz, wx, wz, hx, hz, targetValue)
+    if not self.available or targetValue == nil then return false end
+    local entry = self.layers[key]
+    if not entry then return false end
+    local m = entry.modifier
+    if type(m.executeSet) ~= "function" then return false end
+    local targetRaw = encode(targetValue, entry.def)
+    if targetRaw >= RAW_MAX then return false end
+    local ok, err = pcall(function()
+        m:setParallelogramWorldCoords(sx, sz, wx, wz, hx, hz, DensityCoordType.POINT_POINT_POINT)
+        entry.filter:setValueCompareParams(DensityValueCompareType.BETWEEN, RAW_MAX, RAW_MAX)
+        m:executeSet(targetRaw, entry.filter)
+    end)
+    if not ok then
+        SoilLogger.debug("SoilValueMaps: repairCeilingInStrip failed (%s)", tostring(err))
+        return false
+    end
+    return true
+end
+
+function SoilValueMaps:addPaintStripToTarget(key, sx, sz, wx, wz, hx, hz, delta, targetValue)
+    if not self.available or delta == nil or delta <= 0 then return 0 end
+    if targetValue == nil then return 0 end
+    local entry = self.layers[key]
+    if not entry then return 0 end
+    local def = entry.def
+    local upr = unitsPerRaw(def)
+    local rawDelta = math.floor(delta / upr)
+    if rawDelta <= 0 then return 0 end
+
+    -- Parallelogram -> polygon. The fourth corner is w + (h - s).
+    local verts = {
+        { x = sx,           z = sz           },
+        { x = wx,           z = wz           },
+        { x = wx + hx - sx, z = wz + hz - sz },
+        { x = hx,           z = hz           },
+    }
+
+    local rawLow    = def.rawFloor or RAW_MIN
+    local targetRaw = encode(targetValue, def)
+    if targetRaw <= rawLow then return 0 end
+
+    local meanBefore = self:readAverageOfPolygon(key, verts)
+
+    -- Pass 1: full dose to everything that stays under target after taking it.
+    local fullHigh = targetRaw - rawDelta
+    if fullHigh >= rawLow then
+        self:applyRawDeltaToPolygonBand(key, verts, rawDelta, rawLow, fullHigh)
+    end
+
+    -- Pass 2: still short, but the full dose would overshoot. Land exactly on target.
+    local partLow = math.max(rawLow, targetRaw - rawDelta + 1)
+    if partLow <= targetRaw - 1 then
+        self:setPolygonWhere(key, verts, targetRaw, partLow, targetRaw - 1)
+    end
+
+    -- [FIX-1] Pass 3: repair the ceiling sentinel inside the strip we just painted.
+    --
+    -- Measured live 2026-08-26, field 82, 180 logged boom strips: 34% of probed
+    -- pixels finished at raw 255 (pH 7.5, the map ceiling) and 75% finished above
+    -- the 6.5 target -- on a field the player had deliberately set uniform. Passes
+    -- 1 and 2 above cannot produce that: Pass 1's band stops at targetRaw-rawDelta
+    -- and Pass 2 sets exactly targetRaw. Tillage was not running (no SF-26 flush
+    -- lines in that session), so this is the only path that touched pH.
+    --
+    -- Raw 255 is documented in this file as a SENTINEL -- "the ceiling refusal" --
+    -- not a point on the pH scale, so a pixel carrying it inside a strip we just
+    -- dosed is a refusal marker, not alkaline soil. Standing it back down to the
+    -- target repairs the marker without inventing soil chemistry.
+    --
+    -- Deliberately narrow: ONLY the sentinel, ONLY inside this polygon. Ground
+    -- genuinely above target keeps its value -- lime cannot lower pH, and a
+    -- blanket "clamp everything above target" would silently do exactly that.
+    if targetRaw < RAW_MAX and self:hasAnyInBand(key, verts, RAW_MAX, RAW_MAX) then
+        self:setPolygonWhere(key, verts, targetRaw, RAW_MAX, RAW_MAX)
+        SoilLogger.warning(
+            "[FIX-1] '%s': strip finished with raw-255 ceiling sentinel pixels after " ..
+            "a CAPPED paint (delta=%.4f rawDelta=%d targetRaw=%d). Stood them down to " ..
+            "target. Passes 1-2 cannot produce this, so if it keeps appearing the band " ..
+            "filter is not holding and the cause is upstream of the cap.",
+            tostring(key), delta, rawDelta, targetRaw)
+    end
+
+    local meanAfter = self:readAverageOfPolygon(key, verts)
+    if meanBefore == nil or meanAfter == nil then return 0 end
+    local applied = meanAfter - meanBefore
+    if applied <= 0 then return 0 end
+    return applied
 end
 
 -- ─────────────────────────────────────────────────────────

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -244,6 +244,12 @@ function SoilRequestFullSyncEvent:run(connection)
     -- unblocks and stops the retry timer right away.
     connection:sendEvent(SoilFullSyncEvent.new(g_SoilFertilityManager.settings, {}))
 
+    -- [SF-22] Piggyback the requesting farm's PRIVATE walked-mask FULL onto the
+    -- join handshake, so a joining client gets its own farm's mask right away and
+    -- never another farm's bytes. Sits before the field-count early return so an
+    -- empty-map join still delivers the mask. No-op for a non-ordinary farm.
+    SoilNetworkEvents_SendScoutingMaskFull(connection)
+
     -- Step 2: nothing to batch - we're done.
     if fieldCount == 0 then return end
 
@@ -2287,6 +2293,174 @@ function SoilNetworkEvents_BroadcastValueMapChecksums()
         end
     end
     g_server:broadcastEvent(SoilValueMapChecksumEvent.new(checksums))
+end
+
+-- ==========================================================================
+-- [SF-22] SoilScoutingMaskSyncEvent (server -> client): farm-private delivery of
+-- the walked mask. Mode FULL (0) replaces one farm's slice atomically across a
+-- contiguous chunk sequence; mode DELTA (1) adds a handful of freshly walked
+-- cells (always chunk 1 of 1). The server sends a farm's bytes ONLY to that
+-- farm's own clients, so another farm never receives an entry.
+--
+-- CLIENT-APPLY ONLY: the run() guard is `g_server ~= nil` (NOT the weaker
+-- `not g_client` used by SoilFullSyncEvent). A listen host has g_client, and
+-- Connection:sendEvent runs a local-stream event in-process; applying a display
+-- payload on the host would clobber its own authoritative mask.
+-- ==========================================================================
+SoilScoutingMaskSyncEvent = SoilScoutingMaskSyncEvent or {}
+SoilScoutingMaskSyncEvent_mt = Class(SoilScoutingMaskSyncEvent, Event)
+
+InitEventClass(SoilScoutingMaskSyncEvent, "SoilScoutingMaskSyncEvent")
+
+SoilScoutingMaskSyncEvent.SCHEMA      = 1
+SoilScoutingMaskSyncEvent.MODE_FULL   = 0
+SoilScoutingMaskSyncEvent.MODE_DELTA  = 1
+SoilScoutingMaskSyncEvent.MAX_ENTRIES = 32
+
+function SoilScoutingMaskSyncEvent.emptyNew()
+    return Event.new(SoilScoutingMaskSyncEvent_mt)
+end
+
+local function sfNewMaskSync(mode, farmId, chunkIndex, chunkCount, entries)
+    local self = SoilScoutingMaskSyncEvent.emptyNew()
+    self.mode       = mode
+    self.farmId     = farmId
+    self.chunkIndex = chunkIndex or 1
+    self.chunkCount = chunkCount or 1
+    self.entries    = entries or {}
+    return self
+end
+
+--- One FULL chunk (chunkIndex of chunkCount) of farmId's mask.
+function SoilScoutingMaskSyncEvent.newFull(farmId, chunkIndex, chunkCount, entries)
+    return sfNewMaskSync(SoilScoutingMaskSyncEvent.MODE_FULL, farmId, chunkIndex, chunkCount, entries)
+end
+
+--- One independently applicable DELTA (always chunk 1 of 1) of farmId's mask.
+function SoilScoutingMaskSyncEvent.newDelta(farmId, entries)
+    return sfNewMaskSync(SoilScoutingMaskSyncEvent.MODE_DELTA, farmId, 1, 1, entries)
+end
+
+function SoilScoutingMaskSyncEvent:writeStream(streamId, connection)
+    streamWriteUInt8(streamId, SoilScoutingMaskSyncEvent.SCHEMA)
+    streamWriteUInt8(streamId, self.mode or 0)
+    streamWriteUIntN(streamId, self.farmId or 0, FarmManager.FARM_ID_SEND_NUM_BITS)
+    streamWriteUInt16(streamId, self.chunkIndex or 1)
+    streamWriteUInt16(streamId, self.chunkCount or 1)
+    local n = math.min(#self.entries, SoilScoutingMaskSyncEvent.MAX_ENTRIES)
+    streamWriteUInt16(streamId, n)
+    for i = 1, n do
+        local e = self.entries[i]
+        streamWriteInt32(streamId, e.fieldId or 0)
+        streamWriteString(streamId, e.cellKey or "")
+        streamWriteInt32(streamId, e.day or 0)
+        streamWriteFloat32(streamId, e.truth or 0)
+        streamWriteFloat32(streamId, e.x or 0)
+        streamWriteFloat32(streamId, e.z or 0)
+        streamWriteInt32(streamId, e.gen or 0)
+    end
+end
+
+function SoilScoutingMaskSyncEvent:readStream(streamId, connection)
+    self.schema     = streamReadUInt8(streamId)
+    self.mode       = streamReadUInt8(streamId)
+    self.farmId     = streamReadUIntN(streamId, FarmManager.FARM_ID_SEND_NUM_BITS)
+    self.chunkIndex = streamReadUInt16(streamId)
+    self.chunkCount = streamReadUInt16(streamId)
+    local n = streamReadUInt16(streamId)
+    self.entries = {}
+    for i = 1, n do
+        local e = {}
+        e.fieldId = streamReadInt32(streamId)
+        e.cellKey = streamReadString(streamId)
+        e.day     = streamReadInt32(streamId)
+        e.truth   = streamReadFloat32(streamId)
+        e.x       = streamReadFloat32(streamId)
+        e.z       = streamReadFloat32(streamId)
+        e.gen     = streamReadInt32(streamId)
+        self.entries[i] = e
+    end
+    self:run(connection)
+end
+
+function SoilScoutingMaskSyncEvent:run(connection)
+    -- CLIENT-APPLY ONLY. The listen host is g_server ~= nil and must never
+    -- overwrite its own authoritative mask with a display payload.
+    if g_server ~= nil then return end
+    local scouting = g_SoilFertilityManager and g_SoilFertilityManager.soilSystem
+        and g_SoilFertilityManager.soilSystem.spatialScouting
+    if scouting == nil or SoilScoutingBridge == nil or SoilScoutingBridge.applyMaskEvent == nil then return end
+    local localFarmId = g_localPlayer and g_localPlayer.farmId
+    SoilScoutingBridge.applyMaskEvent(scouting, localFarmId, {
+        schema     = self.schema,
+        mode       = self.mode,
+        farmId     = self.farmId,
+        chunkIndex = self.chunkIndex,
+        chunkCount = self.chunkCount,
+        entries    = self.entries,
+    })
+end
+
+-- ==========================================================================
+-- [SF-22] SoilScoutingMaskRequestEvent (client -> server): "send me a fresh FULL
+-- of my current farm's mask". No payload, no selector: the server resolves the
+-- requesting connection's user and ordinary farm and replies with one contiguous
+-- FULL. Spectator / guided-tour / invalid / unresolved receives no mask. Sent on
+-- a farm switch; the join case piggybacks on SoilRequestFullSyncEvent:run.
+-- ==========================================================================
+SoilScoutingMaskRequestEvent = SoilScoutingMaskRequestEvent or {}
+SoilScoutingMaskRequestEvent_mt = Class(SoilScoutingMaskRequestEvent, Event)
+
+InitEventClass(SoilScoutingMaskRequestEvent, "SoilScoutingMaskRequestEvent")
+
+function SoilScoutingMaskRequestEvent.emptyNew()
+    return Event.new(SoilScoutingMaskRequestEvent_mt)
+end
+
+function SoilScoutingMaskRequestEvent.new()
+    return SoilScoutingMaskRequestEvent.emptyNew()
+end
+
+function SoilScoutingMaskRequestEvent:readStream(streamId, connection)
+    self:run(connection)
+end
+
+function SoilScoutingMaskRequestEvent:writeStream(streamId, connection)
+    -- no payload: the server resolves the farm from the connection, never the wire
+end
+
+function SoilScoutingMaskRequestEvent:run(connection)
+    -- SERVER ONLY: resolve the requester's ordinary farm and reply with a FULL.
+    if g_server == nil or connection == nil then return end
+    SoilNetworkEvents_SendScoutingMaskFull(connection)
+end
+
+--- Server helper: resolve a connection's ordinary farm and send its walked-mask
+--- FULL. No-op for a non-ordinary or unresolved farm. Shared by the join
+--- piggyback (SoilRequestFullSyncEvent:run) and the farm-switch request event.
+---@param connection table
+function SoilNetworkEvents_SendScoutingMaskFull(connection)
+    if g_server == nil or connection == nil then return end
+    local scouting = g_SoilFertilityManager and g_SoilFertilityManager.soilSystem
+        and g_SoilFertilityManager.soilSystem.spatialScouting
+    if scouting == nil or SoilScoutingBridge == nil or SoilScoutingBridge.sendFarmFull == nil then return end
+
+    local userManager = g_currentMission and g_currentMission.userManager
+    local user = userManager and userManager:getUserByConnection(connection)
+    if user == nil then return end
+
+    local farmId = nil
+    if g_farmManager and type(g_farmManager.getFarmByUserId) == "function" then
+        local farm = g_farmManager:getFarmByUserId(user:getId())
+        farmId = farm and farm.farmId
+    end
+    if farmId == nil then farmId = user.farmId end
+
+    if not (SpatialScouting and SpatialScouting.isOrdinaryFarmId
+            and SpatialScouting.isOrdinaryFarmId(farmId)) then
+        return
+    end
+    SoilScoutingBridge.sendFarmFull(scouting, connection, farmId)
 end
 
 SoilLogger.info("Network events system loaded")

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -69,6 +69,7 @@ function SoilSettingsGUI:registerConsoleCommands()
     addConsoleCommand("SoilResetSettings", "Reset all settings to defaults", "consoleCommandResetSettings", self)
     addConsoleCommand("SoilSaveData", "Force save soil data", "consoleCommandSaveData", self)
     addConsoleCommand("SoilDebug", "Toggle debug mode", "consoleCommandDebug", self)
+    addConsoleCommand("rfAutoRateSet", "Playtest harness: force sprayer Auto rate ON (1) / OFF (0) / normal (clear) for ALL vehicles this session", "consoleCommandAutoRateSet", self)
     addConsoleCommand("SoilDrainVehicle", "Drain custom fertilizer from current vehicle/implements (50% refund)", "consoleCommandDrainVehicle", self)
     addConsoleCommand("soilSetState", "Set field state: soilSetState <fieldId> <N> <P> <K> <pH> <OM>", "consoleCommandSetState", self)
     addConsoleCommand("soilRecoverField", "Recover field to default values: soilRecoverField [fieldId]", "consoleCommandRecoverField", self)
@@ -1285,6 +1286,30 @@ function SoilSettingsGUI:consoleCommandSetPlowingBonus(enabled)
         return string.format("Plowing bonus %s", newVal and "enabled" or "disabled")
     end
     return "Error: Soil Mod not initialized"
+end
+
+--- [SF-46] Playtest harness (BUILD 13:54): deterministic Auto lock that a
+--- console can set when the Shift-R+L chord cannot be delivered reliably.
+--- Sets SprayerRateManager.autoForce, which getAutoMode consults FIRST for
+--- every vehicle - so it survives vehicle changes and helper hand-off, and
+--- the HUD reads the forced state through the same getter it always used.
+--- `rfAutoRateSet 1` = force ON, `rfAutoRateSet 0` = force OFF,
+--- `rfAutoRateSet clear` = remove the override (per-vehicle toggles rule again).
+function SoilSettingsGUI:consoleCommandAutoRateSet(arg)
+    local sfm = g_SoilFertilityManager
+    local rm = sfm and sfm.sprayerRateManager
+    if not rm then return "rfAutoRateSet: sprayerRateManager not available" end
+    if arg == "1" then
+        rm.autoForce = true
+        return "Auto rate FORCED ON for all vehicles (session; 'rfAutoRateSet clear' to undo)"
+    elseif arg == "0" then
+        rm.autoForce = false
+        return "Auto rate FORCED OFF for all vehicles (session; 'rfAutoRateSet clear' to undo)"
+    elseif arg == "clear" or arg == nil or arg == "" then
+        rm.autoForce = nil
+        return "Auto rate override cleared - per-vehicle toggle (Shift-R+L) rules again"
+    end
+    return "Usage: rfAutoRateSet 1|0|clear"
 end
 
 function SoilSettingsGUI:consoleCommandDebug()

--- a/src/specializations/SFNozzleEffects.lua
+++ b/src/specializations/SFNozzleEffects.lua
@@ -51,10 +51,61 @@ end
 
 -- Price of the combined See & Spray upgrade (single purchase enables weed+pest+disease).
 SFNozzleEffects.SEE_SPRAY_PRICE = 2500
+-- [PACK] Precision pack: variable rate + section control, one purchase.
+-- Without it a sprayer applies ONE rate across the whole boom, set by hand or by
+-- auto-rate, and over-application is possible -- which is what a machine with no
+-- rate control actually does.
+SFNozzleEffects.PRECISION_PRICE = 4500
 
 -- Make the combined See & Spray Yes/No configuration buyable on EVERY sprayer, not only
 -- vehicles whose XML declares it. Mirrors PF SprayerNodeData's getConfigurationsFromXML
 -- override exactly (synthesize a 2-item VehicleConfigurationItem set) - no PF dependency.
+--- [PACK] True when this machine was bought with the precision pack.
+function SFNozzleEffects:sfHasPrecisionPack()
+    local spec = self[SFNozzleEffects.SPEC_TABLE_NAME]
+    return spec ~= nil and spec.hasPrecision == true
+end
+
+
+--- [PACK] True for a sprayer that predates the pack and so lost variable rate on
+--- this load. Used once, to explain the change rather than let it read as a bug.
+function SFNozzleEffects:sfIsLegacyNoPack()
+    local spec = self[SFNozzleEffects.SPEC_TABLE_NAME]
+    return spec ~= nil and spec.legacyNoPack == true
+end
+
+
+--- [SPRAY-ONLY] Can this machine actually carry crop protection?
+---
+--- In FS25 a manure spreader, a slurry tanker and a bulk fertiliser spreader all
+--- declare a <sprayer> block, so testing for that alone offered See & Spray on
+--- muck spreaders. It could never fire there -- the spot-spray path returns early
+--- unless the tank holds herbicide, insecticide or fungicide -- but the player
+--- could still be sold the upgrade, which is its own bug.
+---
+--- fillTypeCategories is the real discriminator: crop sprayers carry "sprayer",
+--- while the others carry MANURESPREADER / slurryTank / BULK. Substring match is
+--- safe here: "spreader" does not contain "sprayer".
+local function sfCanCarryCropProtection(xmlFile, key)
+    local found = false
+    local function checkUnit(_, fuKey)
+        if found then return end
+        local cats = xmlFile:getString(fuKey .. "#fillTypeCategories")
+        if cats and string.find(string.lower(cats), "sprayer", 1, true) then
+            found = true
+        end
+    end
+    -- Configured form (most vehicles) and the plain form, in that order.
+    xmlFile:iterate(key .. ".fillUnit.fillUnitConfigurations.fillUnitConfiguration",
+        function(_, cfgKey)
+            xmlFile:iterate(cfgKey .. ".fillUnits.fillUnit", checkUnit)
+        end)
+    if not found then
+        xmlFile:iterate(key .. ".fillUnit.fillUnits.fillUnit", checkUnit)
+    end
+    return found
+end
+
 function SFNozzleEffects.installConfigInjector()
     if SFNozzleEffects._didInstallConfigInjector then return end
     if ConfigurationUtil == nil or type(ConfigurationUtil.getConfigurationsFromXML) ~= "function" then
@@ -80,7 +131,13 @@ function SFNozzleEffects.installConfigInjector()
             configurations         = configurations or {}
             defaultConfigurationIds = defaultConfigurationIds or {}
 
-            if configurations["sfSeeSpray"] == nil then
+            -- [SPRAY-ONLY] Crop-protection machines only -- and the precision pack
+            -- below takes the same gate. A muck spreader or slurry tanker has no
+            -- boom sections to shut off and no per-cell dosing to do; application
+            -- rate is the only control that means anything on one, and that ships
+            -- as standard on every machine.
+            if configurations["sfSeeSpray"] == nil
+                and sfCanCarryCropProtection(xmlFile, key) then
                 local items = {}
 
                 local no = VehicleConfigurationItem.new("sfSeeSpray")
@@ -102,6 +159,33 @@ function SFNozzleEffects.installConfigInjector()
 
                 defaultConfigurationIds["sfSeeSpray"] = ConfigurationUtil.getDefaultConfigIdFromItems(items)
                 configurations["sfSeeSpray"] = items
+            end
+
+            -- [PACK] Same treatment, and the same crop-sprayer gate.
+            if SFNozzleEffects._precisionConfigRegistered
+                and configurations["sfPrecision"] == nil
+                and sfCanCarryCropProtection(xmlFile, key) then
+                local pItems = {}
+
+                local pNo = VehicleConfigurationItem.new("sfPrecision")
+                pNo.isDefault     = true
+                pNo.name          = g_i18n:getText("configuration_valueNo")
+                pNo.index         = 1
+                pNo.saveId        = "1"
+                pNo.price         = 0
+                pNo.isYesNoOption = true
+                table.insert(pItems, pNo)
+
+                local pYes = VehicleConfigurationItem.new("sfPrecision")
+                pYes.name          = g_i18n:getText("configuration_valueYes")
+                pYes.index         = 2
+                pYes.saveId        = "2"
+                pYes.price         = SFNozzleEffects.PRECISION_PRICE
+                pYes.isYesNoOption = true
+                table.insert(pItems, pYes)
+
+                defaultConfigurationIds["sfPrecision"] = ConfigurationUtil.getDefaultConfigIdFromItems(pItems)
+                configurations["sfPrecision"] = pItems
             end
         end
 
@@ -218,6 +302,15 @@ function SFNozzleEffects.initSpecialization()
         )
         -- Gate the shop-config injector: only synthesize items for a registered type.
         SFNozzleEffects._seeSprayConfigRegistered = true
+
+        -- [PACK] Precision pack as a second Yes/No shop configuration.
+        g_vehicleConfigurationManager:addConfigurationType(
+            "sfPrecision",
+            g_i18n:getText("sf_config_precision"),
+            "sfPrecision",
+            VehicleConfigurationItem
+        )
+        SFNozzleEffects._precisionConfigRegistered = true
     end
 end
 
@@ -233,6 +326,8 @@ function SFNozzleEffects.registerFunctions(vehicleType)
     -- Sharing those names lets one spec overwrite the other, so the 5-arg caller would hit
     -- our 4-arg function and pass a boolean into lastSpeed (the SFNozzleEffects:419
     -- "compare boolean < number" crash, issue #636). Never reuse those names here.
+    SpecializationUtil.registerFunction(vehicleType, "sfHasPrecisionPack",           SFNozzleEffects.sfHasPrecisionPack)
+    SpecializationUtil.registerFunction(vehicleType, "sfIsLegacyNoPack",             SFNozzleEffects.sfIsLegacyNoPack)
     SpecializationUtil.registerFunction(vehicleType, "sfGetNumNozzleEffectsActive",  SFNozzleEffects.sfGetNumNozzleEffectsActive)
     SpecializationUtil.registerFunction(vehicleType, "sfUpdateNozzleEffectsState",   SFNozzleEffects.sfUpdateNozzleEffectsState)
     SpecializationUtil.registerFunction(vehicleType, "sfUpdateNozzleEffectState",    SFNozzleEffects.sfUpdateNozzleEffectState)
@@ -267,8 +362,18 @@ function SFNozzleEffects:onPreLoad(savegame)
     spec.seeSprayWeed    = combined or oldWeed
     spec.seeSprayPest    = combined or oldPest
     spec.seeSprayDisease = combined or oldDisease
-    SoilLogger.debug("[SFNozzleEffects] onPreLoad: seeSprayWeed=%s seeSprayPest=%s seeSprayDisease=%s",
-        tostring(spec.seeSprayWeed), tostring(spec.seeSprayPest), tostring(spec.seeSprayDisease))
+    -- [PACK] Variable rate + section control are one purchase.
+    spec.hasPrecision = (self.configurations["sfPrecision"] or 1) > 1
+    -- [PACK] A sprayer already in a save from before the pack existed has no
+    -- sfPrecision configuration at all -- distinct from a new purchase where the
+    -- player chose "No". Both end up without the pack, but only the first has had
+    -- a feature taken away, so only the first is owed an explanation.
+    spec.legacyNoPack = (savegame ~= nil)
+        and (self.configurations["sfPrecision"] == nil)
+        and not spec.hasPrecision
+    SoilLogger.debug("[SFNozzleEffects] onPreLoad: seeSprayWeed=%s seeSprayPest=%s seeSprayDisease=%s precision=%s",
+        tostring(spec.seeSprayWeed), tostring(spec.seeSprayPest), tostring(spec.seeSprayDisease),
+        tostring(spec.hasPrecision))
 end
 
 -- ── onLoad - read nozzle nodes from XML ──────────────────────────────────────

--- a/src/ui/RfPdaSoilPanel.lua
+++ b/src/ui/RfPdaSoilPanel.lua
@@ -743,9 +743,23 @@ function RfPdaSoilPanel.refreshTreatmentPlan(page)
     end
     setSelectedLabel(nextTip)
 
+    -- [SF-33] When the average reads fine but the map does not, say so rather
+    -- than showing a bare "OK". A player who has just looked at a patchy SOIL
+    -- LAYERS map and then reads "no treatment needed" stops trusting the plan.
+    local mismatchLine = nil
+    if SoilTreatmentRates and SoilTreatmentRates.getSpatialMismatchLine then
+        local okM, m = pcall(SoilTreatmentRates.getSpatialMismatchLine, fieldId)
+        if okM then mismatchLine = m end
+    end
+
     if #rows == 0 then
-        setProductOk(tr("sf_treat_action_ok", "OK - no treatment needed"), COLOR_GOOD)
+        if mismatchLine then
+            setProductOk(mismatchLine, COLOR_FAIR)
+        else
+            setProductOk(tr("sf_treat_action_ok", "OK - no treatment needed"), COLOR_GOOD)
+        end
     else
+        if mismatchLine then setSelectedLabel(mismatchLine) end
         fillProductRows(rows)
     end
 

--- a/src/ui/SoilGuideDialog.lua
+++ b/src/ui/SoilGuideDialog.lua
@@ -78,12 +78,12 @@ SoilGuideDialog.PAGE1 = {
     { t="B", k="sf_guide_p1_36", v="See & Spray   Live per-cell pressure in the vehicle." },
     { t="B", k="sf_guide_p1_37", v="  Any sprayer with the See & Spray shop config." },
     { t="B", k="sf_guide_p1_38", v="Variable Rate  Auto-adjusts boom rate from deficits." },
-    { t="B", k="sf_guide_p1_39", v="  Key: Toggle Variable Rate (Alt+7). Admin on." },
+    { t="B", k="sf_guide_p1_39", v="  Key: Right Shift+V toggles Variable Rate. Admin on." },
     { t="S", v=" " },
     { t="H", k="sf_guide_p1_40", v="KEYBINDINGS" },
-    { t="B", k="sf_guide_p1_41", v="Most keys ship unbound. Four have defaults:" },
-    { t="B", k="sf_guide_p1_42", v="HUD Drag = Shift+H, Variable Rate = Alt+7," },
-    { t="B", k="sf_guide_p1_43", v="Scout = Shift+K, Treatment = Shift+T." },
+    { t="B", k="sf_guide_p1_41", v="Soil uses Right Shift + a letter (or [ ] for rate):" },
+    { t="B", k="sf_guide_p1_42", v="HUD O, Drag P, Variable Rate V, Auto Rate L," },
+    { t="B", k="sf_guide_p1_43", v="Rate [ / ], Scout K, Treatment T, Settings S, Map M." },
     { t="B", k="sf_guide_p1_44", v="Rebind any of them in Options > Controls > Mods." },
 }
 
@@ -142,7 +142,7 @@ SoilGuideDialog.PAGE2 = {
     { t="B", k="sf_guide_p2_42", v="See & Spray: any sprayer with the S&S shop config." },
     { t="S", v=" " },
     { t="H", k="sf_guide_p2_43", v="FREE PANEL LAYOUT" },
-    { t="B", k="sf_guide_p2_44", v="Enable in Settings > Display. Use Shift+H to drag." },
+    { t="B", k="sf_guide_p2_44", v="Enable in Settings > Display. Use Right Shift+P to drag." },
     { t="B", k="sf_guide_p2_45", v="Press [-] in any title bar to collapse a panel." },
 }
 
@@ -228,9 +228,9 @@ SoilGuideDialog.PAGE4 = {
     { t="B", k="sf_guide_p4_41", v="Herbicide    Cuts weed pressure." },
     { t="B", k="sf_guide_p4_42", v="Insecticide  Cuts pest pressure." },
     { t="B", k="sf_guide_p4_43", v="Fungicide    Cuts disease pressure." },
-    { t="B", k="sf_guide_p4_44", v="Scout a field (Shift+K) to name its disease" },
+    { t="B", k="sf_guide_p4_44", v="Scout a field (Right Shift+K) to name its disease" },
     { t="B", k="sf_guide_p4_45", v="  and pick a targeted fungicide for it." },
-    { t="B", k="sf_guide_p4_46", v="Treatment (Shift+T) lists what each field" },
+    { t="B", k="sf_guide_p4_46", v="Treatment (Right Shift+T) lists what each field" },
     { t="B", k="sf_guide_p4_47", v="  needs right now, product by product." },
     -- COLUMN BREAK
     { t="COL", v="" },
@@ -273,8 +273,8 @@ SoilGuideDialog.PAGE5 = {
     { t="H", k="sf_guide_p5_06", v="WHERE DO I ASSIGN KEYBOARD SHORTCUTS?" },
     { t="B", k="sf_guide_p5_07", v="Options > Controls > Mods" },
     { t="B", k="sf_guide_p5_08", v="Most SF_ keys ship unbound. Four have defaults:" },
-    { t="B", k="sf_guide_p5_09", v="HUD Drag Shift+H, Variable Rate Alt+7, Scout" },
-    { t="B", k="sf_guide_p5_10", v="Shift+K, Treatment Shift+T. Rebind them in Mods." },
+    { t="B", k="sf_guide_p5_09", v="Right Shift: HUD O, Drag P, VRA V, Auto L, rate [ ]" },
+    { t="B", k="sf_guide_p5_10", v="Scout Right Shift+K, Treatment Right Shift+T. Rebind in Mods." },
     { t="S", v=" " },
     { t="H", k="sf_guide_p5_11", v="WHY DID MY NITROGEN DROP AFTER RAIN?" },
     { t="B", k="sf_guide_p5_12", v="Heavy rain leaches nitrogen from soil." },
@@ -339,6 +339,77 @@ local function tr(key, fallback)
         end
     end
     return fallback or key
+end
+
+-- ── [SF-29] Live chord rewriting ──────────────────────────
+-- The guide is authored with default chords spelled out, and 25 of the 26
+-- locale files carry the same English sentences behind an [EN] marker. Some of
+-- those literals are now WRONG rather than merely imprecise: Variable Rate left
+-- Alt+7 and HUD drag left Shift+H when the suite moved to the Right Shift
+-- family. Rewriting the RESOLVED text at display time means the player reads
+-- the key they actually have bound. It costs no locale edits, and it does not
+-- depend on 26 translators having kept a chord literal in step.
+--
+-- Longest literals first, and matching runs in two passes through a placeholder,
+-- because a live chord is itself of the form "Right Shift+X" and a single-pass
+-- replace would cheerfully rewrite its own output.
+local SF_CHORD_LITERALS = {
+    { lit = "Right Shift%+V", plain = "Right Shift+V", action = "SF_VARIABLE_RATE"   },
+    { lit = "Right Shift%+P", plain = "Right Shift+P", action = "SF_HUD_DRAG"        },
+    { lit = "Right Shift%+K", plain = "Right Shift+K", action = "SF_SCOUT"           },
+    { lit = "Right Shift%+T", plain = "Right Shift+T", action = "SF_TREATMENT"       },
+    { lit = "Right Shift%+O", plain = "Right Shift+O", action = "SF_TOGGLE_HUD"      },
+    { lit = "Right Shift%+M", plain = "Right Shift+M", action = "SF_CYCLE_MAP_LAYER" },
+    { lit = "Right Shift%+,", plain = "Right Shift+,", action = "SF_HANDFUL"         },
+    -- Stale pre-Right-Shift spellings still sitting in the locale files.
+    { lit = "Alt%+7",         plain = "Alt+7",         action = "SF_VARIABLE_RATE"   },
+    { lit = "Shift%+H",       plain = "Shift+H",       action = "SF_HUD_DRAG"        },
+    { lit = "Shift%+K",       plain = "Shift+K",       action = "SF_SCOUT"           },
+    { lit = "Shift%+T",       plain = "Shift+T",       action = "SF_TREATMENT"       },
+    { lit = "Shift%+O",       plain = "Shift+O",       action = "SF_TOGGLE_HUD"      },
+    { lit = "Shift%+M",       plain = "Shift+M",       action = "SF_CYCLE_MAP_LAYER" },
+}
+
+--- Live chord for an action. Prefers SettingsHub's shared helper when the hub
+--- is installed, and otherwise makes the same engine call the hub makes, so a
+--- standalone Soil install behaves identically.
+local function sfLiveChord(actionName)
+    if RfLiveBinding ~= nil and RfLiveBinding.getChord ~= nil then
+        return RfLiveBinding.getChord(actionName)
+    end
+    if g_inputDisplayManager == nil or InputAction == nil then return nil end
+    local action = InputAction[actionName]
+    if action == nil then return nil end
+    local ok, help = pcall(function()
+        return g_inputDisplayManager:getControllerSymbolOverlays(action, "", "", false)
+    end)
+    if not ok or help == nil or help.keys == nil then return nil end
+    local parts = {}
+    for _, k in ipairs(help.keys) do parts[#parts + 1] = tostring(k) end
+    if #parts == 0 then return nil end
+    return table.concat(parts, "+")
+end
+
+--- Replace default chord literals in `text` with whatever is bound right now.
+--- An action with no binding keeps its authored literal rather than being
+--- blanked, so a guide line never loses its meaning; the Controls page is where
+--- "unassigned" is meant to be visible.
+local function sfApplyLiveChords(text)
+    if type(text) ~= "string" or text == "" then return text end
+    local used = {}
+    for i, entry in ipairs(SF_CHORD_LITERALS) do
+        local token = "\1" .. tostring(i) .. "\2"
+        local replaced
+        text, replaced = text:gsub(entry.lit, token)
+        if replaced > 0 then used[i] = token end
+    end
+    if next(used) == nil then return text end
+    for i, token in pairs(used) do
+        local entry = SF_CHORD_LITERALS[i]
+        local shown = sfLiveChord(entry.action) or entry.plain
+        text = text:gsub(token, (shown:gsub("%%", "%%%%")))
+    end
+    return text
 end
 
 -- ── Constructor ───────────────────────────────────────────
@@ -452,7 +523,10 @@ function SoilGuideDialog:_buildContent(pageNum)
             if profile then
                 local el = TextElement.new()
                 el:loadProfile(profile, true)
-                el:setText(row.k and tr(row.k, row.v or "") or (row.v or ""))
+                -- [SF-29] Resolve the string first, THEN rewrite chord literals,
+                -- so the live binding wins over both the l10n entry and the
+                -- authored fallback.
+                el:setText(sfApplyLiveChords(row.k and tr(row.k, row.v or "") or (row.v or "")))
                 currentBox:addElement(el)
                 el:onGuiSetupFinished()
                 table.insert(self._contentLineEls, { box = currentBox, el = el })

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -2176,18 +2176,75 @@ function SoilHUD:getSprayerFillType(sprayer)
         end
     end
 
-    -- Priority 4: fall back to generic fill unit query (works when parked)
+    -- Priority 4: fall back to generic fill unit query (works when parked).
+    --
+    -- [FIX-4] Only consider fill types this mod can actually APPLY. The old loop
+    -- took the first non-empty unit, and on a tractor or a self-propelled machine
+    -- that is the fuel tank -- so auto-rate read DIESEL, found it absent from
+    -- FERTILIZER_PROFILES, and pinned the rate at 1.00x. Measured live: 1,226 LIME
+    -- applications went down at full rate while the log repeated
+    -- "Auto-rate calc: DIESEL NOT in FERTILIZER_PROFILES - holding 1.0x", which is
+    -- exactly the over-liming the player saw. Auto-rate cannot back off a product
+    -- it does not know it is spreading.
+    --
+    -- Two passes on purpose: prefer a unit holding something we have a profile for,
+    -- and only then accept any other non-fuel product, so an unrecognised custom
+    -- fertiliser still resolves rather than falling back to diesel.
     if not fillTypeIndex then
-        local ok, units = pcall(function() return sprayer:getFillUnits() end)
-        if ok and units then
-            for i = 1, #units do
-                local ft = sprayer:getFillUnitFillType(i)
-                if ft and ft > 0 and ft ~= FillType.UNKNOWN then
-                    fillTypeIndex = ft
-                    break
+        local profiles = SoilConstants.FERTILIZER_PROFILES or {}
+        local NON_PRODUCT = {
+            DIESEL = true, DEF = true, ADBLUE = true, AIR = true, ELECTRICCHARGE = true,
+            METHANE = true, LIQUIDMANURE = false,   -- liquid manure IS a product
+        }
+        -- Search the machine AND anything attached to it: on a tractor + spreader the
+        -- lime is in the implement's hopper, never in the tractor. Filtering fuel out
+        -- without also looking at implements just turned "reads DIESEL" into "reads
+        -- nothing", and auto-rate bailed instead of pinning -- worse, not better.
+        local candidates = { sprayer }
+        local function addImplements(v, depth)
+            if v == nil or depth > 3 then return end
+            local ok, impls = pcall(function()
+                return v.getAttachedImplements and v:getAttachedImplements() or nil
+            end)
+            if not ok or impls == nil then return end
+            for _, impl in ipairs(impls) do
+                local obj = impl and impl.object
+                if obj ~= nil then
+                    candidates[#candidates + 1] = obj
+                    addImplements(obj, depth + 1)
                 end
             end
         end
+        addImplements(sprayer, 1)
+        local root = sprayer.rootVehicle
+        if root and root ~= sprayer then
+            candidates[#candidates + 1] = root
+            addImplements(root, 1)
+        end
+
+        local firstOther
+        for _, v in ipairs(candidates) do
+            if fillTypeIndex then break end
+            local ok, units = pcall(function() return v:getFillUnits() end)
+            if ok and units then
+                for i = 1, #units do
+                    local ft = v:getFillUnitFillType(i)
+                    if ft and ft > 0 and ft ~= FillType.UNKNOWN then
+                        local desc = g_fillTypeManager and g_fillTypeManager:getFillTypeByIndex(ft)
+                        local name = desc and desc.name
+                        if name and NON_PRODUCT[name] ~= true then
+                            if profiles[name] ~= nil then
+                                fillTypeIndex = ft   -- known product: take it
+                                break
+                            elseif firstOther == nil then
+                                firstOther = ft      -- plausible product, keep as fallback
+                            end
+                        end
+                    end
+                end
+            end
+        end
+        if not fillTypeIndex then fillTypeIndex = firstOther end
     end
 
     if not fillTypeIndex then return nil end
@@ -2268,36 +2325,38 @@ function SoilHUD:_calcCropTargetRateIdx(fillType)
     local profile = SoilConstants.FERTILIZER_PROFILES and SoilConstants.FERTILIZER_PROFILES[fillType.name]
     if not profile then return nil end
 
-    local ct           = info.cropTargets
-    local totalWeight  = 0
-    local weightedDef  = 0
-    local anyDeficit   = false
+    local ct = info.cropTargets
 
-    if profile.N and profile.N > 0 and ct.N and ct.N.opt > 0 then
-        local deficit = math.max(0, ct.N.opt - info.nitrogen.value) / ct.N.opt
-        if deficit > 0 then anyDeficit = true end
-        weightedDef  = weightedDef  + deficit * profile.N
-        totalWeight  = totalWeight  + profile.N
+    -- [SF-34] Mirror of calculateAutoRateIndex's close-the-gap sizing, kept in
+    -- step with SoilFertilityManager (one formula, two sites, never drift):
+    -- required = gap / (coeff * BASE_RATE / 1000), sized by the biggest carried
+    -- need, clamped to the same [0.01, 1.20] dial range.
+    local baseRow = SoilConstants.SPRAYER_RATE.BASE_RATES
+                    and SoilConstants.SPRAYER_RATE.BASE_RATES[fillType.name]
+    local perThousand = (baseRow and baseRow.value and baseRow.value > 0)
+                        and (baseRow.value / 1000.0) or nil
+    if not perThousand then return nil end
+
+    local req = nil
+    -- [SF-42] Fraction-of-gap, mirroring calculateAutoRateIndex's retune: 0.50
+    -- of the remaining gap per pass (George CLOSED DESIGN 11:23), capped at the
+    -- per-pass physical maximum (60 nutrient units, matching AUTO_PASS_MAX
+    -- there). Keep the two in step.
+    local function consider(gap, coeff)
+        if coeff and coeff > 0 and gap and gap > 0 then
+            local boost = math.min(gap * 0.50, 60)
+            local m = boost / (coeff * perThousand)
+            if req == nil or m > req then req = m end
+        end
     end
-    if profile.P and profile.P > 0 and ct.P and ct.P.opt > 0 then
-        local deficit = math.max(0, ct.P.opt - info.phosphorus.value) / ct.P.opt
-        if deficit > 0 then anyDeficit = true end
-        weightedDef  = weightedDef  + deficit * profile.P
-        totalWeight  = totalWeight  + profile.P
-    end
-    if profile.K and profile.K > 0 and ct.K and ct.K.opt > 0 then
-        local deficit = math.max(0, ct.K.opt - info.potassium.value) / ct.K.opt
-        if deficit > 0 then anyDeficit = true end
-        weightedDef  = weightedDef  + deficit * profile.K
-        totalWeight  = totalWeight  + profile.K
-    end
+    if ct.N and ct.N.opt and ct.N.opt > 0 then consider(ct.N.opt - info.nitrogen.value,   profile.N) end
+    if ct.P and ct.P.opt and ct.P.opt > 0 then consider(ct.P.opt - info.phosphorus.value, profile.P) end
+    if ct.K and ct.K.opt and ct.K.opt > 0 then consider(ct.K.opt - info.potassium.value,  profile.K) end
 
     -- No relevant nutrients in this fertilizer, or field already at/above all targets
-    if totalWeight <= 0 or not anyDeficit then return nil end
+    if req == nil or req <= 0 then return nil end
 
-    local defFraction = weightedDef / totalWeight
-    local targetMult  = 0.20 + defFraction * (1.20 - 0.20)
-    targetMult = math.max(0.20, math.min(1.20, targetMult))
+    local targetMult = math.max(0.01, math.min(1.20, req))
 
     local steps   = SoilConstants.SPRAYER_RATE.STEPS
     local bestIdx = SoilConstants.SPRAYER_RATE.DEFAULT_INDEX

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -966,14 +966,20 @@ function SoilMapOverlay:updateSamplePoints(force)
                         local scouting = self.soilSystem and self.soilSystem.spatialScouting
                         local compose = nil
                         if scouting and scouting:isArmed() then
-                            local owner = g_farmlandManager and g_farmlandManager.getFarmlandOwner
-                                and g_farmlandManager:getFarmlandOwner(farmlandId)
+                            -- [SF-22] Compose ONLY from the local VIEWING farm's own
+                            -- walked mask, never the land owner. A client holds only
+                            -- its own farm's mask bytes (another farm receives zero),
+                            -- so keying by owner would paint nothing for a contractor
+                            -- and risk leaking across farms on a listen host. A
+                            -- non-ordinary or unresolved viewer yields no compose
+                            -- object, so the cell stays UNKNOWN.
+                            local viewingFarm = g_localPlayer and g_localPlayer.farmId
                             local day = g_currentMission and g_currentMission.environment
                                 and g_currentMission.environment.currentDay
-                            if owner and owner > 0 and day then
+                            if SpatialScouting.isOrdinaryFarmId(viewingFarm) and day then
                                 compose = {
                                     scouting = scouting,
-                                    farmId   = owner,
+                                    farmId   = viewingFarm,
                                     fieldId  = farmlandId,
                                     day      = day,
                                 }

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -84,6 +84,32 @@ SoilMapOverlay.CB_UNKNOWN = {0.38, 0.40, 0.43}
 -- ── Gradient helpers ──────────────────────────────────────
 -- Shared red→amber→green gradient.  t=0 is worst (red), t=1 is best (green).
 -- These are the same three stop-colors used in drawHealthGradientBar.
+-- [SF-50] pH-only 4-stop gradient (George CLOSED DESIGN 19:12; Wizard wants
+-- deeper multi-stage colour on the pH layer specifically). Stops: deep red ->
+-- amber -> bright green -> deep green, linearly interpolated. Every other
+-- layer stays on healthGradient below. Over-limed (>7.0) reaches this with
+-- t=0 from layerValueToT and lands on the deep-red stop, as before.
+local PH_STOPS = {
+    { 0.00, 0.88, 0.10, 0.10 },  -- deep red
+    { 0.33, 0.90, 0.70, 0.10 },  -- amber
+    { 0.66, 0.30, 0.90, 0.30 },  -- bright green
+    { 1.00, 0.10, 0.50, 0.10 },  -- deep green
+}
+local function pHGradient(t)
+    t = math.max(0, math.min(1, t))
+    for i = 1, #PH_STOPS - 1 do
+        local s0, s1 = PH_STOPS[i], PH_STOPS[i + 1]
+        if t <= s1[1] then
+            local a = (t - s0[1]) / (s1[1] - s0[1])
+            return s0[2] + (s1[2] - s0[2]) * a,
+                   s0[3] + (s1[3] - s0[3]) * a,
+                   s0[4] + (s1[4] - s0[4]) * a
+        end
+    end
+    local last = PH_STOPS[#PH_STOPS]
+    return last[2], last[3], last[4]
+end
+
 local function healthGradient(t)
     t = math.max(0, math.min(1, t))
     local r, g, b
@@ -108,15 +134,19 @@ local function layerValueToT(layerIdx, val)
     elseif layerIdx == 2 then return math.max(0, math.min(1, val / 100))        -- P   0-100
     elseif layerIdx == 3 then return math.max(0, math.min(1, val / 100))        -- K   0-100
     elseif layerIdx == 4 then
-        -- Match SoilHUD:pHColor bands (not a 6.75-centred bell):
-        -- 6.5-7.0 good, >7.0-7.5 poor (over-limed), >=5.5 fair, else poor.
+        -- [SF-49] Continuous pH ramp (George CLOSED DESIGN 16:08). The old
+        -- discrete 0.5/1.0 bands rendered mid-pass 6.29 and overlap 6.60 as
+        -- similar tints even though the painted VALUES were right - TEST 15:54
+        -- failed on legend alone. Ramping 5.5->6.5 across fair (0..0.5) and
+        -- 6.5->7.0 across optimal (0.5..1.0) makes 6.29 read amber (~0.395)
+        -- and 6.60 read greener (~0.60). Over-limed >7.0 stays poor (0.0).
         local pH = val or 7.0
         if pH >= 6.5 and pH <= 7.0 then
-            return 1.0
-        elseif pH > 7.0 and pH <= 7.5 then
+            return 0.5 + (pH - 6.5) / (7.0 - 6.5) * 0.5
+        elseif pH > 7.0 then
             return 0.0
         elseif pH >= 5.5 then
-            return 0.5
+            return (pH - 5.5) / (6.5 - 5.5) * 0.5
         else
             return 0.0
         end
@@ -529,14 +559,24 @@ function SoilMapOverlay:_pdaDrawDMV(ingameMap, mapX, mapY, mapWidth, mapHeight, 
 
     self:_pdaPollBuildFinished()
 
-    -- Kick a (re)build when the layer changed or the refresh timer elapsed
+    -- Kick a (re)build when the layer changed, the refresh timer elapsed, or the
+    -- value maps were mutated since the last build ([SF-23]).
     if layerIdx ~= self._pdaActiveLayer then
         self._pdaActiveLayer  = layerIdx
         self._pdaHasShownOnce = false     -- don't show the previous layer's pixels
         self._pdaBuildInFlight = false
+        self._pdaValueMapsDirty = false
         self:_pdaKickBuild(layerIdx)
         self._pdaNextBuildMs = now + 3000
-    elseif not self._pdaBuildInFlight and now >= self._pdaNextBuildMs then
+    elseif not self._pdaBuildInFlight
+           and (now >= self._pdaNextBuildMs
+                or (self._pdaValueMapsDirty and now >= (self._pdaDirtyFloorMs or 0))) then
+        -- [SF-23] A tillage/spray paint sets _pdaValueMapsDirty, which short
+        -- circuits the 3 s timer so a change is on screen on the next draw rather
+        -- than up to three seconds later. Floored at 250 ms so a burst of paints
+        -- can never thrash the DMV rebuild, which is the expensive call here.
+        self._pdaValueMapsDirty = false
+        self._pdaDirtyFloorMs   = now + 250
         self:_pdaKickBuild(layerIdx)
         self._pdaNextBuildMs = now + 3000
     end
@@ -1986,6 +2026,12 @@ function SoilMapOverlay:valueToLayerColor(layerIdx, val)
         end
         return GOOD[1], GOOD[2], GOOD[3]
     end
+    -- [SF-50] pH takes the 4-stop gradient; every other layer keeps the
+    -- 3-stop health ramp. Same t from layerValueToT either way, so the
+    -- over-limed>7.0 -> t=0 rule is shared.
+    if layerIdx == 4 then
+        return pHGradient(layerValueToT(layerIdx, val))
+    end
     return healthGradient(layerValueToT(layerIdx, val))
 end
 
@@ -2096,6 +2142,12 @@ function SoilMapOverlay:getLayerColor(layerIdx, info, farmlandId)
     -- Unscouted disease shows the neutral unknown tone, never the pressure ramp.
     if layerIdx == 9 and info.shownDiseasePressure == nil then
         return self:unknownColor()
+    end
+    -- [SF-50] pH takes the 4-stop gradient; every other layer keeps the
+    -- 3-stop health ramp. Same t from layerValueToT either way, so the
+    -- over-limed>7.0 -> t=0 rule is shared.
+    if layerIdx == 4 then
+        return pHGradient(layerValueToT(layerIdx, val))
     end
     return healthGradient(layerValueToT(layerIdx, val))
 end

--- a/src/ui/SoilTreatmentRates.lua
+++ b/src/ui/SoilTreatmentRates.lua
@@ -255,6 +255,47 @@ local function collectPlanRows(fieldId)
         return rows, nil
     end
 
+    -- [SF-33] Decide from the MAP, not the field average.
+    --
+    -- getFieldInfo(fieldId) with no x/z returns field scalars, while the map and
+    -- the tooltip read the ~2 m value maps. That is why the plan could say a field
+    -- was fine while SOIL LAYERS showed patches of bad ground, and why players
+    -- stopped trusting the plan. The rollup samples the same maps the picture is
+    -- drawn from, so both now answer from one source.
+    --
+    -- Rule (George CLOSED DESIGN 16:58): prescribe when at least
+    -- SPATIAL_PRESCRIBE_PCT of sampled cells are below the threshold, OR when the
+    -- worst single cell is below it. The percentage filters edge noise; the worst
+    -- cell catches a genuinely bad patch the average hides.
+    local SPATIAL_PRESCRIBE_PCT = 5
+    local spatial = nil
+    do
+        local okS, s = pcall(function() return sfm.soilSystem:getFieldSpatialSummary(fieldId) end)
+        if okS then spatial = s end
+    end
+    local spatialMismatch = false
+
+    --- Severity for one nutrient from the map, falling back to the scalar when
+    --- no rollup is available (no value maps, or polygon unresolved).
+    ---@return boolean poorHit
+    ---@return boolean fairHit
+    local function severity(key, scalarVal, poorTh, fairTh)
+        local s = spatial and spatial[key]
+        if not s then
+            return (scalarVal < poorTh), (scalarVal < fairTh)
+        end
+        local poorHit = (s.pctBelowPoor >= SPATIAL_PRESCRIBE_PCT)
+                        or (s.worst ~= nil and s.worst < poorTh)
+        local fairHit = (s.pctBelowFair >= SPATIAL_PRESCRIBE_PCT)
+                        or (s.worst ~= nil and s.worst < fairTh)
+        -- The average says fine, the map says otherwise: that disagreement is
+        -- worth telling the player about rather than silently overriding.
+        if scalarVal >= fairTh and (poorHit or fairHit) then
+            spatialMismatch = true
+        end
+        return poorHit, fairHit
+    end
+
     local thresh  = SoilConstants.STATUS_THRESHOLDS or {}
     local fieldArea = info.fieldArea or 1.0
     local rrIdx = (sfm.settings and sfm.settings.replenishmentRate) or 3
@@ -274,40 +315,58 @@ local function collectPlanRows(fieldId)
     local kFair = (thresh.potassium and thresh.potassium.fair) or 40
 
     local nVal = info.nitrogen and info.nitrogen.value or 0
-    if nVal < nPoor then
+    local nPoorHit, nFairHit = severity("nitrogen", nVal, nPoor, nFair)
+    if nPoorHit then
         appendNutrientRows(rows, "N", nVal, targetN, rrMult, fieldArea,
             { {"UREA","N"}, {"UAN32","N"} },
             tr("sf_treat_action_n_poor", "Apply UAN32, UREA, or ANHYDROUS."), "poor", 3, 0)
-    elseif nVal < nFair then
+    elseif nFairHit then
         appendNutrientRows(rows, "N", nVal, targetN, rrMult, fieldArea,
             { {"AMS","N"}, {"AN","N"} },
             tr("sf_treat_action_n_fair", "Apply AMS or STARTER fertilizer."), "fair", 3, 1)
     end
 
     local pVal = info.phosphorus and info.phosphorus.value or 0
-    if pVal < pPoor then
+    local pPoorHit, pFairHit = severity("phosphorus", pVal, pPoor, pFair)
+    if pPoorHit then
         appendNutrientRows(rows, "P", pVal, targetP, rrMult, fieldArea,
             { {"MAP","P"}, {"DAP","P"} },
             tr("sf_treat_action_p_poor", "Apply MAP or DAP (Phosphorus)."), "poor", 3, 0)
-    elseif pVal < pFair then
+    elseif pFairHit then
         appendNutrientRows(rows, "P", pVal, targetP, rrMult, fieldArea,
             { {"LIQUID_MAP","P"}, {"LIQUID_DAP","P"} },
             tr("sf_treat_action_p_fair", "Top-up with Liquid MAP, Liquid DAP, or DAP (P)."), "fair", 3, 1)
     end
 
     local kVal = info.potassium and info.potassium.value or 0
-    if kVal < kPoor then
+    local kPoorHit, kFairHit = severity("potassium", kVal, kPoor, kFair)
+    if kPoorHit then
         appendNutrientRows(rows, "K", kVal, targetK, rrMult, fieldArea,
             { {"POTASH","K"}, {"LIQUID_POTASH","K"} },
             tr("sf_treat_action_k_poor", "Apply POTASH (Potassium)."), "poor", 3, 0)
-    elseif kVal < kFair then
+    elseif kFairHit then
         appendNutrientRows(rows, "K", kVal, targetK, rrMult, fieldArea,
             { {"POTASH","K"}, {"LIQUID_POTASH","K"} },
             tr("sf_treat_action_k_fair", "Top-up with Liquid Potash or Potash (K)."), "fair", 3, 1)
     end
 
     local ph = math.floor(((info.pH or 7.0) * 10) + 0.5) / 10
-    if ph < 6.5 then
+    -- [SF-33] pH needs its own rule: unlike N/P/K, too much is as wrong as too
+    -- little, so acid share and over-limed share are asked separately. A field
+    -- averaging a healthy 6.8 can still be a third acid and a third over-limed,
+    -- and that field needs lime, not reassurance.
+    local phS = spatial and spatial.pH
+    local limeHit, gypsumHit
+    if phS then
+        limeHit   = (phS.pctBelowFair >= SPATIAL_PRESCRIBE_PCT) or ((phS.mean or ph) < 6.5)
+        gypsumHit = (phS.pctOverLimed >= SPATIAL_PRESCRIBE_PCT)
+        if ph >= 6.5 and limeHit   then spatialMismatch = true end
+        if ph <= 7.5 and gypsumHit then spatialMismatch = true end
+    else
+        limeHit   = ph < 6.5
+        gypsumHit = ph > 7.5
+    end
+    if limeHit then
         addStaticRow(rows, "pH",
             productWithHow("LIME", tr("rf_pda_treat_method_dry", "spreader")),
             "poor", 2, 0,
@@ -318,7 +377,7 @@ local function collectPlanRows(fieldId)
             "poor", 2, 0,
             tr("rf_pda_treat_next_how_liq_lime", "apply with a sprayer/tank"),
             "LIQUIDLIME", true)
-    elseif ph > 7.5 then
+    elseif gypsumHit then
         addStaticRow(rows, "pH",
             productWithHow("GYPSUM", tr("rf_pda_treat_method_dry", "spreader")),
             "fair", 2, 1,
@@ -368,7 +427,11 @@ local function collectPlanRows(fieldId)
             "FUNGICIDE", false)
     end
 
-    return rows, info
+    -- [SF-33] Third return is additive: existing callers take one or two values
+    -- and are unaffected. `mismatch` is true when the field average reads fine
+    -- but the map does not, which the PDA and the dialog surface as a line rather
+    -- than quietly overruling one number with the other.
+    return rows, info, { spatial = spatial, mismatch = spatialMismatch }
 end
 
 --- Build ordered treatment plan lines for a field (for PDA expand / tablet).
@@ -413,6 +476,22 @@ end
 --- Short "Do this next" tip for Selected-field line (preferred first product after sort).
 ---@param fieldId number
 ---@return string|nil
+--- [SF-33] A line for when the field average and the soil map disagree.
+---
+--- Returns nil when they agree, so a caller can append unconditionally. The
+--- wording lives here rather than in each screen so the PDA panel and the
+--- Treatment dialog cannot drift into saying different things about the same
+--- field. Honest copy is the point: it explains BOTH numbers instead of quietly
+--- overruling one, which is what left players unsure which to believe.
+---@param fieldId number
+---@return string|nil
+function SoilTreatmentRates.getSpatialMismatchLine(fieldId)
+    local _, _, sp = collectPlanRows(fieldId)
+    if not sp or not sp.mismatch then return nil end
+    return tr("rf_pda_treat_spatial_mismatch",
+        "Field average looks fine, but the soil map has patches below target. The plan follows the map.")
+end
+
 function SoilTreatmentRates.buildNextStepLine(fieldId)
     local rows, info = collectPlanRows(fieldId)
     if rows == nil or #rows == 0 then

--- a/src/ui/SoilVariableRatePanel.lua
+++ b/src/ui/SoilVariableRatePanel.lua
@@ -137,6 +137,10 @@ function SoilVariableRatePanel:draw()
     end
 
     local sprayer = self:getActiveSprayer()
+    -- [PACK] No add-on, no panel. Showing a variable-rate readout for a machine
+    -- that cannot do variable rate invites the player to trust numbers the spray
+    -- path never uses. Edit mode still draws it so the HUD can be positioned.
+    if not inEditMode and not sfm:hasPrecisionPack(sprayer) then return end
 
     -- The suite editor always exposes a placement frame, even without a matching
     -- applicator. Moving it opts into the existing independent-panels setting.

--- a/tools/test/lua/kneel_sf37_test.lua
+++ b/tools/test/lua/kneel_sf37_test.lua
@@ -29,6 +29,7 @@ do
     }
     g_farmlandManager = {
         getFarmlandAtWorldPosition = function() return { id = 5 } end,
+        getFarmlandOwner = function() return 1 end,   -- [SF-22] farm 1 owns this land
     }
     g_localPlayer = { farmId = 1 }
 
@@ -53,6 +54,7 @@ do
     }
     g_farmlandManager = {
         getFarmlandAtWorldPosition = function() return { id = 7 } end,
+        getFarmlandOwner = function() return 3 end,   -- [SF-22] the requesting farm owns it
     }
     -- The requesting player's record carries farm 3.
     g_currentMission.playerSystem = {
@@ -100,7 +102,7 @@ do
     T.ok("a client never writes locally", not written)
 end
 
--- ── The kneel write marks the mask dirty for NetworkSync ────────────────────
+-- ── The kneel hands its changed cell to the farm-private DELTA sender ────────
 do
     g_server = {}
     g_fieldManager = {
@@ -108,16 +110,19 @@ do
     }
     g_farmlandManager = {
         getFarmlandAtWorldPosition = function() return { id = 5 } end,
+        getFarmlandOwner = function() return 1 end,
     }
     g_localPlayer = { farmId = 1 }
-    local dirty = false
-    local saved = SoilScoutingBridge.markDirty
-    SoilScoutingBridge.markDirty = function() dirty = true end
+    local sentFarm, sentCells = nil, nil
+    local saved = SoilScoutingBridge.sendFarmDelta
+    SoilScoutingBridge.sendFarmDelta = function(_sc, farmId, list) sentFarm = farmId; sentCells = list end
 
     local m = newMask()
     m:revealCellAt(nil, 25, 35, 100)
-    T.ok("the kneel flags the NetworkSync module dirty", dirty)
+    T.eq("the kneel hands its cell to the DELTA sender under the kneeling farm", sentFarm, 1)
+    T.ok("the DELTA carries exactly the knelt cell",
+         sentCells ~= nil and #sentCells == 1 and sentCells[1].cellKey == S.cellKey(25, 35))
 
-    SoilScoutingBridge.markDirty = saved
+    SoilScoutingBridge.sendFarmDelta = saved
     g_server = nil
 end

--- a/tools/test/lua/prelude.lua
+++ b/tools/test/lua/prelude.lua
@@ -161,6 +161,8 @@ function streamWriteBool(s, v)      _sfPush(s, "bool", v and true or false) end
 function streamReadBool(s)          return _sfPull(s, "bool") end
 function streamWriteUIntN(s, v, _n) _sfPush(s, "uN", v) end
 function streamReadUIntN(s, _n)     return _sfPull(s, "uN") end
+function streamWriteUInt16(s, v)    _sfPush(s, "u16", v) end
+function streamReadUInt16(s)         return _sfPull(s, "u16") end
 
 -- ── tiny test framework ────────────────────────────────────
 -- Results are emitted as ##TEST_ lines that run-tests.mjs parses out of stdout, so

--- a/tools/test/lua/sf22_private_mask_spec_test.lua
+++ b/tools/test/lua/sf22_private_mask_spec_test.lua
@@ -1,0 +1,259 @@
+-- sf22_private_mask_spec_test.lua - SF-22 FARM-PRIVATE PER-SQUARE VISIBILITY
+--
+-- The walked mask must stay private: one farm shares only the cells its own
+-- players legally learned, another farm receives ZERO of those bytes, and a
+-- client only ever holds its own farm's slice. This bench pins the pure pieces
+-- the two-machine live test cannot reach offline:
+--   1. the ordinary-farm predicate and the reveal gate,
+--   2. the sampler authorisation matrix (own land / contracted land / neighbour),
+--   3. the one-farm serialiser and the every-user remote selector,
+--   4. the client apply: DELTA immediacy, FULL atomicity + chunk assembly, the
+--      wrong-farm / non-ordinary / bad-chunk rejections, generation + freshness,
+--   5. the farm-switch transition classifier,
+--   6. the SoilScoutingMaskSyncEvent write/read wire round-trip (FULL + DELTA).
+--
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/config/SoilBlends.lua, src/SpatialScouting.lua, src/integrations/SoilScoutingBridge.lua, src/OrganicCertification.lua, src/ResistanceBands.lua, src/config/SettingsSchema.lua, src/network/NetworkEvents.lua
+
+-- The event's farm id rides FarmManager.FARM_ID_SEND_NUM_BITS; stub the constant
+-- the base game supplies (verified 4 bits, MAX_NUM_FARMS 8).
+FarmManager = FarmManager or { FARM_ID_SEND_NUM_BITS = 4, MAX_NUM_FARMS = 8 }
+
+local S = SpatialScouting
+local B = SoilScoutingBridge
+
+local function newMask()
+    local m = S.new()
+    m:arm({ available = true, readValueAtWorld = function() return 40 end, writeValueAtWorld = function() end })
+    return m
+end
+
+-- ── 1. isOrdinaryFarmId: only the eight playable farms ──────────────────────
+do
+    for id = 1, 8 do T.ok("ordinary farm " .. id .. " accepted", S.isOrdinaryFarmId(id)) end
+    T.ok("spectator 0 rejected",       not S.isOrdinaryFarmId(0))
+    T.ok("above max (9) rejected",     not S.isOrdinaryFarmId(9))
+    T.ok("guided-tour 14 rejected",    not S.isOrdinaryFarmId(14))
+    T.ok("invalid 15 rejected",        not S.isOrdinaryFarmId(15))
+    T.ok("nil rejected",               not S.isOrdinaryFarmId(nil))
+    T.ok("non-integer rejected",       not S.isOrdinaryFarmId(1.5))
+    T.ok("string rejected",            not S.isOrdinaryFarmId("1"))
+end
+
+-- ── 2. isRevealAuthorized: same farm OR contracting, both ordinary ──────────
+do
+    T.ok("same farm authorised",        S.isRevealAuthorized(2, 2, false))
+    T.ok("contracting farm authorised", S.isRevealAuthorized(2, 3, true))
+    T.ok("neighbour NOT authorised",    not S.isRevealAuthorized(2, 3, false))
+    T.ok("non-ordinary owner rejected", not S.isRevealAuthorized(2, 0, true))
+    T.ok("non-ordinary player rejected",not S.isRevealAuthorized(0, 2, true))
+end
+
+-- ── 3. Sampler authorisation matrix (via _samplePlayer) ─────────────────────
+local function walkerAt(farmId)
+    return { getIsInVehicle = function() return false end,
+             getPosition = function() return 5, 0, 5 end, farmId = farmId }
+end
+local function setWorld(ownerFarmId, contractMap)
+    g_fieldManager = { getFieldAtWorldPosition = function() return { farmland = { id = 5 } } end }
+    g_farmlandManager = {
+        getFarmlandAtWorldPosition = function() return { id = 5 } end,
+        getFarmlandOwner = function() return ownerFarmId end,
+    }
+    g_farmManager = { getFarmById = function(_self, farmId)
+        return { getIsContractingFor = function(_f, ownerId) return contractMap and contractMap[ownerId] == true end }
+    end }
+end
+
+do
+    g_server = {}
+    -- Own land: farm 2 on farm-2 ground writes.
+    setWorld(2, nil)
+    local m = newMask()
+    local changed, farm, field = m:_samplePlayer(walkerAt(2), 100)
+    T.ok("own-land walk writes", changed)
+    T.eq("write lands under the walking farm", farm, 2)
+    T.eq("write keys on the resolved farmland", field, 5)
+
+    -- Contracted land: farm 2 on farm-3 ground while contracting for 3 writes.
+    setWorld(3, { [3] = true })
+    local m2 = newMask()
+    T.ok("contracted-land walk writes", (m2:_samplePlayer(walkerAt(2), 100)))
+    T.ok("the contracted cell lands under the contractor's farm", m2:maskEntry(2, 5, S.cellKey(5, 5)) ~= nil)
+
+    -- Neighbour: farm 2 on farm-3 ground with no contract writes NOTHING.
+    setWorld(3, nil)
+    local m3 = newMask()
+    T.ok("neighbour walk writes nothing", not (m3:_samplePlayer(walkerAt(2), 100)))
+    T.ok("the neighbour mask stays empty", next(m3.masks) == nil)
+
+    -- Non-ordinary walking farm (spectator) writes nothing even on owned-looking land.
+    setWorld(0, nil)
+    local m4 = newMask()
+    T.ok("a spectator walker writes nothing", not (m4:_samplePlayer(walkerAt(0), 100)))
+    g_server = nil
+end
+
+-- ── 4a. serializeFarmMask: one farm only, deterministic order ───────────────
+do
+    local m = newMask()
+    m:noteWalk(1, 6, "20", 100, 11, 0, 0)
+    m:noteWalk(1, 6, "10", 100, 12, 0, 0)
+    m:noteWalk(1, 5, "99", 100, 13, 0, 0)
+    m:noteWalk(2, 9, "7", 100, 55, 0, 0)   -- another farm
+
+    local e = B.serializeFarmMask(m, 1)
+    T.eq("only farm 1's three cells serialise", #e, 3)
+    T.eq("ordered by numeric field id first", e[1].fieldId, 5)
+    T.eq("then by string cell key (10 before 20)", e[2].cellKey, "10")
+    T.eq("and 20 after 10", e[3].cellKey, "20")
+    T.eq("empty farm serialises to nothing", #B.serializeFarmMask(m, 4), 0)
+end
+
+-- ── 4b. selectRemoteConnections: same-farm remotes only ─────────────────────
+do
+    local function conn(opts) return {
+        isConnected = opts.connected ~= false,
+        isReadyForEvents = opts.ready ~= false,
+        getIsLocal = function() return opts.localStream == true end,
+    } end
+    local users = {
+        { id = 11, connection = conn({}) },                       -- farm 1 remote  (keep)
+        { id = 12, connection = conn({ localStream = true }) },   -- farm 1 LOOPBACK (drop)
+        { id = 13, connection = conn({ connected = false }) },    -- farm 1 dropped  (drop)
+        { id = 14, connection = conn({ ready = false }) },        -- farm 1 loading  (drop)
+        { id = 21, connection = conn({}) },                       -- farm 2 remote   (drop: wrong farm)
+    }
+    local farmOf = { [11] = 1, [12] = 1, [13] = 1, [14] = 1, [21] = 2 }
+    local farmManager = { getFarmByUserId = function(_self, uid) return { farmId = farmOf[uid] } end }
+
+    local conns = B.selectRemoteConnections(users, farmManager, 1)
+    T.eq("exactly one farm-1 remote is selected", #conns, 1)
+    T.ok("the loopback host connection is never selected", conns[1] == users[1].connection)
+    T.eq("a non-ordinary target farm selects nobody", #B.selectRemoteConnections(users, farmManager, 0), 0)
+end
+
+-- ── 4c. applyMaskEvent: DELTA immediacy + guards ────────────────────────────
+do
+    local c = newMask()
+    -- DELTA applies at once and never clears.
+    B.applyMaskEvent(c, 1, { mode = B.MASK_MODE_DELTA, farmId = 1, chunkIndex = 1, chunkCount = 1,
+        entries = { { fieldId = 5, cellKey = "1", day = 100, truth = 42, x = 0, z = 0, gen = 0 } } })
+    T.eq("DELTA cell composes for its own farm", c:composeShown(1, 5, "1", 103, -1, false), 42)
+
+    -- A second DELTA adds without wiping the first.
+    B.applyMaskEvent(c, 1, { mode = B.MASK_MODE_DELTA, farmId = 1, chunkIndex = 1, chunkCount = 1,
+        entries = { { fieldId = 6, cellKey = "2", day = 101, truth = 13, x = 0, z = 0, gen = 0 } } })
+    T.eq("DELTA never clears the prior cell", c:composeShown(1, 5, "1", 103, -1, false), 42)
+    T.eq("the second DELTA cell is present too", c:composeShown(1, 6, "2", 103, -1, false), 13)
+
+    -- Wrong-farm payload is rejected before mutation.
+    local w = newMask()
+    B.applyMaskEvent(w, 1, { mode = B.MASK_MODE_DELTA, farmId = 2, chunkIndex = 1, chunkCount = 1,
+        entries = { { fieldId = 5, cellKey = "1", day = 100, truth = 42 } } })
+    T.ok("a wrong-farm payload lands nothing", next(w.masks) == nil)
+
+    -- Non-ordinary local farm is rejected.
+    local n = newMask()
+    B.applyMaskEvent(n, 0, { mode = B.MASK_MODE_DELTA, farmId = 0, chunkIndex = 1, chunkCount = 1,
+        entries = { { fieldId = 5, cellKey = "1", day = 100, truth = 42 } } })
+    T.ok("a non-ordinary local farm lands nothing", next(n.masks) == nil)
+end
+
+-- ── 4d. FULL is atomic across chunks; a dropped chunk never applies ─────────
+do
+    -- Two-chunk FULL: nothing composes until BOTH chunks arrive.
+    local c = newMask()
+    B.applyMaskEvent(c, 1, { mode = B.MASK_MODE_FULL, farmId = 1, chunkIndex = 1, chunkCount = 2,
+        entries = { { fieldId = 5, cellKey = "1", day = 100, truth = 42, gen = 0 } } })
+    T.eq("FULL does not apply on the first of two chunks", c:composeShown(1, 5, "1", 103, -1, false), -1)
+    B.applyMaskEvent(c, 1, { mode = B.MASK_MODE_FULL, farmId = 1, chunkIndex = 2, chunkCount = 2,
+        entries = { { fieldId = 6, cellKey = "2", day = 101, truth = 13, gen = 0 } } })
+    T.eq("FULL applies both cells once the set is complete (cell 5)", c:composeShown(1, 5, "1", 103, -1, false), 42)
+    T.eq("FULL applies both cells once the set is complete (cell 6)", c:composeShown(1, 6, "2", 103, -1, false), 13)
+
+    -- A dropped final chunk means the FULL never applies (no torn state).
+    local d = newMask()
+    B.applyMaskEvent(d, 1, { mode = B.MASK_MODE_FULL, farmId = 1, chunkIndex = 1, chunkCount = 2,
+        entries = { { fieldId = 5, cellKey = "1", day = 100, truth = 42, gen = 0 } } })
+    -- chunk 2 never arrives
+    T.ok("a partial FULL never mutates the live mask", next(d.masks) == nil)
+
+    -- FULL replaces atomically: an old cell absent from the new set is gone.
+    local r = newMask()
+    r:noteWalk(1, 5, "OLD", 90, 99, 0, 0)
+    B.applyMaskEvent(r, 1, { mode = B.MASK_MODE_FULL, farmId = 1, chunkIndex = 1, chunkCount = 1,
+        entries = { { fieldId = 5, cellKey = "NEW", day = 100, truth = 42, gen = 0 } } })
+    T.eq("FULL clears the stale cell", r:composeShown(1, 5, "OLD", 103, -1, false), -1)
+    T.eq("FULL installs the fresh cell", r:composeShown(1, 5, "NEW", 103, -1, false), 42)
+
+    -- An out-of-range chunk index is rejected without touching live tables.
+    local o = newMask()
+    B.applyMaskEvent(o, 1, { mode = B.MASK_MODE_FULL, farmId = 1, chunkIndex = 3, chunkCount = 2,
+        entries = { { fieldId = 5, cellKey = "1", day = 100, truth = 42 } } })
+    T.ok("an out-of-range chunk lands nothing", next(o.masks) == nil)
+end
+
+-- ── 4e. generation is raised before freshness; freshest day wins ────────────
+do
+    -- An entry stamped with a newer generation raises the field generation so a
+    -- stale-generation compose is gated out.
+    local c = newMask()
+    B.applyMaskEvent(c, 1, { mode = B.MASK_MODE_DELTA, farmId = 1, chunkIndex = 1, chunkCount = 1,
+        entries = { { fieldId = 5, cellKey = "1", day = 100, truth = 42, gen = 2 } } })
+    T.eq("generation-2 cell composes under generation 2", c:composeShown(1, 5, "1", 103, -1, false), 42)
+    T.eq("the field generation was raised to 2", c.generations[1][5], 2)
+
+    -- Freshest day wins on a same-cell re-apply.
+    B.applyMaskEvent(c, 1, { mode = B.MASK_MODE_DELTA, farmId = 1, chunkIndex = 1, chunkCount = 1,
+        entries = { { fieldId = 5, cellKey = "1", day = 105, truth = 77, gen = 2 } } })
+    T.eq("a newer day overwrites the cell truth", c:composeShown(1, 5, "1", 106, -1, false), 77)
+end
+
+-- ── 5. classifyLocalFarmTransition ──────────────────────────────────────────
+do
+    T.eq("the first observation is a no-op", B.classifyLocalFarmTransition(false, nil, 1), nil)
+    T.eq("an unchanged farm is a no-op", B.classifyLocalFarmTransition(true, 1, 1), nil)
+    local d = B.classifyLocalFarmTransition(true, 1, 2)
+    T.ok("a switch to an ordinary farm clears and requests", d ~= nil and d.clear == true and d.request == true)
+    local d2 = B.classifyLocalFarmTransition(true, 1, 0)
+    T.ok("a switch to a non-ordinary farm clears but does NOT request",
+         d2 ~= nil and d2.clear == true and d2.request == false)
+end
+
+-- ── 6. SoilScoutingMaskSyncEvent wire round-trip (FULL + DELTA) ──────────────
+do
+    g_server = nil   -- keep readStream's trailing run() a safe no-op (no manager present)
+    local CONN = {}
+    local function rt(name, ev)
+        local s = _sfMockStream()
+        ev:writeStream(s, CONN)
+        local wrote = #s.q
+        local dst = SoilScoutingMaskSyncEvent.emptyNew()
+        dst:readStream(s, CONN)
+        T.eq(name .. ": no type mismatches", s.typeErrors, 0)
+        T.eq(name .. ": no stream underflow", s.underflows, 0)
+        T.eq(name .. ": stream fully drained", s.r, wrote + 1)
+        return dst
+    end
+
+    local entries = {
+        { fieldId = 5, cellKey = "20003", day = 100, truth = 42, x = 25, z = 35, gen = 1 },
+        { fieldId = 6, cellKey = "-30004", day = 101, truth = 13, x = -25, z = -35, gen = 0 },
+    }
+    local full = rt("FULL", SoilScoutingMaskSyncEvent.newFull(3, 1, 2, entries))
+    T.eq("FULL: mode preserved", full.mode, SoilScoutingMaskSyncEvent.MODE_FULL)
+    T.eq("FULL: farm id preserved", full.farmId, 3)
+    T.eq("FULL: chunk index preserved", full.chunkIndex, 1)
+    T.eq("FULL: chunk count preserved", full.chunkCount, 2)
+    T.eq("FULL: entry count preserved", #full.entries, 2)
+    T.eq("FULL: field id preserved", full.entries[1].fieldId, 5)
+    T.eq("FULL: cell key preserved", full.entries[2].cellKey, "-30004")
+    T.near("FULL: truth preserved", full.entries[1].truth, 42)
+    T.eq("FULL: generation preserved", full.entries[1].gen, 1)
+
+    local delta = rt("DELTA", SoilScoutingMaskSyncEvent.newDelta(2, { entries[1] }))
+    T.eq("DELTA: mode preserved", delta.mode, SoilScoutingMaskSyncEvent.MODE_DELTA)
+    T.eq("DELTA: farm id preserved", delta.farmId, 2)
+    T.eq("DELTA: is chunk 1 of 1", delta.chunkCount, 1)
+    T.eq("DELTA: single entry preserved", #delta.entries, 1)
+end

--- a/tools/test/lua/spatial_scouting_spec_test.lua
+++ b/tools/test/lua/spatial_scouting_spec_test.lua
@@ -188,19 +188,39 @@ do
          m:composeShown(1, 5, "1", 400, 33, true), 33)
 end
 
--- ── NetworkSync wire shape (LAW 3: payload carries its own truth) ────────────
+-- ── [SF-22] Farm-private wire shape: one farm's mask serialises ALONE ────────
 do
     local m = newMask()
     m:noteWalk(1, 5, "1", 100, 42, 5, 5)
     m:noteWalk(1, 6, "2", 101, 13, 15, 15)
-    m:noteWalk(2, 9, "7", 102, 55, 7, 7)
+    m:noteWalk(2, 9, "7", 102, 55, 7, 7)   -- a DIFFERENT farm's cell
 
-    local arr = SoilScoutingBridge.serializeMask(m)
-    local m2 = newMask()
-    SoilScoutingBridge.deserializeMask(arr, m2)
+    -- serializeFarmMask reads ONLY the named farm: farm 1 gets its own two cells
+    -- and never a byte of farm 2.
+    local entries1 = SoilScoutingBridge.serializeFarmMask(m, 1)
+    T.eq("farm 1 serialises exactly its own two cells", #entries1, 2)
+    for _, e in ipairs(entries1) do
+        T.ok("no farm-2 field id leaks into farm 1's payload", e.fieldId == 5 or e.fieldId == 6)
+    end
+    T.ok("payload entries are primitives (fieldId is a number)", type(entries1[1].fieldId) == "number")
 
-    T.eq("wire: farm 1 cell survives", m2:composeShown(1, 5, "1", 103, -1, false), 42)
-    T.eq("wire: farm 1 second cell survives", m2:composeShown(1, 6, "2", 103, -1, false), 13)
-    T.eq("wire: farm 2 cell survives", m2:composeShown(2, 9, "7", 105, -1, false), 55)
-    T.ok("wire: array is primitives only", type(arr[1]) == "number")
+    -- A client on farm 1 applies farm 1's FULL and reconstructs exactly those cells.
+    g_localPlayer = { farmId = 1 }
+    local c1 = newMask()
+    SoilScoutingBridge.applyMaskEvent(c1, 1, {
+        mode = SoilScoutingBridge.MASK_MODE_FULL, farmId = 1,
+        chunkIndex = 1, chunkCount = 1, entries = entries1,
+    })
+    T.eq("client farm 1: cell 5 survives", c1:composeShown(1, 5, "1", 103, -1, false), 42)
+    T.eq("client farm 1: cell 6 survives", c1:composeShown(1, 6, "2", 103, -1, false), 13)
+    T.eq("client farm 1: never receives farm 2's cell", c1:composeShown(2, 9, "7", 105, -1, false), -1)
+
+    -- A payload STAMPED for farm 2, handed to a farm-1 client, is rejected whole
+    -- (the wrong-farm guard fires before any mutation): nothing lands.
+    local c2 = newMask()
+    SoilScoutingBridge.applyMaskEvent(c2, 1, {
+        mode = SoilScoutingBridge.MASK_MODE_FULL, farmId = 2,
+        chunkIndex = 1, chunkCount = 1, entries = SoilScoutingBridge.serializeFarmMask(m, 2),
+    })
+    T.ok("a payload for the wrong farm is rejected wholesale", next(c2.masks) == nil)
 end

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -793,6 +793,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -1424,4 +1424,7 @@
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
     <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -788,6 +788,9 @@
     <e k="sf_desc_smartSensorEnabled"      v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -788,6 +788,9 @@
     <e k="sf_desc_smartSensorEnabled"      v="Umožňuje hráčům používat sekční řízení ramene Smart Sensor na základě živých dat o půdě" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Vypíná sekce ramene nad místy, která nevyžadují postřik" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Plevel" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Škůdci" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Choroby" />

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -732,6 +732,9 @@
     <e k="sf_desc_smartSensorEnabled"      v="Tillad spillere at bruge Smart Sensor-bomsektionsstyring baseret på jorddata" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Deaktivér bomsektioner over områder, der ikke har behov for sprøjtning" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Juster udbringningsmængden pr. sektion baseret på jordens næringsstofunderskud" />

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -762,6 +762,9 @@
     <e k="sf_variable_rate_long"           v="Variable Ausbringmenge basierend auf Bodendefiziten aktivieren oder deaktivieren" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Gestängesektionen über Bereichen ohne Spritzbedarf unterdrücken" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Unkraut" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Schädlinge" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Krankheit" />

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -745,6 +745,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -450,6 +450,7 @@
     <e k="sf_map_btn_cycle_layer" v="Cycle Layer" eh="875dbf22" />
     <e k="sf_map_btn_treatment" v="Treatment Plan" eh="4ba012e2" />
     <e k="sf_map_btn_disable" v="Disable Overlay" eh="8e75dec5" />
+    <e k="rf_pda_treat_spatial_mismatch" v="Field average looks fine, but the soil map has patches below target. The plan follows the map." />
     <e k="sf_treat_action_ok" v="OK" eh="e0aa021e" />
     <e k="sf_help_title" v="Soil Quick Reference" eh="8986bb6d" />
     <e k="sf_help_nutrients_header" v="NUTRIENTS" eh="9aeb39bf" />
@@ -788,6 +789,9 @@
     <e k="sf_desc_smartSensorEnabled"      v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -745,6 +745,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -788,6 +788,9 @@
     <e k="sf_desc_smartSensorEnabled"      v="Allow players to use Smart Sensor boom-section control based on live soil data" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -746,6 +746,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1402,4 +1402,7 @@
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
     <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -765,6 +765,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -792,6 +792,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -792,6 +792,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -772,6 +772,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -773,6 +773,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -774,6 +774,9 @@
     <e k="sf_variable_rate_long"           v="Variabele dosering op basis van bodemtekorten in- of uitschakelen" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Boomsecties onderdrukken boven gebieden die geen bespuiting nodig hebben" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="Zie &amp; Sproei: Onkruid" />
     <e k="sf_config_seeSprayPest"          v="Zie &amp; Sproei: Plaag" />
     <e k="sf_config_seeSprayDisease"       v="Zie &amp; Sproei: Ziekte" />

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -774,6 +774,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -774,6 +774,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -793,6 +793,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -793,6 +793,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -734,6 +734,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -745,6 +745,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -746,6 +746,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -745,6 +745,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -745,6 +745,9 @@
     <e k="sf_variable_rate_long"           v="Enable or disable Variable Rate Application based on soil deficits" />
     <e k="sf_desc_seeAndSprayEnabled"      v="Suppress boom sections over areas that do not need spraying" />
     <e k="sf_config_seeSpray"              v="See &amp; Spray" />
+    <e k="sf_config_precision"             v="Precision Pack (Variable Rate + Section Control)" />
+    <e k="sf_pack_required"                v="This sprayer does not have the add-on needed for that function. Please visit the shop to upgrade your sprayer." />
+    <e k="sf_pack_legacy_notice"           v="Variable rate and section control now need the Precision Pack. This sprayer does not have it - visit the shop to upgrade." />
     <e k="sf_config_seeSprayWeed"          v="See &amp; Spray: Weed" />
     <e k="sf_config_seeSprayPest"          v="See &amp; Spray: Pest" />
     <e k="sf_config_seeSprayDisease"       v="See &amp; Spray: Disease" />    <e k="sf_desc_variableRateEnabled"     v="Adjust application rate per section based on soil nutrient deficits" />


### PR DESCRIPTION
Certified handoff **SF-22** (Stage 7 TRAVELLED, IRIS + Arissani) — repairs the ownership joint on the walked soil mask so knowledge stays private per farm.

## What it does
- One farm shares only the cells its own players legally learned (own land, or land it is actively contracting).
- **Another farm receives zero mask bytes** — it keeps the existing UNKNOWN state.
- A client forgets the old farm's mask when it switches farms.
- No new map, pricing, public service, FarmTablet surface, or player-facing string.

## Design notes (the load-bearing bits)
- **Authorization before any truth read** — `SpatialScouting.isRevealAuthorized` gates walk and kneel; the farm comes from the server player record with no farm-1 fallback.
- **Client-apply-only sync event** — `SoilScoutingMaskSyncEvent:run` guards `if g_server ~= nil then return end` (not the weaker `not g_client`), because a listen host runs a local-stream event in-process and must never overwrite its own authoritative mask. The remote selector also drops the loopback connection.
- **Atomic FULL / immediate DELTA** — a FULL replaces a farm's slice only after every chunk arrives exactly once; DELTA never clears; generation is raised before freshness.
- **Farm-switch route** — a pure-client subscriber to `PLAYER_FARM_CHANGED` drops the old farm and pulls a fresh FULL for the new one.

Every engine API verified against the decompile (`FARM_ID_SEND_NUM_BITS`, `getIsContractingFor`, `getFarmByUserId`, `PLAYER_FARM_CHANGED`, `Connection:sendEvent` local-stream behavior, MessageCenter arg order).

## Files (6 source + test infra)
`SpatialScouting.lua`, `integrations/SoilScoutingBridge.lua`, `network/NetworkEvents.lua`, `main.lua`, `ui/SoilMapOverlay.lua`, `HandfulRead.lua`; new `sf22_private_mask_spec_test.lua`, re-pointed `spatial_scouting`/`kneel` specs, `prelude.lua` (+UInt16 stubs).

## Verification
- Syntax ✅ 92 files · Lint ✅ clean · Logic ✅ **3092 passed** (+79), 0 new failures (the 4 remaining failures are pre-existing SF-14/spray tests, confirmed on baseline).
- New bench covers: ordinary-farm predicate, authorization matrix (own / contracted / neighbour), one-farm serializer, remote selector (loopback/disconnected/wrong-farm rejects), atomic FULL + chunk assembly + reject paths, transition classifier, and the event wire round-trip.

## Release gate — stays LOCKED
Merges `MERGED-LOCKED` under `read_the_dirt`. Unlock needs the in-game observations that offline cannot prove: two-farm privacy, same-farm parity, contract gate, join/reconnect, farm switch, listen-host authoritative counts, dedicated-server FULL, NetworkSync-absent, and large-save perf.