### PR TITLE
feat(soil): SF-14 zone yield of the established crop (v2.0 replacement)

### DIFF
--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -818,15 +818,15 @@ function SoilFertilityManager:activateSoilSystem()
             end
         end
 
-        -- SF-14 ZONE YIELD: initialize + register the daily capture accrual.
+        -- SF-14 ZONE YIELD: initialize + register the growth-message capture.
         -- Server-only by the value-map write's nature; the module's own live
         -- gate keeps it inert until the growth_modulation release gate opens.
-        -- Time Guard absent: the capture runs on SF's own day tracking via
-        -- checkDayFallback, pumped from the soil system's daily pump.
+        -- The capture runs once per drained FINISHED_GROWTH_PERIOD delivery;
+        -- Time Guard creates no second ordinary capture.
         if self.zoneYield then
             self.zoneYield:initialize()
             if g_server ~= nil then
-                self.zoneYield:registerDailyAccrual()
+                self.zoneYield:registerGrowthMessage()
             end
         end
 

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -779,7 +779,7 @@ function SoilFertilitySystem:onHarvest(fieldId, fruitTypeIndex, liters, strawRat
         harvestField.sownCrop                = nil  -- crop harvested; lastCrop now carries it (#661)
         -- frozenYieldModifier is NOT cleared here (#598): onHarvest fires per-cut, so
         -- clearing here defeats the freeze and causes yield to drop with each combine pass.
-        -- The freeze is cleared once per game day in _processOneDailyField instead.
+        -- The freeze is cleared once per crop cycle in onSowing (SF-14 owns the cycle).
     end
 
     SoilLogger.debug("Harvest: Field %d, Crop %d, %.0fL (biological), area=%.1f", fieldId, fruitTypeIndex, liters, area or 0)
@@ -1057,6 +1057,15 @@ function SoilFertilitySystem:onSowing(fieldId, area, seedsFruitType, cropBiomass
     if not fieldId or fieldId <= 0 then return end
     local field = self:getOrCreateField(fieldId, true)
     if not field then return end
+
+    -- SF-14: sowing opens a NEW crop cycle, so the previous crop's yield
+    -- capture and freeze are cleared here (not on the next game day). The
+    -- same crop does not change its yield result halfway through harvest, but
+    -- a fresh sowing must start clean: the old capture no longer describes
+    -- the standing crop and the old freeze no longer applies.
+    field.frozenYieldModifier  = nil
+    field.frozenYieldFruitType = nil
+    field.zoneYieldCaptureReady = nil
 
     -- SF-18: opening (or extending) the establishment window. Every sowing pass
     -- extends, making re-drilling and multi-day drilling the same case.
@@ -2713,15 +2722,9 @@ function SoilFertilitySystem:update(dt)
         g_SoilFertilityManager.establishment:checkDayFallback()
     end
 
-    -- [SF-14] ZONE YIELD: daily cadence pump. When Time Guard is present its
-    -- accrual drives the capture; this call runs the capture on SF's own day
-    -- tracking when Time Guard is absent, the brief's named neutral flow.
-    -- Server only: the capture write is server-authoritative.
-    if g_server ~= nil and g_SoilFertilityManager and g_SoilFertilityManager.zoneYield
-        and g_SoilFertilityManager.zoneYield.isInitialized
-        and g_SoilFertilityManager.zoneYield.checkDayFallback then
-        g_SoilFertilityManager.zoneYield:checkDayFallback()
-    end
+    -- [SF-14] ZONE YIELD: no daily pump. The capture runs once per drained
+    -- FINISHED_GROWTH_PERIOD delivery (server-only by the value-map write's
+    -- nature); Time Guard creates no second ordinary capture.
 
     -- REFINED: round-robin display-layer mirror. Keeps the per-pixel
     -- weed/pest/disease/urgency/yield maps in step with the field-level
@@ -4537,12 +4540,6 @@ function SoilFertilitySystem:_processOneDailyField(fieldId, field)
     field.sessionLastProduct      = nil
     field._geometricCoverageOwner = nil  -- #753
     field.sprayTrailPts           = nil
-
-    -- Clear the yield-modifier freeze from the previous harvest session (#598).
-    -- Frozen on the first cut of a harvest pass and held until the next game day so
-    -- that per-cut nutrient depletion does not cause yield to drop mid-harvest (#556).
-    field.frozenYieldModifier  = nil
-    field.frozenYieldFruitType = nil
 
     -- ── Compaction natural decay ─────────────────────────────────────────────
     if self.settings.compactionEnabled and SoilConstants.COMPACTION then
@@ -7245,10 +7242,16 @@ function SoilFertilitySystem:saveToXMLFile(xmlFile, key)
             -- now-depleted field-average nutrients with the one-shot burn already consumed,
             -- so the yield figure silently changed after every reload and a save/reload
             -- erased an active burn penalty entirely (#656). Only written while a freeze is
-            -- live; cleared on the next game-day change by _processOneDailyField as before.
+            -- live; cleared on the next SOWING by onSowing (SF-14 owns the crop cycle).
             if field.frozenYieldModifier and field.frozenYieldFruitType then
                 setXMLFloat(xmlFile, fieldKey .. "#frozenYieldModifier", field.frozenYieldModifier)
                 setXMLInt(xmlFile, fieldKey .. "#frozenYieldFruitType", field.frozenYieldFruitType)
+            end
+            -- SF-14: persist the capture-ready marker so a fresh capture survives
+            -- save/reload and an upgraded save (no marker) keeps using fallback until
+            -- one fresh capture pass succeeds.
+            if field.zoneYieldCaptureReady == true then
+                setXMLBool(xmlFile, fieldKey .. "#zoneYieldCaptureReady", true)
             end
 
             -- Save daily application throttles
@@ -7366,6 +7369,7 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
             amendBurnPenalty = getXMLFloat(xmlFile, fieldKey .. "#amendBurnPenalty") or nil,
             frozenYieldModifier  = getXMLFloat(xmlFile, fieldKey .. "#frozenYieldModifier") or nil,
             frozenYieldFruitType = getXMLInt(xmlFile, fieldKey .. "#frozenYieldFruitType") or nil,
+            zoneYieldCaptureReady = (getXMLBool(xmlFile, fieldKey .. "#zoneYieldCaptureReady") == true) or nil,
             coverageFraction = getXMLFloat(xmlFile, fieldKey .. "#coverageFraction") or 0,
             lastAlertSeason = getXMLInt(xmlFile, fieldKey .. "#lastAlertSeason") or nil,
             compaction = 0,
@@ -7614,6 +7618,10 @@ function SoilFertilitySystem:getSoilStateTable()
                 e.frozenYieldModifier  = field.frozenYieldModifier
                 e.frozenYieldFruitType = field.frozenYieldFruitType
             end
+            -- SF-14 capture-ready marker (matches XML save).
+            if field.zoneYieldCaptureReady == true then
+                e.zoneYieldCaptureReady = true
+            end
             -- Organic certification sub-table (only when present).
             if field.organic then
                 e.organic = {
@@ -7701,6 +7709,7 @@ function SoilFertilitySystem:applySoilStateTable(data)
                 amendBurnPenalty      = e.amendBurnPenalty,
                 frozenYieldModifier   = e.frozenYieldModifier,
                 frozenYieldFruitType  = e.frozenYieldFruitType,
+                zoneYieldCaptureReady = e.zoneYieldCaptureReady == true and true or nil,
                 coverageFraction      = e.coverageFraction or 0,
                 lastAlertSeason       = e.lastAlertSeason,
                 compaction            = 0,

--- a/src/ZoneYield.lua
+++ b/src/ZoneYield.lua
@@ -7,37 +7,45 @@
 -- never recomputed live at harvest.
 --
 -- THE TWO HALVES.
---   The capture (per growth period): rides the family's shared
---   read (ViabilityMask:getCellGrowthInfo, extended to carry the
---   full input set), scores each cell's N/P/K against the
---   efficiency band, clamps at write time, and writes to the
---   `yieldEfficiency` value-map layer.
---   The read (per harvest work-area pass): reads the captured,
---   growth-time-static `yieldEfficiency` layer across the header,
---   area-weighted per SF-25's ratified rule, producing one scalar.
+--   The capture (per drained growth period): rides the engine's
+--   FINISHED_GROWTH_PERIOD message (GrowthSystem publishes
+--   finishedPeriod, hasPendingGrowth), scores each cell's N/P/K
+--   against the efficiency band, clamps at write time, and writes
+--   to the `yieldEfficiency` value-map layer. One drained delivery
+--   produces one capture pass. Time Guard creates no second
+--   ordinary capture.
+--   The read (per harvest work-area pass): a pre-cut spatial
+--   context method prepares the scalar BEFORE the destructive base
+--   Cutter call, reading the captured, growth-time-static
+--   `yieldEfficiency` layer across the true work-area polygon,
+--   fruit-masked, area-weighted per SF-25's ratified rule.
 --
 -- THE FREEZE SUPERSESSION. On the spatial path (value maps
--- present), the SF-16 scalar `frozenYieldModifier` freeze is
--- BYPASSED, not reused: the per-pass modifier is the area-weighted
--- read of the captured layer, computed fresh each pass. The scalar
--- freeze stays exactly as built for the non-spatial fallback (maps
--- absent, field-average path), one branch, untouched.
+--   present and a fresh capture exists), the per-pass modifier is
+--   the fruit-filtered polygon read of the captured layer. The
+--   scalar `frozenYieldModifier` freeze stays exactly as built for
+--   the non-spatial fallback (maps absent, field-average path) and
+--   for contract fields, one branch, untouched. The same crop does
+--   not change its yield result halfway through harvest because
+--   earlier passes depleted nutrients: the capture is frozen at
+--   growth time and the scalar freeze holds the field-average
+--   fallback for the harvest run.
 --
 -- THE CALIBRATION BAR (reconciliation invariant). A uniform field,
--- where every cell shares the same growth-time conditions, must
--- yield exactly what it yields today. The capture formula IS
--- `_yieldModifierFromNutrients` (the same single source of truth
--- computeYieldModifier uses) evaluated with the CELL's own N/P/K,
--- clamped to the band. On a uniform field every cell carries the
--- field average, so every captured cell equals computeYieldModifier
--- output and the area-weighted read reconciles exactly, within the
--- band's own floor/ceiling.
+--   where every cell shares the same growth-time conditions, must
+--   yield exactly what it yields today. The capture formula IS
+--   `_yieldModifierFromNutrients` (the same single source of truth
+--   computeYieldModifier uses) evaluated with the CELL's own N/P/K,
+--   clamped to the band. On a uniform field every cell carries the
+--   field average, so every captured cell equals computeYieldModifier
+--   output and the area-weighted read reconciles exactly, within the
+--   band's own floor/ceiling.
 --
 -- COMPOSITION WITH SF-55 (addendum 2026-08-05): the per-pass read
--- applies `effective = captured * (1 - drag)` from day one; a nil
--- drag (the SF-55 layer is not present yet) reads as zero and the
--- read is unchanged. One writer per value still holds: SF-14 writes
--- capture, SF-55 writes drag, the read composes them.
+--   applies `effective = captured * (1 - drag)` from day one; a nil
+--   drag (the SF-55 layer is not present yet) reads as zero and the
+--   read is unchanged. One writer per value still holds: SF-14 writes
+--   capture, SF-55 writes drag, the read composes them.
 --
 -- The family ships LOCKED: inert unless the growth_modulation
 -- release gate is open AND the mask is enabled.
@@ -53,25 +61,26 @@ local ZoneYield_mt = Class(ZoneYield)
 ZoneYield.BAND_FLOOR   = 0.7
 ZoneYield.BAND_CEILING = 1.15
 
--- Time Guard accrual. Priority 98 lands one behind the credit
--- bookkeeper (97), so the ground has settled, the dead have been
--- counted, and rewards have been accrued before the day's capture.
-ZoneYield.DAILY_ACCURAL_ID       = 'SF14_zoneYieldCapture'
-ZoneYield.DAILY_ACCURAL_PRIORITY = 98
+-- Capture lattice: 8 m step, coarsened only enough to stay at or
+-- below 600 accepted points per field per drained growth event.
+ZoneYield.CAPTURE_LATTICE_STEP_M = 8
+ZoneYield.CAPTURE_MAX_POINTS     = 600
 
--- Header read sample step, and the hard cap. The per-cell VALUE-MAP
--- read cost at harvest cadence is a NAMED bench item (brief section
--- 6), NOT asserted equal to boom-section cadence: this bounds the
--- worst case so a pathological header can never spin the frame.
-ZoneYield.HEADER_SAMPLE_STEP_M = 4
-ZoneYield.HEADER_MAX_SAMPLES   = 256
+-- Drag lattice: 4 m step under a 256 accepted-point ceiling. Each
+-- accepted point performs one harvestable-fruit query plus one
+-- yieldEfficiency point read and one trafficDrag point read.
+ZoneYield.DRAG_LATTICE_STEP_M = 4
+ZoneYield.DRAG_MAX_POINTS     = 256
 
 function ZoneYield.new(manager)
     local self = setmetatable({}, ZoneYield_mt)
     self.manager = manager
     self.isInitialized = false
-    self._tgAccrualRegistered = false
-    self._lastFallbackDay = nil
+    self._messageSubscribed = false
+    -- (fruitTypeIndex, allowsForageGrowthState) -> DensityMapFilter
+    self._fruitFilterCache = {}
+    -- fieldId -> fruitTypeIndex last contract-refreshed for
+    self._contractRefreshed = {}
     return self
 end
 
@@ -81,7 +90,15 @@ end
 
 function ZoneYield:delete()
     self.isInitialized = false
-    self._lastFallbackDay = nil
+    if self._messageSubscribed then
+        local mc = g_messageCenter
+        if mc and type(mc.unsubscribe) == 'function' then
+            pcall(function() mc:unsubscribe(MessageType.FINISHED_GROWTH_PERIOD, self) end)
+        end
+        self._messageSubscribed = false
+    end
+    self._fruitFilterCache = {}
+    self._contractRefreshed = {}
 end
 
 -- ============================================================
@@ -138,17 +155,37 @@ function ZoneYield.captureScore(soilSystem, field, cropName, n, p, k)
 end
 
 -- ============================================================
--- THE CAPTURE PASS (per growth period, per cell)
+-- THE CAPTURE PASS (per drained growth period, per cell)
 -- ============================================================
 
--- The survey lattice. Re-derive the family's own adaptive grid
--- exactly as ViabilityMask/GrowthCredit do, reading BOTH constants
--- off ViabilityMask at runtime, never copied literals.
----@param fieldId number
+--- Ray-casting point-in-polygon test. Pure, bench-drivable.
+---@param x number
+---@param z number
 ---@param verts table list of {x=, z=}
----@return table header { originX, originZ, step, maxX, maxZ }
-function ZoneYield:_deriveHeader(fieldId, verts)
-    local vm = ViabilityMask
+---@return boolean
+function ZoneYield.pointInPolygon(x, z, verts)
+    local inside = false
+    local n = #verts
+    if n < 3 then return false end
+    local j = n
+    for i = 1, n do
+        local vi, vj = verts[i], verts[j]
+        if (vi.z > z) ~= (vj.z > z) then
+            local xint = (vj.x - vi.x) * (z - vi.z) / (vj.z - vi.z) + vi.x
+            if x < xint then inside = not inside end
+        end
+        j = i
+    end
+    return inside
+end
+
+--- The capture lattice for one field: an 8 m grid over the polygon
+--- bounding box, coarsened only enough to stay at or below
+--- CAPTURE_MAX_POINTS accepted centres. Returns the list of
+--- {x=, z=} centres that fall inside the polygon.
+---@param verts table list of {x=, z=}
+---@return table list of {x=, z=}
+function ZoneYield:_deriveCapturePoints(verts)
     local minX, maxX = verts[1].x, verts[1].x
     local minZ, maxZ = verts[1].z, verts[1].z
     for i = 2, #verts do
@@ -158,29 +195,33 @@ function ZoneYield:_deriveHeader(fieldId, verts)
         if v.z < minZ then minZ = v.z end
         if v.z > maxZ then maxZ = v.z end
     end
-    local step = vm.SAMPLE_STEP_M
+    local step = ZoneYield.CAPTURE_LATTICE_STEP_M
     local est = math.ceil((maxX - minX) / step) * math.ceil((maxZ - minZ) / step)
-    if est > vm.MAX_SAMPLES then
-        step = step * math.ceil(math.sqrt(est / vm.MAX_SAMPLES))
+    if est > ZoneYield.CAPTURE_MAX_POINTS then
+        step = step * math.ceil(math.sqrt(est / ZoneYield.CAPTURE_MAX_POINTS))
     end
-    return {
-        originX = minX + step * 0.5,
-        originZ = minZ + step * 0.5,
-        step    = step,
-        maxX    = maxX,
-        maxZ    = maxZ,
-    }
+    local out = {}
+    local x = minX + step * 0.5
+    while x <= maxX do
+        local z = minZ + step * 0.5
+        while z <= maxZ do
+            if ZoneYield.pointInPolygon(x, z, verts) then
+                out[#out + 1] = { x = x, z = z }
+            end
+            z = z + step
+        end
+        x = x + step
+    end
+    return out
 end
 
---- The growing crop's name for one field, resolved once per pass.
---- The live fruit read mirrors getFieldInfo (FieldState at the
---- field centre); `field.lastCrop` is the fallback. nil means
---- nothing growing, and a field with no crop captures nothing
---- (SF-18 orthogonality: an empty cell contributes no area).
+--- The live fruit type index for one field, resolved once per pass.
+--- Uses the live FieldState at the field centre (mirrors getFieldInfo);
+--- `field.lastCrop` alone is NOT proof that a crop still stands, so a
+--- field with no live fruit resolves to nil and captures nothing.
 ---@param fieldId number
----@param field table
----@return string|nil
-function ZoneYield:_resolveCropName(fieldId, field)
+---@return number|nil fruitTypeIndex
+function ZoneYield:_resolveLiveFruit(fieldId)
     if g_fieldManager ~= nil and g_fieldManager.fields then
         local fsField = nil
         for _, f in ipairs(g_fieldManager.fields) do
@@ -196,64 +237,62 @@ function ZoneYield:_resolveCropName(fieldId, field)
                 return fs
             end)
             if ok and fieldState and fieldState.fruitTypeIndex ~= FruitType.UNKNOWN then
-                local fruitDesc = g_fruitTypeManager and
-                    g_fruitTypeManager:getFruitTypeByIndex(fieldState.fruitTypeIndex)
-                if fruitDesc and fruitDesc.name then return fruitDesc.name end
+                return fieldState.fruitTypeIndex
             end
         end
-    end
-    if field and field.lastCrop and field.lastCrop ~= "" then
-        return field.lastCrop
     end
     return nil
 end
 
---- One capture field: walk the survey lattice, read N/P/K per cell
---- through the family's shared read, score, clamp, write to the
---- yieldEfficiency layer at that position.
+--- One capture field: walk the capture lattice, read N/P/K per cell
+--- through the value maps (three reads), score, clamp, write to the
+--- yieldEfficiency layer at that position. Sets the ready marker only
+--- after at least one successful write.
 ---@param fieldId number
 ---@param field table
+---@param fruitTypeIndex number
 ---@param ss table the soil system
 ---@param vm table the value maps
----@return boolean
-function ZoneYield:_captureField(fieldId, field, ss, vm)
+---@return boolean captured
+function ZoneYield:_captureField(fieldId, field, fruitTypeIndex, ss, vm)
     if type(ss._getFieldPolyVerts) ~= 'function' then return false end
     local verts = ss:_getFieldPolyVerts(fieldId, field)
     if verts == nil or #verts < 3 then return false end
 
-    local cropName = self:_resolveCropName(fieldId, field)
-    if cropName == nil then return false end
+    local fruitDesc = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(fruitTypeIndex)
+    local cropName = fruitDesc and fruitDesc.name or ""
+    if cropName == "" then return false end
 
-    local viability = self:_viability()
-    if viability == nil then return false end
+    local points = self:_deriveCapturePoints(verts)
+    if #points == 0 then return false end
 
-    local header = self:_deriveHeader(fieldId, verts)
-    local x = header.originX
-    local gx = 0
-    while x <= header.maxX do
-        local z = header.originZ
-        local gz = 0
-        while z <= header.maxZ do
-            local info = viability:getCellGrowthInfo(fieldId, x, z)
-            if info ~= nil then
-                local n = info.n
-                local p = info.p
-                local k = info.k
-                if type(n) == 'number' and type(p) == 'number' and type(k) == 'number' then
-                    local score = ZoneYield.captureScore(ss, field, cropName, n, p, k)
-                    vm:writeValueAtWorld('yieldEfficiency', x, z, score * 100, header.step * 0.5)
-                end
-            end
-            z = z + header.step
-            gz = gz + 1
+    local writes = 0
+    local reads = 0
+    for _, pt in ipairs(points) do
+        local n = vm:readValueAtWorld('nitrogen', pt.x, pt.z)
+        local p = vm:readValueAtWorld('phosphorus', pt.x, pt.z)
+        local k = vm:readValueAtWorld('potassium', pt.x, pt.z)
+        reads = reads + 3
+        if type(n) == 'number' and type(p) == 'number' and type(k) == 'number' then
+            local score = ZoneYield.captureScore(ss, field, cropName, n, p, k)
+            vm:writeValueAtWorld('yieldEfficiency', pt.x, pt.z, score * 100, ZoneYield.CAPTURE_LATTICE_STEP_M * 0.5)
+            writes = writes + 1
         end
-        x = x + header.step
-        gx = gx + 1
     end
-    return true
+
+    if writes > 0 then
+        field.zoneYieldCaptureReady = true
+    end
+
+    if SoilLogger ~= nil and type(SoilLogger.info) == 'function' then
+        SoilLogger.info("SF14_CAPTURE field=%d fruit=%d accepted=%d reads=%d writes=%d ready=%d skipped=none ms=0",
+            fieldId, fruitTypeIndex, #points, reads, writes, field.zoneYieldCaptureReady and 1 or 0)
+    end
+    return writes > 0
 end
 
---- The whole capture pass: every tracked field, every period.
+--- The whole capture pass: every tracked field, one drained growth
+--- delivery. Returns the number of fields captured.
 ---@return number fields captured
 function ZoneYield:runCapturePass()
     if not self:isLive() then return 0 end
@@ -266,7 +305,18 @@ function ZoneYield:runCapturePass()
     for fieldId in pairs(ss.fieldData) do
         local field = ss.fieldData[fieldId]
         if field ~= nil then
-            if self:_captureField(fieldId, field, ss, vm) then
+            local fruitTypeIndex = self:_resolveLiveFruit(fieldId)
+            if fruitTypeIndex == nil then
+                if SoilLogger ~= nil and type(SoilLogger.info) == 'function' then
+                    SoilLogger.info("SF14_CAPTURE field=%d fruit=none accepted=0 reads=0 writes=0 ready=0 skipped=no-live-fruit ms=0", fieldId)
+                end
+            elseif field.frozenYieldFruitType == fruitTypeIndex then
+                -- The same harvest retains its earlier capture.
+                if SoilLogger ~= nil and type(SoilLogger.info) == 'function' then
+                    SoilLogger.info("SF14_CAPTURE field=%d fruit=%d accepted=0 reads=0 writes=0 ready=%d skipped=frozen ms=0",
+                        fieldId, fruitTypeIndex, field.zoneYieldCaptureReady and 1 or 0)
+                end
+            elseif self:_captureField(fieldId, field, fruitTypeIndex, ss, vm) then
                 captured = captured + 1
             end
         end
@@ -274,8 +324,84 @@ function ZoneYield:runCapturePass()
     return captured
 end
 
+--- Server-only FINISHED_GROWTH_PERIOD handler. One drained delivery
+--- produces one capture pass. Returns unless the manager and server
+--- are live, growth is enabled, and hasPendingGrowth == false.
+---@param finishedPeriod number
+---@param hasPendingGrowth boolean
+function ZoneYield:onFinishedGrowthPeriod(finishedPeriod, hasPendingGrowth)
+    local mission = g_currentMission
+    if mission == nil or not mission:getIsServer() then return end
+    if not self.isInitialized then return end
+    if not self:isLive() then return end
+    if hasPendingGrowth ~= false then return end
+    local growthMode = mission.missionInfo and mission.missionInfo.growthMode
+    if growthMode == GrowthMode.DISABLED then return end
+    self:runCapturePass()
+end
+
+--- Register the FINISHED_GROWTH_PERIOD subscription (server-only by
+--- the value-map write's nature). Same shape and version-skew guard
+--- as the rest of the family. Time Guard creates no second capture.
+function ZoneYield:registerGrowthMessage()
+    if self._messageSubscribed then return true end
+    if g_messageCenter ~= nil
+        and MessageType ~= nil and MessageType.FINISHED_GROWTH_PERIOD ~= nil
+        and type(g_messageCenter.subscribe) == 'function' then
+        local ok = pcall(function()
+            g_messageCenter:subscribe(MessageType.FINISHED_GROWTH_PERIOD, self.onFinishedGrowthPeriod, self)
+        end)
+        if ok then self._messageSubscribed = true end
+        return ok
+    end
+    return false
+end
+
 -- ============================================================
--- THE HARVEST READ (per work-area pass, area-weighted)
+-- THE FRUIT FILTER CACHE (harvest-state DensityMapFilter)
+-- ============================================================
+
+--- Build (and cache) one harvest-state DensityMapFilter per
+--- (fruitTypeIndex, allowsForageGrowthState) pair. The accepted range
+--- is minForageGrowthState when forage is allowed, else
+--- minHarvestingGrowthState, up to maxHarvestingGrowthState. Built
+--- from FruitTypeDesc.terrainDataPlaneId / startStateChannel /
+--- numStateChannels. Supersampling is set to ALL when available,
+--- following the base-shipped mixed-map technique (NitrogenMap).
+---@param fruitTypeIndex number
+---@param allowsForageGrowthState boolean
+---@return table|nil DensityMapFilter
+function ZoneYield:_getFruitFilter(fruitTypeIndex, allowsForageGrowthState)
+    local key = fruitTypeIndex .. ":" .. (allowsForageGrowthState and "1" or "0")
+    local cached = self._fruitFilterCache[key]
+    if cached ~= nil then return cached end
+
+    local desc = g_fruitTypeManager and g_fruitTypeManager:getFruitTypeByIndex(fruitTypeIndex)
+    if desc == nil or desc.terrainDataPlaneId == nil then return nil end
+
+    local minState = desc.minHarvestingGrowthState
+    if allowsForageGrowthState then
+        minState = desc.minForageGrowthState
+    end
+    local maxState = desc.maxHarvestingGrowthState
+
+    local ok, filter = pcall(function()
+        local f = DensityMapFilter.new(desc.terrainDataPlaneId, desc.startStateChannel, desc.numStateChannels)
+        if DensityFilterSupersamplingMode ~= nil and DensityFilterSupersamplingMode.ALL ~= nil
+           and type(f.setSupersamplingMode) == 'function' then
+            f:setSupersamplingMode(DensityFilterSupersamplingMode.ALL)
+        end
+        f:setValueCompareParams(DensityValueCompareType.BETWEEN, minState, maxState)
+        return f
+    end)
+    if not ok or filter == nil then return nil end
+
+    self._fruitFilterCache[key] = filter
+    return filter
+end
+
+-- ============================================================
+-- THE PRE-CUT SPATIAL CONTEXT (per harvest work-area pass)
 -- ============================================================
 
 --- SF-55 composition line, applied per-cell from day one. A nil drag
@@ -315,127 +441,252 @@ function ZoneYield.aggregateAreaWeighted(samples)
     return sum / area
 end
 
---- Build the header polygon(s) from a combine's work areas: the
---- combine's own spec_workArea plus any attached implements, the
---- same iteration the fieldId fallback uses. Returns a list of
---- {x=, z=} polygons (one per work area), or nil when none resolves.
----@param combineSelf table the harvesting vehicle
----@return table|nil
-function ZoneYield:_headerPolygons(combineSelf)
-    local polygons = {}
-    local function tryVehicle(vehicle)
-        if vehicle == nil then return end
-        if vehicle.spec_workArea and vehicle.spec_workArea.workAreas then
-            for _, wa in ipairs(vehicle.spec_workArea.workAreas) do
-                if wa and wa.start and wa.width and wa.height then
-                    local ok, poly = pcall(function()
-                        local xs, _, zs = getWorldTranslation(wa.start)
-                        local xw, _, zw = getWorldTranslation(wa.width)
-                        local xh, _, zh = getWorldTranslation(wa.height)
-                        if not xs or not xw or not xh then return nil end
-                        local x4 = xw + xh - xs
-                        local z4 = zw + zh - zs
-                        local minX = math.min(xs, xw, xh, x4)
-                        local maxX = math.max(xs, xw, xh, x4)
-                        local minZ = math.min(zs, zw, zh, z4)
-                        local maxZ = math.max(zs, zw, zh, z4)
-                        return {
-                            { x = minX, z = minZ },
-                            { x = maxX, z = minZ },
-                            { x = maxX, z = maxZ },
-                            { x = minX, z = maxZ },
-                        }
-                    end)
-                    if ok and poly and #poly >= 3 then
-                        polygons[#polygons + 1] = poly
+--- The true parallelogram of one work area, preserved as the three
+--- corner points (start, width, height) the engine uses.
+---@param workArea table
+---@return table|nil { start={x,z}, width={x,z}, height={x,z} }
+function ZoneYield:_workAreaParallelogram(workArea)
+    if workArea == nil or workArea.start == nil or workArea.width == nil or workArea.height == nil then
+        return nil
+    end
+    local ok, sx, _, sz = pcall(getWorldTranslation, workArea.start)
+    if not ok or not sx then return nil end
+    local ok2, xw, _, zw = pcall(getWorldTranslation, workArea.width)
+    if not ok2 or not xw then return nil end
+    local ok3, xh, _, zh = pcall(getWorldTranslation, workArea.height)
+    if not ok3 or not xh then return nil end
+    return {
+        start  = { x = sx, z = sz },
+        width  = { x = xw, z = zw },
+        height = { x = xh, z = zh },
+    }
+end
+
+--- Resolve the field id from a work-area parallelogram using the
+--- existing HookManager field resolver (field manager then farmland
+--- manager at the start corner, with attached-implement fallback).
+---@param cutterSelf table
+---@param para table { start={x,z}, ... }
+---@return number|nil
+function ZoneYield:_resolveFieldId(cutterSelf, para)
+    local function atWorld(x, z)
+        if g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function" then
+            local field = g_fieldManager:getFieldAtWorldPosition(x, z)
+            if field and field.farmland then return field.farmland.id end
+        end
+        if g_farmlandManager then
+            local farmland = g_farmlandManager:getFarmlandAtWorldPosition(x, z)
+            if farmland then return farmland.id end
+        end
+        return nil
+    end
+
+    local fieldId = atWorld(para.start.x, para.start.z)
+    if fieldId and fieldId > 0 then return fieldId end
+
+    -- Fallback: attached implements' work areas.
+    local attachedImpls = cutterSelf.spec_attacherJoints and cutterSelf.spec_attacherJoints.attachedImplements
+    if attachedImpls then
+        for _, impl in ipairs(attachedImpls) do
+            local obj = impl and impl.object
+            if obj then
+                local ix, _, iz = pcall(getWorldTranslation, obj.rootNode)
+                if ix then
+                    fieldId = atWorld(ix, iz)
+                end
+                if (not fieldId or fieldId <= 0) and obj.spec_workArea and obj.spec_workArea.workAreas then
+                    for _, wa in ipairs(obj.spec_workArea.workAreas) do
+                        if wa.start then
+                            local ok, wx, _, wz = pcall(getWorldTranslation, wa.start)
+                            if ok and wx then
+                                fieldId = atWorld(wx, wz)
+                            end
+                        end
+                        if fieldId and fieldId > 0 then break end
                     end
                 end
             end
-        end
-        if vehicle.spec_attacherJoints and vehicle.spec_attacherJoints.attachedImplements then
-            for _, impl in ipairs(vehicle.spec_attacherJoints.attachedImplements) do
-                local obj = impl and impl.object
-                if obj then tryVehicle(obj) end
-            end
+            if fieldId and fieldId > 0 then break end
         end
     end
-    tryVehicle(combineSelf)
-    if #polygons == 0 then return nil end
-    return polygons
+    return fieldId
 end
 
---- Sample a polygon on a bounded grid; every sample is the centre of
---- an equal-area cell (step squared), which is what makes the
---- aggregation an area-weighted integral rather than a scatter of
---- points. Capped so a pathological header cannot spin the frame.
----@param verts table {x=,z=} polygon
----@return table list of {x=, z=}
-function ZoneYield:_samplePolygon(verts)
-    local step = ZoneYield.HEADER_SAMPLE_STEP_M
-    local minX, maxX = verts[1].x, verts[1].x
-    local minZ, maxZ = verts[1].z, verts[1].z
-    for i = 2, #verts do
-        local v = verts[i]
-        if v.x < minX then minX = v.x end
-        if v.x > maxX then maxX = v.x end
-        if v.z < minZ then minZ = v.z end
-        if v.z > maxZ then maxZ = v.z end
-    end
-    local out = {}
+--- The fruit-filtered traffic drag over a polygon. Reads the SF-55
+--- trafficDrag layer masked by the fruit filter; nil or zero is
+--- identity (drag = 0). Returns a fraction in [0,1] or nil.
+---@param vm table value maps
+---@param verts table polygon
+---@param fruitFilter table|nil
+---@return number|nil
+function ZoneYield:_readTrafficDragPolygon(vm, verts, fruitFilter)
+    local drag, _ = vm:readAverageOfPolygon('trafficDrag', verts, fruitFilter)
+    if type(drag) ~= 'number' or drag <= 0 then return nil end
+    return math.max(0, math.min(1, drag))
+end
+
+--- The fruit-filtered yieldEfficiency polygon mean, divided by 100
+--- exactly once. nil when the spatial path cannot answer.
+---@param vm table value maps
+---@param verts table polygon
+---@param fruitFilter table|nil
+---@return number|nil multiplier in [BAND_FLOOR, BAND_CEILING]
+function ZoneYield:_readYieldPolygon(vm, verts, fruitFilter)
+    local mean, _ = vm:readAverageOfPolygon('yieldEfficiency', verts, fruitFilter)
+    if type(mean) ~= 'number' then return nil end
+    return mean / 100
+end
+
+--- The drag path: one 4 m candidate lattice under a 256 accepted-point
+--- ceiling. Each accepted point performs one harvestable-fruit query
+--- plus one yieldEfficiency point read and one trafficDrag point read.
+--- Skip unwritten capture; unwritten drag is zero. Returns the
+--- composed scalar or nil.
+---@param vm table value maps
+---@param para table parallelogram
+---@param fruitTypeIndex number
+---@param allowsForageGrowthState boolean
+---@param drag number positive drag fraction
+---@return number|nil
+function ZoneYield:_readDragPath(vm, para, fruitTypeIndex, allowsForageGrowthState, drag)
+    local minX = math.min(para.start.x, para.width.x, para.height.x)
+    local maxX = math.max(para.start.x, para.width.x, para.height.x)
+    local minZ = math.min(para.start.z, para.width.z, para.height.z)
+    local maxZ = math.max(para.start.z, para.width.z, para.height.z)
+
+    local step = ZoneYield.DRAG_LATTICE_STEP_M
+    local samples = {}
     local count = 0
     local x = minX + step * 0.5
-    while x <= maxX and count < ZoneYield.HEADER_MAX_SAMPLES do
+    while x <= maxX and count < ZoneYield.DRAG_MAX_POINTS do
         local z = minZ + step * 0.5
-        while z <= maxZ and count < ZoneYield.HEADER_MAX_SAMPLES do
-            out[#out + 1] = { x = x, z = z }
+        while z <= maxZ and count < ZoneYield.DRAG_MAX_POINTS do
+            -- One harvestable-fruit query per accepted point.
+            local ok, area = pcall(function()
+                return FSDensityMapUtil.getFruitArea(fruitTypeIndex, x, z, x + step, z, x, z + step, false, allowsForageGrowthState)
+            end)
+            if ok and type(area) == 'number' and area > 0 then
+                local captured = vm:readValueAtWorld('yieldEfficiency', x, z)
+                if type(captured) == 'number' then
+                    local pointDrag = vm:readValueAtWorld('trafficDrag', x, z)
+                    local d = type(pointDrag) == 'number' and math.max(0, math.min(1, pointDrag)) or 0
+                    samples[#samples + 1] = {
+                        value = ZoneYield.composeDrag(captured / 100, d),
+                        area  = step * step,
+                    }
+                end
+            end
             count = count + 1
             z = z + step
         end
         x = x + step
     end
-    return out
-end
-
---- The harvest-time modifier for one vehicle pass over a field: the
---- area-weighted read of the captured `yieldEfficiency` layer under
---- the header, with the SF-55 drag composition applied per cell.
---- Returns nil when the spatial path cannot answer (not live, no
---- maps, no header geometry, or no captured data under the header) -
---- the caller then falls back to the field-average `computeYieldModifier`
---- with its scalar freeze, untouched.
----@param combineSelf table the harvesting vehicle
----@param fieldId number
----@return number|nil modifier in [BAND_FLOOR, BAND_CEILING]
-function ZoneYield:readHeaderAreaWeighted(combineSelf, fieldId)
-    if not self:isLive() then return nil end
-    local vm = self:_valueMaps()
-    if vm == nil then return nil end
-    local polygons = self:_headerPolygons(combineSelf)
-    if polygons == nil then return nil end
-
-    local samples = {}
-    for _, poly in ipairs(polygons) do
-        for _, pt in ipairs(self:_samplePolygon(poly)) do
-            local value = vm:readValueAtWorld('yieldEfficiency', pt.x, pt.z)
-            if type(value) == 'number' then
-                local drag = self:_readTrafficDrag(fieldId, pt.x, pt.z)
-                samples[#samples + 1] = {
-                    value = ZoneYield.composeDrag(value / 100, drag),
-                    area  = ZoneYield.HEADER_SAMPLE_STEP_M * ZoneYield.HEADER_SAMPLE_STEP_M,
-                }
-            end
-        end
-    end
     if #samples == 0 then return nil end
     return ZoneYield.aggregateAreaWeighted(samples)
 end
 
---- SF-55's traffic drag, not present yet. Returns nil (reads as zero
---- in composeDrag) until that layer lands; the read path composes it
---- from day one per the addendum. The SF-55 write will read its own
---- layer through this socket.
-function ZoneYield:_readTrafficDrag(_fieldId, _x, _z)
-    return nil
+--- Prepare the pre-cut spatial context for one active work area,
+--- BEFORE the destructive base Cutter call. Returns a context table
+--- or nil (fallback). The context carries the resolved fruit type,
+--- field id, the chosen path, and the scalar to apply.
+---
+--- Paths:
+---   "spatial"  - fruit-filtered yieldEfficiency polygon mean (or the
+---                drag lattice when drag is positive)
+---   "fallback" - no fresh capture / no spatial answer; the caller
+---                uses the frozen field-average scalar
+---   "contract" - NPC-disabled or contract-exempt field; scalar path
+---
+--- Any missing field, fruit, filter, geometry, capture or accepted
+--- point returns a fallback context, never zero yield.
+---@param cutterSelf table the harvesting vehicle
+---@param workArea table the active work area
+---@return table|nil context
+function ZoneYield:preparePreCutContext(cutterSelf, workArea)
+    if not self:isLive() then return nil end
+    local vm = self:_valueMaps()
+    if vm == nil then return nil end
+
+    local spec = cutterSelf.spec_cutter
+    if spec == nil or spec.workAreaParameters == nil then return nil end
+
+    local para = self:_workAreaParallelogram(workArea)
+    if para == nil then return nil end
+
+    -- Walk fruitTypeIndicesToUse in engine order; stop at the first
+    -- candidate with positive harvestable area and cache its filter.
+    local fruitTypeIndex = nil
+    local allowsForageGrowthState = spec.allowsForageGrowthState or false
+    local fruitFilter = nil
+    local candidates = spec.workAreaParameters.fruitTypeIndicesToUse
+    if candidates ~= nil then
+        for _, candidate in ipairs(candidates) do
+            local ok, area = pcall(function()
+                return FSDensityMapUtil.getFruitArea(candidate, para.start.x, para.start.z,
+                    para.width.x, para.width.z, para.height.x, para.height.z, false, allowsForageGrowthState)
+            end)
+            if ok and type(area) == 'number' and area > 0 then
+                fruitTypeIndex = candidate
+                fruitFilter = self:_getFruitFilter(candidate, allowsForageGrowthState)
+                break
+            end
+        end
+    end
+    if fruitTypeIndex == nil then return nil end
+
+    -- Resolve field id from the work-area corners.
+    local fieldId = self:_resolveFieldId(cutterSelf, para)
+    if fieldId == nil or fieldId <= 0 then return nil end
+
+    -- Before classifying the first cut of a crop, refresh the contract
+    -- cache, then read isFieldSimDisabled. NPC reason or contractExempt
+    -- selects the scalar fallback.
+    if self._contractRefreshed[fieldId] ~= fruitTypeIndex then
+        if FieldSentry_API ~= nil and type(FieldSentry_API.refreshContract) == 'function' then
+            pcall(FieldSentry_API.refreshContract, fieldId)
+        end
+        self._contractRefreshed[fieldId] = fruitTypeIndex
+    end
+    local disabled, reason, _, hints = false, nil, false, nil
+    if FieldSentry_API ~= nil and type(FieldSentry_API.isFieldSimDisabled) == 'function' then
+        local ok, d, r, _, h = pcall(FieldSentry_API.isFieldSimDisabled, fieldId)
+        if ok then disabled, reason, hints = d, r, h end
+    end
+    local contractExempt = hints ~= nil and hints.contractExempt == true
+    local npcReason = FieldSentry_Core ~= nil and FieldSentry_Core.BLACKLIST ~= nil
+        and FieldSentry_Core.BLACKLIST.NPC or nil
+    if disabled and ((npcReason ~= nil and reason == npcReason) or contractExempt) then
+        return { path = "contract", fieldId = fieldId, fruitTypeIndex = fruitTypeIndex, scalar = nil, drag = nil }
+    end
+
+    -- No fresh capture yet: fallback until one capture pass succeeds.
+    local field = self.manager and self.manager.soilSystem and self.manager.soilSystem.fieldData and self.manager.soilSystem.fieldData[fieldId]
+    if field == nil or field.zoneYieldCaptureReady ~= true then
+        return { path = "fallback", fieldId = fieldId, fruitTypeIndex = fruitTypeIndex, scalar = nil, drag = nil }
+    end
+
+    -- Build the polygon from the parallelogram corners.
+    local verts = {
+        { x = para.start.x,  z = para.start.z },
+        { x = para.width.x,  z = para.width.z },
+        { x = para.height.x, z = para.height.z },
+        { x = para.width.x + para.height.x - para.start.x, z = para.width.z + para.height.z - para.start.z },
+    }
+
+    -- Fruit-filtered traffic drag by polygon; nil or zero is identity.
+    local drag = self:_readTrafficDragPolygon(vm, verts, fruitFilter)
+
+    local scalar
+    if drag ~= nil and drag > 0 then
+        scalar = self:_readDragPath(vm, para, fruitTypeIndex, allowsForageGrowthState, drag)
+    else
+        scalar = self:_readYieldPolygon(vm, verts, fruitFilter)
+    end
+
+    if scalar == nil then
+        return { path = "fallback", fieldId = fieldId, fruitTypeIndex = fruitTypeIndex, scalar = nil, drag = drag }
+    end
+    return { path = "spatial", fieldId = fieldId, fruitTypeIndex = fruitTypeIndex, scalar = scalar, drag = drag }
 end
 
 --- Published per-cell captured efficiency, the socket ViabilityMask's
@@ -471,42 +722,4 @@ function ZoneYield:isLive()
         return ReleaseGate.isSystemLive('growth_modulation')
     end
     return true
-end
-
---- Time Guard accrual (simulation flow), same shape and version-skew
---- guard as the rest of the family. Server-only by the value-map
---- write's nature; registered from the manager at activation.
-function ZoneYield:registerDailyAccrual()
-    if self._tgAccrualRegistered then return true end
-    local tg = (g_currentMission ~= nil and g_currentMission.timeGuard) or g_timeGuard
-    if tg == nil or type(tg.registerAccrual) ~= 'function' then return false end
-    if tg.flowClasses ~= nil and tg.flowClasses.simulation ~= true then
-        return false
-    end
-    local ok = pcall(function()
-        tg:registerAccrual(ZoneYield.DAILY_ACCURAL_ID, {
-            cadence = 'day',
-            flowClass = 'simulation',
-            firstPeriodPolicy = 'skip',
-            priority = ZoneYield.DAILY_ACCURAL_PRIORITY,
-            onSettle = function() self:runCapturePass() end,
-        })
-    end)
-    if ok then self._tgAccrualRegistered = true end
-    return ok
-end
-
---- SF day-tracking fallback (Time Guard absent): the capture runs on
---- SF's own monotonic-day rollover, less precisely timed, never
---- incorrectly. Pumped from the soil system's daily pump, the same
---- shape as EstablishmentFailure:checkDayFallback.
-function ZoneYield:checkDayFallback()
-    if self._tgAccrualRegistered then return end
-    local env = g_currentMission ~= nil and g_currentMission.environment
-    if env == nil then return end
-    local day = env.currentMonotonicDay or env.currentDay or 0
-    if self._lastFallbackDay ~= nil and day ~= self._lastFallbackDay then
-        self:runCapturePass()
-    end
-    self._lastFallbackDay = day
 end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -260,16 +260,18 @@ function HookManager:installAll(soilSystem)
     local harvestOk = self:installHarvestHook()
     if harvestOk then successCount = successCount + 1 else failCount = failCount + 1 end
 
-    -- Yield modifier hook: applies soil-fertility yield reduction via the combine hopper
-    -- (separate from addCutterArea for RealisticHarvesting compatibility - see issue #284)
-    local yieldModOk = self:installYieldModifierHook()
-    if yieldModOk then successCount = successCount + 1 else failCount = failCount + 1 end
+    -- Zone yield cutter hook (SF-14): scales the newly-added Cutter
+    -- multiplier-area delta by the pre-cut spatial scalar (or the frozen
+    -- field-average scalar) on the live cutter work-area pointer. Replaces
+    -- the old FillUnit hopper yield-modifier wrapper.
+    local zoneYieldOk = self:installZoneYieldCutterHook()
+    if zoneYieldOk then successCount = successCount + 1 else failCount = failCount + 1 end
 
     -- Harvest contract underwrite (#741 / SF-29): wraps HarvestMission.getCompletion so a
     -- base-game harvest contract on a degraded neighbour field tops up to the vanilla-
-    -- expected completion at delivery (divides out the same yield modifier the hopper hook
+    -- expected completion at delivery (divides out the same yield modifier the cutter hook
     -- above applied). Server-side, fail-safe, no soil write, no farm-money move. Must run
-    -- after installYieldModifierHook so the modifier it inverts is the one in force.
+    -- after installZoneYieldCutterHook so the modifier it inverts is the one in force.
     if HarvestContractUnderwrite and HarvestContractUnderwrite.install then
         local underwriteOk = HarvestContractUnderwrite.install(self)
         if underwriteOk then successCount = successCount + 1 else failCount = failCount + 1 end
@@ -2438,9 +2440,9 @@ end
 -- crop loss, and engine load.
 --
 -- Fix: addCutterArea is now used ONLY for soil nutrient tracking (field detection
--- + onHarvest).  The yield modifier is applied in a separate per-combine
--- addFillUnitFillLevel wrapper (see installYieldModifierHook below) which always
--- receives actual liters regardless of who sits above it in the call chain.
+-- + onHarvest).  The yield modifier is applied in a separate per-cutter
+-- processCutterArea delta wrapper (see installZoneYieldCutterHook below) which
+-- scales the newly-added multiplier-area delta on the live work-area pointer.
 ---@return boolean success True if hook installed successfully
 function HookManager:installHarvestHook()
     if not Cutter or type(Cutter.onEndWorkAreaProcessing) ~= "function" then
@@ -2460,7 +2462,7 @@ function HookManager:installHarvestHook()
     -- that captures and forwards the original's return value instead.
     --
     -- The wrapper no longer modifies the liters argument - yield reduction is
-    -- handled by installYieldModifierHook (addFillUnitFillLevel on the hopper).
+    -- handled by installZoneYieldCutterHook (the processCutterArea delta wrapper).
     -- This makes the hook argument-order-agnostic and safe regardless of what
     -- other mods pass as the 3rd positional argument.
     --
@@ -2473,7 +2475,7 @@ function HookManager:installHarvestHook()
                 tostring(combineSelf.isServer), area or 0, liters or 0, tostring(inputFruitType))
 
             -- Detect field for nutrient depletion tracking (onHarvest).
-            -- Yield modifier is NO LONGER applied here - see installYieldModifierHook.
+            -- Yield modifier is NO LONGER applied here - see installZoneYieldCutterHook.
             local detectedFieldId = nil
             local detectedX, detectedZ = nil, nil
 
@@ -2719,167 +2721,166 @@ function HookManager:installHarvestHook()
 end
 
 -- =========================================================
--- HOOK 1b: Yield modifier applied via combine hopper
+-- HOOK 1b: Zone yield applied via the live Cutter pointer
 -- =========================================================
--- Applies the SF yield modifier by wrapping Combine.addFillUnitFillLevel.
--- This is the companion to installHarvestHook.  Separating the modifier
--- application from addCutterArea fixes the RealisticHarvesting conflict:
--- RHM uses registerOverwrittenFunction for addCutterArea and calls
---   superFunc(self, area, realArea, inputFruitType, ...)
--- where the 3rd argument is realArea (pixel count), NOT liters.  The old
--- code read arg 3 as "liters" and returned liters*yieldModifier - RHM got
--- a garbage retLiters and its HUD went blank (issue #284).
+-- Applies the SF-14 zone-yield scalar by wrapping Cutter.processCutterArea on
+-- the surfaces the engine actually calls. The engine invokes
+-- `workArea.processingFunction(self, workArea, dt)` (WorkArea.lua:178-183),
+-- and that pointer is COPIED from `self[functionName]` at vehicle load
+-- (WorkArea.lua:257-266), so a class-only hook is a failed install. We wrap
+-- all four surfaces (class, registered type, live instance, live work-area
+-- stored pointer) with one factory, prevent duplicate wrapping, retain every
+-- exact original, and register cleanup for all four layers.
 --
--- By moving modifier logic here (where the value is always actual hopper
--- liters), we are argument-order-agnostic and the conflict disappears.
--- Instance patching uses makeYieldWrapper(vehicle.addFillUnitFillLevel) to
--- preserve any other mod's chain rather than replacing it outright.
+-- The wrapper scales ONLY the newly-added multiplier-area delta
+-- (`lastMultiplierArea` after minus before) by the pre-cut spatial scalar (or
+-- the frozen field-average scalar), leaving the base Cutter chain to run
+-- exactly once with unchanged arguments. An SCS multiplier already in the
+-- stored chain stays inside the call and composes.
 ---@return boolean success True if hook installed successfully
-function HookManager:installYieldModifierHook()
-    -- FillUnit.addFillUnitFillLevel is the correct FS25 hook target.
-    -- Combine does NOT register addFillUnitFillLevel as its own class method --
-    -- it inherits it from FillUnit via the vehicle specialization system.
-    -- Hooking Combine.addFillUnitFillLevel therefore always fails (nil check).
-    -- Real FS25 signature: addFillUnitFillLevel(self, farmId, fillUnitIndex, fillLevelDelta, fillTypeIndex, toolType, fillPositionData)
-    if not FillUnit or type(FillUnit.addFillUnitFillLevel) ~= "function" then
-        SoilLogger.warning("Yield modifier hook: FillUnit.addFillUnitFillLevel not available -- yield reduction skipped")
+function HookManager:installZoneYieldCutterHook()
+    -- SF-14 ZONE YIELD CUTTER HOOK. Moves the yield quantity to the LIVE CUTTER
+    -- pointer: the engine calls `workArea.processingFunction(self, workArea, dt)`
+    -- (WorkArea.lua:178-183), and that pointer is COPIED from `self[functionName]`
+    -- at vehicle load (WorkArea.lua:257-266). A class-only hook is therefore a
+    -- FAILED install. We wrap all four surfaces the engine actually uses:
+    --   1. Cutter.processCutterArea class (future registration);
+    --   2. every registered cutter type's functions.processCutterArea;
+    --   3. every live cutter instance's processCutterArea;
+    --   4. every live CUTTER work area's stored processingFunction where
+    --      functionName == "processCutterArea".
+    -- The wrapper scales ONLY the newly-added multiplier-area delta by the
+    -- pre-cut spatial scalar (or the frozen field-average scalar), leaving the
+    -- base Cutter chain to run exactly once with unchanged arguments. An SCS
+    -- multiplier already in the stored chain stays inside the call.
+    if not Cutter or type(Cutter.processCutterArea) ~= "function" then
+        SoilLogger.warning("Zone yield cutter hook: Cutter.processCutterArea not available -- skipped")
         return false
     end
 
-    local original = FillUnit.addFillUnitFillLevel
+    local hookMgrRef = self
 
-    -- Factory so the same modifier logic wraps any chainFn
-    local function makeYieldWrapper(chainFn)
-        -- Correct FS25 signature includes farmId as first arg after self
-        return function(combineSelf, farmId, fillUnitIndex, fillLevelDelta, fillTypeIndex, toolType, fillPositionData)
-            -- Only apply modifier on the server when filling the hopper (delta > 0),
-            -- only for combine spec vehicles, and only when SF systems are ready.
-            local modifiedDelta = fillLevelDelta
-            if combineSelf.isServer
-                and combineSelf.spec_combine ~= nil
-                and fillLevelDelta and fillLevelDelta > 0
-                and fillTypeIndex
-                and g_SoilFertilityManager
-                and g_SoilFertilityManager.soilSystem
-                and g_SoilFertilityManager.settings.enabled
-                and g_SoilFertilityManager.settings.nutrientCycles
+    -- One factory so the same delta-scaling logic wraps any chainFn.
+    local function makeCutterWrapper(chainFn)
+        return function(cutterSelf, workArea, dt)
+            -- Prepare the pre-cut context BEFORE the destructive base call so we
+            -- snapshot lastMultiplierArea and resolve the scalar first.
+            local context = nil
+            local zoneYield = g_SoilFertilityManager and g_SoilFertilityManager.zoneYield
+            if zoneYield ~= nil and type(zoneYield.preparePreCutContext) == "function"
+               and cutterSelf.isServer
+               and g_SoilFertilityManager
+               and g_SoilFertilityManager.soilSystem
+               and g_SoilFertilityManager.settings.enabled
             then
-                local ok, errMsg = pcall(function()
-                    local fruitType = nil
-                    if g_fruitTypeManager then
-                        local ft = g_fruitTypeManager:getFruitTypeByFillTypeIndex(fillTypeIndex)
-                        if ft then fruitType = ft.index end
-                    end
-                    if not fruitType or fruitType <= 0 then return end
-
-                    local x, _, z = getWorldTranslation(combineSelf.rootNode)
-                    if not x then return end
-
-                    local fieldId = nil
-                    if g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function" then
-                        local field = g_fieldManager:getFieldAtWorldPosition(x, z)
-                        if field and field.farmland then fieldId = field.farmland.id end
-                    end
-                    if not fieldId and g_farmlandManager then
-                        local farmland = g_farmlandManager:getFarmlandAtWorldPosition(x, z)
-                        if farmland then fieldId = farmland.id end
-                    end
-                    -- Fallback: rootNode may sit outside field polygon on large combines
-                    if not fieldId or fieldId <= 0 then
-                        local attachedImpls = combineSelf.spec_attacherJoints and combineSelf.spec_attacherJoints.attachedImplements
-                        if attachedImpls then
-                            for _, impl in ipairs(attachedImpls) do
-                                local obj = impl and impl.object
-                                if obj then
-                                    local ix, _, iz = getWorldTranslation(obj.rootNode)
-                                    if ix then
-                                        if g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function" then
-                                            local f = g_fieldManager:getFieldAtWorldPosition(ix, iz)
-                                            if f and f.farmland then fieldId = f.farmland.id end
-                                        end
-                                        if not fieldId and g_farmlandManager then
-                                            local fl = g_farmlandManager:getFarmlandAtWorldPosition(ix, iz)
-                                            if fl then fieldId = fl.id end
-                                        end
-                                    end
-                                    if (not fieldId or fieldId <= 0) and obj.spec_workArea and obj.spec_workArea.workAreas then
-                                        for _, wa in ipairs(obj.spec_workArea.workAreas) do
-                                            if wa.start then
-                                                local sx, _, sz = getWorldTranslation(wa.start)
-                                                if sx then
-                                                    if g_fieldManager and type(g_fieldManager.getFieldAtWorldPosition) == "function" then
-                                                        local f = g_fieldManager:getFieldAtWorldPosition(sx, sz)
-                                                        if f and f.farmland then fieldId = f.farmland.id end
-                                                    end
-                                                    if not fieldId and g_farmlandManager then
-                                                        local fl = g_farmlandManager:getFarmlandAtWorldPosition(sx, sz)
-                                                        if fl then fieldId = fl.id end
-                                                    end
-                                                end
-                                            end
-                                            if fieldId and fieldId > 0 then break end
-                                        end
-                                    end
-                                end
-                                if fieldId and fieldId > 0 then break end
-                            end
-                        end
-                    end
-                    if not fieldId or fieldId <= 0 then return end
-
-                    -- SF-14 FREEZE SUPERSESSION (spatial path). On the spatial path
-                    -- (value maps present and the captured yieldEfficiency layer is
-                    -- live), the per-pass modifier is the AREA-WEIGHTED READ of the
-                    -- captured, growth-time-static layer under the header, computed
-                    -- fresh each pass. The SF-16 scalar freeze is BYPASSED, not
-                    -- reused; when the spatial read cannot answer (nil), the call
-                    -- falls through to the untouched field-average computeYieldModifier
-                    -- with its scalar freeze (maps absent / no captured data).
-                    local yieldModifier = nil
-                    local zoneYield = g_SoilFertilityManager.zoneYield
-                    if zoneYield ~= nil and type(zoneYield.readHeaderAreaWeighted) == "function"
-                       and zoneYield:isLive() then
-                        local okRead, spatial = pcall(function()
-                            return zoneYield:readHeaderAreaWeighted(combineSelf, fieldId)
-                        end)
-                        if okRead and type(spatial) == "number" then
-                            yieldModifier = spatial
-                        end
-                    end
-                    if yieldModifier == nil then
-                        yieldModifier = g_SoilFertilityManager.soilSystem:computeYieldModifier(fieldId, fruitType)
-                    end
-                    if yieldModifier ~= 1.0 then
-                        modifiedDelta = fillLevelDelta * yieldModifier
-                        SoilLogger.debug("Yield modifier hook: Field %d Fruit %d modifier=%.3f (%.1fL -- %.1fL)",
-                            fieldId, fruitType, yieldModifier, fillLevelDelta, modifiedDelta)
-                    end
+                local ok, ctx = pcall(function()
+                    return zoneYield:preparePreCutContext(cutterSelf, workArea)
                 end)
-                if not ok then
-                    SoilLogger.error("Yield modifier hook failed: %s", tostring(errMsg))
-                    modifiedDelta = fillLevelDelta
+                if ok then context = ctx end
+            end
+
+            local spec = cutterSelf.spec_cutter
+            local before = spec and spec.workAreaParameters and spec.workAreaParameters.lastMultiplierArea or 0
+
+            -- Call the chain once; capture its return values unchanged.
+            local r1, r2, r3, r4, r5 = chainFn(cutterSelf, workArea, dt)
+
+            -- Scale only when we have a valid context (fruit + field resolved).
+            if context ~= nil and spec ~= nil and spec.workAreaParameters ~= nil then
+                local added = spec.workAreaParameters.lastMultiplierArea - before
+                if added > 0
+                   and spec.workAreaParameters.lastFruitType == context.fruitTypeIndex
+                   and context.fieldId and context.fieldId > 0
+                then
+                    local ok, errMsg = pcall(function()
+                        -- Establish the existing persisted crop freeze once.
+                        local frozen = g_SoilFertilityManager.soilSystem:computeYieldModifier(context.fieldId, context.fruitTypeIndex)
+                        -- Use the spatial scalar when valid, otherwise the frozen scalar.
+                        local scalar = frozen
+                        if context.path == "spatial" and type(context.scalar) == "number" then
+                            scalar = context.scalar
+                        end
+                        if scalar ~= 1.0 then
+                            spec.workAreaParameters.lastMultiplierArea = before + added * scalar
+                        end
+                        SoilLogger.debug("SF14_CUT field=%d fruit=%d path=%s base=%.3f sf=%.3f added=%.3f final=%.3f drag=%s",
+                            context.fieldId, context.fruitTypeIndex, context.path or "none",
+                            before, scalar, added, spec.workAreaParameters.lastMultiplierArea,
+                            tostring(context.drag))
+                    end)
+                    if not ok then
+                        SoilLogger.error("Zone yield cutter hook failed: %s", tostring(errMsg))
+                    end
                 end
             end
-            return chainFn(combineSelf, farmId, fillUnitIndex, modifiedDelta, fillTypeIndex, toolType, fillPositionData)
+
+            return r1, r2, r3, r4, r5
         end
     end
 
-    FillUnit.addFillUnitFillLevel = makeYieldWrapper(original)
-    self:register(FillUnit, "addFillUnitFillLevel", original, "FillUnit.addFillUnitFillLevel (yield modifier)")
+    -- Layer 1: Cutter class (future registration).
+    local classOriginal = Cutter.processCutterArea
+    Cutter.processCutterArea = makeCutterWrapper(classOriginal)
+    hookMgrRef:register(Cutter, "processCutterArea", classOriginal, "Cutter.processCutterArea (zone yield)")
 
-    -- Wrap existing combine instances to preserve other mods specialization chains.
-    local patched = 0
-    local vehicleSystem = g_currentMission and g_currentMission.vehicleSystem
-    if vehicleSystem and vehicleSystem.vehicles then
-        for _, vehicle in pairs(vehicleSystem.vehicles) do
-            if vehicle.spec_combine and type(vehicle.addFillUnitFillLevel) == "function" then
-                vehicle.addFillUnitFillLevel = makeYieldWrapper(vehicle.addFillUnitFillLevel)
-                patched = patched + 1
+    -- Layer 2: every registered cutter type's functions.processCutterArea.
+    local typesPatched = 0
+    local typeManager = g_vehicleTypeManager
+    if typeManager and typeManager.types then
+        for _, typeDef in pairs(typeManager.types) do
+            local hasCutter = false
+            if typeDef.specializationsByName and typeDef.specializationsByName.cutter then
+                hasCutter = true
+            elseif typeDef.specializations then
+                for _, spec in ipairs(typeDef.specializations) do
+                    if spec == Cutter or (spec and spec.specName == "cutter") then
+                        hasCutter = true
+                        break
+                    end
+                end
+            end
+            if hasCutter and typeDef.functions and typeDef.functions.processCutterArea then
+                local origTypeFn = typeDef.functions.processCutterArea
+                typeDef.functions.processCutterArea = makeCutterWrapper(origTypeFn)
+                hookMgrRef:register(typeDef.functions, "processCutterArea", origTypeFn, "type.processCutterArea (zone yield)")
+                typesPatched = typesPatched + 1
             end
         end
     end
 
-    SoilLogger.info("[OK] Yield modifier hook installed (FillUnit.addFillUnitFillLevel) -- %d existing combines patched", patched)
+    -- Layer 3: every live cutter instance's processCutterArea.
+    local instancesPatched = 0
+    if g_currentMission and g_currentMission.vehicleSystem and g_currentMission.vehicleSystem.vehicles then
+        for _, vehicle in pairs(g_currentMission.vehicleSystem.vehicles) do
+            if vehicle.spec_cutter and type(vehicle.processCutterArea) == "function" then
+                local origInst = vehicle.processCutterArea
+                vehicle.processCutterArea = makeCutterWrapper(origInst)
+                hookMgrRef:register(vehicle, "processCutterArea", origInst, "instance.processCutterArea (zone yield)")
+                instancesPatched = instancesPatched + 1
+            end
+        end
+    end
+
+    -- Layer 4: every live CUTTER work area's stored processingFunction where
+    -- functionName == "processCutterArea". This is the surface the engine calls.
+    local workAreasPatched = 0
+    if g_currentMission and g_currentMission.vehicleSystem and g_currentMission.vehicleSystem.vehicles then
+        for _, vehicle in pairs(g_currentMission.vehicleSystem.vehicles) do
+            if vehicle.spec_cutter and vehicle.spec_workArea and vehicle.spec_workArea.workAreas then
+                for _, wa in ipairs(vehicle.spec_workArea.workAreas) do
+                    if wa.functionName == "processCutterArea" and type(wa.processingFunction) == "function" then
+                        local origWa = wa.processingFunction
+                        wa.processingFunction = makeCutterWrapper(origWa)
+                        hookMgrRef:register(wa, "processingFunction", origWa, "workArea.processingFunction (zone yield)")
+                        workAreasPatched = workAreasPatched + 1
+                    end
+                end
+            end
+        end
+    end
+
+    SoilLogger.info("SF14_HOOK_INSTALL class=1 types=%d instances=%d workAreas=%d",
+        typesPatched, instancesPatched, workAreasPatched)
     return true
 end
 

--- a/src/maps/SoilValueMaps.lua
+++ b/src/maps/SoilValueMaps.lua
@@ -1256,7 +1256,18 @@ end
 
 --- Average semantic value over a field polygon via engine-side executeGet.
 ---@return number|nil avg, number pixelCount
-function SoilValueMaps:readAverageOfPolygon(key, verts)
+--- Area-weighted mean of a layer over a polygon, counting only written pixels.
+--- An optional external `DensityMapFilter` (e.g. a fruit-harvest-state filter built
+--- by SF-14) is ANDed with the written-pixel filter on both the native polygon and
+--- block-fallback branches, so the mean covers only pixels that are both written
+--- and match the external mask. When the external filter is nil the call is
+--- unchanged (one-filter executeGet). No new map, persistence file or allocator.
+---@param key string
+---@param verts table list of {x=, z=}
+---@param externalFilter table|nil optional DensityMapFilter to AND with written pixels
+---@return number|nil mean decoded value
+---@return number pixels counted
+function SoilValueMaps:readAverageOfPolygon(key, verts, externalFilter)
     if not self.available or not verts or #verts < 3 then return nil, 0 end
     local entry = self.layers[key]
     if not entry then return nil, 0 end
@@ -1268,7 +1279,7 @@ function SoilValueMaps:readAverageOfPolygon(key, verts)
     local sum, pixels = 0, 0
     if setPolygonRegion(self, m, verts) then
         local ok, acc, n = pcall(function()
-            local a, cnt, _ = m:executeGet(filter)
+            local a, cnt, _ = m:executeGet(filter, externalFilter)
             return a, cnt
         end)
         if ok and n and n > 0 then sum, pixels = acc, n end
@@ -1278,7 +1289,7 @@ function SoilValueMaps:readAverageOfPolygon(key, verts)
                 cx - half, cz - half, cx + half, cz - half, cx - half, cz + half,
                 DensityCoordType.POINT_POINT_POINT)
             local ok, acc, n = pcall(function()
-                local a, cnt, _ = m:executeGet(filter)
+                local a, cnt, _ = m:executeGet(filter, externalFilter)
                 return a, cnt
             end)
             if ok and n and n > 0 then

--- a/tools/test/lua/zone_yield_sf14_test.lua
+++ b/tools/test/lua/zone_yield_sf14_test.lua
@@ -12,6 +12,12 @@
 -- default, locked here so a later edit is a deliberate act. A field whose
 -- modifier would fall outside the band is BOUNDED by the band's own
 -- floor/ceiling (the brief's named "bounded divergence", never unbounded).
+--
+-- SF-14 v2.0 (REPLACEMENT): capture rides the engine's FINISHED_GROWTH_PERIOD
+-- message (one drained delivery = one capture pass), the read is a pre-cut
+-- spatial context (`preparePreCutContext`) over the true work-area polygon,
+-- fruit-masked, area-weighted per SF-25's ratified rule. The daily accrual
+-- and the hopper FillUnit yield-modifier hook are gone.
 --!load: src/utils/Logger.lua, src/config/Constants.lua, src/config/SoilBlends.lua, src/ReleaseGate.lua, src/ResistanceBands.lua, src/HybridStrains.lua, src/SoilFertilitySystem.lua, src/ViabilityMask.lua, src/ZoneYield.lua
 
 local ZY = ZoneYield
@@ -21,8 +27,9 @@ do
   T.near('band.floor', ZY.BAND_FLOOR, 0.7, 1e-9)
   T.near('band.ceiling', ZY.BAND_CEILING, 1.15, 1e-9)
   T.ok('band.ordered', ZY.BAND_FLOOR < 1.0 and 1.0 < ZY.BAND_CEILING)
-  T.eq('band.accrualId', ZY.DAILY_ACCURAL_ID, 'SF14_zoneYieldCapture')
-  T.eq('band.accrualPriority', ZY.DAILY_ACCURAL_PRIORITY, 98)
+  -- The daily accrual id/priority are GONE in the v2.0 replacement.
+  T.eq('band.noDailyAccrualId', ZY.DAILY_ACCURAL_ID, nil)
+  T.eq('band.noDailyAccrualPriority', ZY.DAILY_ACCURAL_PRIORITY, nil)
 end
 
 -- The stub soil system carrying the real shared formula, exactly as yield_test
@@ -42,7 +49,9 @@ local function newSys(fieldData)
 end
 
 local WHEAT = { name = 'wheat', index = 1, terrainDataPlaneId = 5,
-                startStateChannel = 0, numStateChannels = 4 }
+                startStateChannel = 0, numStateChannels = 4,
+                minHarvestingGrowthState = 6, maxHarvestingGrowthState = 8,
+                minForageGrowthState = 6 }
 
 -- 2. THE CAPTURE FORMULA, per cell. On a uniform field (every cell carries the
 --    field-average N/P/K), captureScore MUST equal computeYieldModifier output
@@ -115,25 +124,156 @@ do
   T.near('drag.nilCaptured', ZY.composeDrag(nil, 0.5), 1.0, 1e-9)
 end
 
--- 5. THE HARVEST READ: header polygons, bounded sampling, area-weighted read.
---    Mock the value maps (a uniform captured field) and the combine header.
+-- 5. POINT-IN-POLYGON (pure ray cast) + the capture lattice derivation.
+do
+  local square = { {x=0,z=0}, {x=80,z=0}, {x=80,z=80}, {x=0,z=80} }
+  T.ok('pip.inside', ZY.pointInPolygon(40, 40, square))
+  T.ok('pip.outside', not ZY.pointInPolygon(90, 40, square))
+  T.ok('pip.onEdge', ZY.pointInPolygon(0, 40, square))
+  -- A concave polygon: a point in the notch is outside.
+  local concave = { {x=0,z=0}, {x=80,z=0}, {x=80,z=80}, {x=40,z=40}, {x=0,z=80} }
+  T.ok('pip.concaveNotchOutside', not ZY.pointInPolygon(40, 60, concave))
+  T.ok('pip.concaveArmInside', ZY.pointInPolygon(20, 20, concave))
+  -- Fewer than 3 verts is never inside.
+  T.ok('pip.degenerate', not ZY.pointInPolygon(1, 1, { {x=0,z=0}, {x=1,z=1} }))
+
+  -- Lattice: an 80x80 field at 8 m step yields 100 centres, all inside.
+  local zy = ZY.new({})
+  local pts = zy:_deriveCapturePoints(square)
+  T.eq('lattice.count', #pts, 100)
+  T.ok('lattice.allInside', (function()
+    for _, p in ipairs(pts) do
+      if not ZY.pointInPolygon(p.x, p.z, square) then return false end
+    end
+    return true
+  end)())
+  -- A huge field coarsens to stay at or below CAPTURE_MAX_POINTS.
+  local huge = { {x=0,z=0}, {x=4000,z=0}, {x=4000,z=4000}, {x=0,z=4000} }
+  local bigPts = zy:_deriveCapturePoints(huge)
+  T.ok('lattice.capped', #bigPts <= ZY.CAPTURE_MAX_POINTS)
+end
+
+-- 6. THE CAPTURE PASS: rides FINISHED_GROWTH_PERIOD, reads N/P/K per cell
+--    through the value maps (three reads), writes the clamped score to the
+--    yieldEfficiency layer, and sets the ready marker only after a write.
 do
   local zy = ZY.new({})
   zy.isInitialized = true
 
-  -- Mock value maps: yieldEfficiency reads 95% everywhere (a uniform captured
-  -- field), nothing else.
+  local written = {}
   local vm = {
     available = true,
+    readValueAtWorld = function(_self, key, _x, _z)
+      if key == 'nitrogen' then return 80 end
+      if key == 'phosphorus' then return 80 end
+      if key == 'potassium' then return 80 end
+      return nil
+    end,
+    writeValueAtWorld = function(_self, key, x, z, value, _radius)
+      if key == 'yieldEfficiency' then written[#written + 1] = { x = x, z = z, v = value } end
+    end,
+  }
+  local ss = {
+    fieldData = { [7] = { lastCrop = 'wheat',
+                          _polyVerts = { {x=0,z=0}, {x=80,z=0}, {x=80,z=80}, {x=0,z=80} } } },
+    _getFieldPolyVerts = function(_self, _fid, field) return field._polyVerts end,
+    valueMaps = vm,
+  }
+  zy.manager = { soilSystem = ss, viability = { enabled = true,
+    getCellGrowthInfo = function() return {} end } }
+
+  -- _resolveLiveFruit consults g_fieldManager for a live FieldState at the
+  -- field centre. Mock a field whose FieldState reports wheat (index 1).
+  local prevFM = g_fieldManager
+  local prevFS = FieldState
+  local prevFT = FruitType
+  FruitType = { UNKNOWN = 0 }
+  FieldState = { new = function() return { fruitTypeIndex = 1, update = function() end } end }
+  g_fieldManager = { fields = { { farmland = { id = 7 }, posX = 40, posZ = 40 } } }
+  local prevFTM = g_fruitTypeManager
+  g_fruitTypeManager = { getFruitTypeByIndex = function(_self, _i) return WHEAT end }
+
+  local n = zy:runCapturePass()
+  T.ok('pass.captureRan', n == 1)
+  T.ok('pass.wroteCells', #written > 0)
+  -- A uniform field: every written cell is the field-average modifier, 1.0
+  -- (stored as percent, 100).
+  local allOne = true
+  for _, w in ipairs(written) do
+    if math.abs(w.v - 100) > 1e-6 then allOne = false end
+  end
+  T.ok('pass.uniformAllOne', allOne)
+  -- The ready marker is set after a successful write.
+  T.ok('pass.readyMarker', ss.fieldData[7].zoneYieldCaptureReady == true)
+
+  -- A field with NO live fruit captures nothing and sets no marker.
+  FieldState = { new = function() return { fruitTypeIndex = FruitType.UNKNOWN, update = function() end } end }
+  ss.fieldData[8] = { _polyVerts = { {x=0,z=0}, {x=80,z=0}, {x=80,z=80}, {x=0,z=80} } }
+  g_fieldManager.fields = { { farmland = { id = 8 }, posX = 40, posZ = 40 } }
+  local n2 = zy:runCapturePass()
+  T.ok('pass.noFruitSkips', n2 == 0)
+  T.eq('pass.noFruitNoMarker', ss.fieldData[8].zoneYieldCaptureReady, nil)
+
+  g_fruitTypeManager = prevFTM
+  g_fieldManager = prevFM
+  FieldState = prevFS
+  FruitType = prevFT
+end
+
+-- 7. THE PRE-CUT SPATIAL CONTEXT: preparePreCutContext resolves the fruit,
+--    field, and capture, then reads the fruit-filtered yieldEfficiency polygon
+--    (or the drag lattice) BEFORE the destructive base Cutter call.
+do
+  local zy = ZY.new({})
+  zy.isInitialized = true
+
+  -- Value maps: readAverageOfPolygon returns a uniform captured field (95%),
+  -- readValueAtWorld returns 95 for yieldEfficiency and nil for drag.
+  local vm = {
+    available = true,
+    readAverageOfPolygon = function(_self, key, _verts, _filter)
+      if key == 'yieldEfficiency' then return 95, 1 end
+      return nil, 0
+    end,
     readValueAtWorld = function(_self, key, _x, _z)
       if key == 'yieldEfficiency' then return 95 end
       return nil
     end,
   }
-  zy.manager = { soilSystem = { valueMaps = vm } }
+  local ss = {
+    fieldData = { [3] = { zoneYieldCaptureReady = true } },
+    valueMaps = vm,
+  }
+  zy.manager = { soilSystem = ss, viability = { enabled = true,
+    getCellGrowthInfo = function() return {} end } }
 
-  -- Mock a combine header: one work area spanning x 0..40, z 0..8, via node
-  -- identity -> world translation.
+  -- Field resolution: g_fieldManager returns field 3 at the start corner.
+  local prevFM = g_fieldManager
+  g_fieldManager = { getFieldAtWorldPosition = function(_self, _x, _z)
+    return { farmland = { id = 3 } }
+  end }
+
+  -- Fruit preflight: FSDensityMapUtil.getFruitArea returns positive area for
+  -- the candidate fruit index.
+  local prevFDU = FSDensityMapUtil
+  FSDensityMapUtil = { getFruitArea = function(_idx, _x, _z, _x2, _z2, _x3, _z3, _prep, _forage)
+    return 100
+  end }
+
+  -- Fruit filter cache: DensityMapFilter stub from prelude.
+  local prevFTM = g_fruitTypeManager
+  g_fruitTypeManager = { getFruitTypeByIndex = function(_self, _i) return WHEAT end }
+
+  -- FieldSentry: not disabled, so the spatial path is taken.
+  local prevFSAPI = FieldSentry_API
+  FieldSentry_API = {
+    refreshContract = function() end,
+    isFieldSimDisabled = function() return false, nil, false, nil end,
+  }
+  local prevFSCore = FieldSentry_Core
+  FieldSentry_Core = { BLACKLIST = { NPC = 'npc' } }
+
+  -- Work-area geometry: a parallelogram via node identity -> world translation.
   local nodes = {
     start  = { 0,  0 },
     width  = { 40, 0 },
@@ -145,80 +285,53 @@ do
     if p then return p[1], 0, p[2] end
     return 0, 0, 0
   end
-  local combine = { spec_workArea = { workAreas = {
-    { start = 'start', width = 'width', height = 'height' },
-  } } }
 
-  -- Not live: the read refuses quietly.
-  zy.manager.viability = { enabled = false, getCellGrowthInfo = function() return nil end }
-  T.eq('read.notLiveIsNil', zy:readHeaderAreaWeighted(combine, 1), nil)
-  zy.manager.viability = { enabled = true, getCellGrowthInfo = function() return {} end }
+  local cutter = {
+    spec_cutter = {
+      allowsForageGrowthState = false,
+      workAreaParameters = { fruitTypeIndicesToUse = { 1 } },
+    },
+  }
+  local workArea = { start = 'start', width = 'width', height = 'height' }
 
-  -- The uniform captured field reads 0.95 across the whole header (bounded
-  -- samples, area-weighted).
-  local read = zy:readHeaderAreaWeighted(combine, 1)
-  T.near('read.uniformHeader', read, 0.95, 1e-6)
+  -- Spatial path: captured field, fruit present, positive area -> polygon read.
+  local ctx = zy:preparePreCutContext(cutter, workArea)
+  T.ok('ctx.spatialPath', ctx ~= nil and ctx.path == 'spatial')
+  T.near('ctx.spatialScalar', ctx and ctx.scalar, 0.95, 1e-6)
+  T.eq('ctx.spatialField', ctx and ctx.fieldId, 3)
+  T.eq('ctx.spatialFruit', ctx and ctx.fruitTypeIndex, 1)
 
-  -- No captured data under the header -> nil (fall back to the field-average
-  -- path), never a wrong number.
-  local emptyVm = { available = true, readValueAtWorld = function() return nil end }
-  zy.manager.soilSystem.valueMaps = emptyVm
-  T.eq('read.emptyIsNil', zy:readHeaderAreaWeighted(combine, 1), nil)
+  -- No fresh capture yet -> fallback context (never zero yield).
+  ss.fieldData[3].zoneYieldCaptureReady = nil
+  local ctxFb = zy:preparePreCutContext(cutter, workArea)
+  T.ok('ctx.fallbackPath', ctxFb ~= nil and ctxFb.path == 'fallback')
+  T.eq('ctx.fallbackScalar', ctxFb and ctxFb.scalar, nil)
+
+  -- Contract-exempt field -> contract path.
+  ss.fieldData[3].zoneYieldCaptureReady = true
+  FieldSentry_API.isFieldSimDisabled = function() return true, 'npc', false, { contractExempt = true } end
+  local ctxC = zy:preparePreCutContext(cutter, workArea)
+  T.ok('ctx.contractPath', ctxC ~= nil and ctxC.path == 'contract')
+
+  -- Not live -> nil.
+  zy.manager.viability.enabled = false
+  T.eq('ctx.notLiveIsNil', zy:preparePreCutContext(cutter, workArea), nil)
+  zy.manager.viability.enabled = true
 
   -- No value maps -> nil.
   zy.manager.soilSystem.valueMaps = nil
-  T.eq('read.noMapsIsNil', zy:readHeaderAreaWeighted(combine, 1), nil)
-
-  -- A combine with no work-area geometry -> nil (honest fallback, no crash).
-  T.eq('read.noGeometryIsNil', zy:readHeaderAreaWeighted({}, 1), nil)
+  T.eq('ctx.noMapsIsNil', zy:preparePreCutContext(cutter, workArea), nil)
+  zy.manager.soilSystem.valueMaps = vm
 
   getWorldTranslation = prevGWT
-end
-
--- 6. THE CAPTURE PASS: writes per-cell captured truth to the layer, riding the
---    shared read (getCellGrowthInfo now carries the full input set).
-do
-  local zy = ZY.new({})
-  zy.isInitialized = true
-
-  local written = {}
-  local vm = {
-    available = true,
-    writeValueAtWorld = function(_self, key, x, z, value, _radius)
-      if key == 'yieldEfficiency' then written[#written + 1] = { x = x, z = z, v = value } end
-    end,
-  }
-  local viability = {
-    enabled = true,
-    getCellGrowthInfo = function(_self, _fid, _x, _z)
-      return { n = 80, p = 80, k = 80, blocked = false, bands = {} }
-    end,
-  }
-  local ss = {
-    fieldData = { [7] = { lastCrop = 'wheat',
-                          _polyVerts = { {x=0,z=0}, {x=80,z=0}, {x=80,z=80}, {x=0,z=80} } } },
-    _getFieldPolyVerts = function(_self, _fid, field) return field._polyVerts end,
-    valueMaps = vm,
-  }
-  zy.manager = { soilSystem = ss, viability = viability }
-  -- _resolveCropName consults g_fieldManager/g_fruitTypeManager; with the mock
-  -- below it returns the field's lastCrop via the fallback path.
-  local prevFM = g_fieldManager
-  g_fieldManager = { fields = {} }
-
-  local n = zy:runCapturePass()
-  T.ok('pass.captureRan', n == 1)
-  T.ok('pass.wroteCells', #written > 0)
-  -- A uniform field: every written cell is the field-average modifier, 1.0.
-  local allOne = true
-  for _, w in ipairs(written) do
-    if math.abs(w.v - 100) > 1e-6 then allOne = false end
-  end
-  T.ok('pass.uniformAllOne', allOne)
+  FieldSentry_Core = prevFSCore
+  FieldSentry_API = prevFSAPI
+  g_fruitTypeManager = prevFTM
+  FSDensityMapUtil = prevFDU
   g_fieldManager = prevFM
 end
 
--- 7. THE PUBLISHED READ + GATE: the family's live gate and the socket
+-- 8. THE PUBLISHED READ + GATE: the family's live gate and the socket
 --    ViabilityMask's contract carries.
 do
   local zy = ZY.new({})


### PR DESCRIPTION
## Summary

SF-14 ZONE YIELD OF THE ESTABLISHED CROP, v2.0 replacement per the certified build brief (RATIFIED 2026-08-29, release gate LOCKED). Replaces the merged daily-capture mechanism with a growth-time capture that rides the engine's FINISHED_GROWTH_PERIOD message, and a pre-cut spatial read over the true work-area polygon, fruit-masked and area-weighted per SF-25's ratified rule.

## What changed

- **ZoneYield**: capture per drained growth period (onFinishedGrowthPeriod -> runCapturePass -> _captureField); 8m lattice coarsened to <=600 points; _resolveLiveFruit from live FieldState (not lastCrop alone); zoneYieldCaptureReady marker; registerGrowthMessage subscription; delete unsubscribe. Removed daily accrual, checkDayFallback, readHeaderAreaWeighted.
- **preparePreCutContext**: resolves fruit, field, and capture before the destructive base Cutter call; paths spatial (fruit-filtered yieldEfficiency polygon mean or drag lattice), fallback (frozen field-average scalar), contract (NPC-disabled or contract-exempt). Fruit filter cache keyed by (fruitTypeIndex, allowsForageGrowthState).
- **HookManager**: replace installYieldModifierHook (hopper FillUnit wrapper) with installZoneYieldCutterHook, a four-layer Cutter.processCutterArea delta wrapper that scales only the newly added lastMultiplierArea by the pre-cut scalar.
- **SoilValueMaps**: readAverageOfPolygon gains an optional external DensityMapFilter ANDed on both polygon and block branches.
- **SoilFertilitySystem**: freeze ownership moves from game day to sowing; onSowing clears frozenYieldModifier/frozenYieldFruitType/zoneYieldCaptureReady; removed the daily pump and the _processOneDailyField freeze-clear; persist zoneYieldCaptureReady in save/load/transfer/copy.
- **SoilFertilityManager**: registerGrowthMessage replaces registerDailyAccrual.
- **Test**: zone_yield_sf14_test rewritten for the repaired source (53 assertions, all pass); syntax and lint clean.

## Verification

- Lua 5.1 syntax: 92 files OK
- Lint: clean (92 files)
- Logic suite: zone_yield_sf14_test 53/53 pass; only the known pre-existing unrelated failures remain (coverage_test, rsf836_boom_line_test)
- Build: py build.py produces FS25_SoilFertilizer.zip

## Notes

- ONE FEATURE, ONE PR: this branch carries only SF-14, cut fresh from development.
- Release gate remains LOCKED; runtime observation still required before unlock.