### PR TITLE
fix(ui): Esc pH continuous ramp + 4-stop gradient legend (SF-49/SF-50)

### DIFF
--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -84,6 +84,32 @@ SoilMapOverlay.CB_UNKNOWN = {0.38, 0.40, 0.43}
 -- ── Gradient helpers ──────────────────────────────────────
 -- Shared red→amber→green gradient.  t=0 is worst (red), t=1 is best (green).
 -- These are the same three stop-colors used in drawHealthGradientBar.
+-- [SF-50] pH-only 4-stop gradient (George CLOSED DESIGN 19:12; Wizard wants
+-- deeper multi-stage colour on the pH layer specifically). Stops: deep red ->
+-- amber -> bright green -> deep green, linearly interpolated. Every other
+-- layer stays on healthGradient below. Over-limed (>7.0) reaches this with
+-- t=0 from layerValueToT and lands on the deep-red stop, as before.
+local PH_STOPS = {
+    { 0.00, 0.88, 0.10, 0.10 },  -- deep red
+    { 0.33, 0.90, 0.70, 0.10 },  -- amber
+    { 0.66, 0.30, 0.90, 0.30 },  -- bright green
+    { 1.00, 0.10, 0.50, 0.10 },  -- deep green
+}
+local function pHGradient(t)
+    t = math.max(0, math.min(1, t))
+    for i = 1, #PH_STOPS - 1 do
+        local s0, s1 = PH_STOPS[i], PH_STOPS[i + 1]
+        if t <= s1[1] then
+            local a = (t - s0[1]) / (s1[1] - s0[1])
+            return s0[2] + (s1[2] - s0[2]) * a,
+                   s0[3] + (s1[3] - s0[3]) * a,
+                   s0[4] + (s1[4] - s0[4]) * a
+        end
+    end
+    local last = PH_STOPS[#PH_STOPS]
+    return last[2], last[3], last[4]
+end
+
 local function healthGradient(t)
     t = math.max(0, math.min(1, t))
     local r, g, b
@@ -108,15 +134,19 @@ local function layerValueToT(layerIdx, val)
     elseif layerIdx == 2 then return math.max(0, math.min(1, val / 100))        -- P   0-100
     elseif layerIdx == 3 then return math.max(0, math.min(1, val / 100))        -- K   0-100
     elseif layerIdx == 4 then
-        -- Match SoilHUD:pHColor bands (not a 6.75-centred bell):
-        -- 6.5-7.0 good, >7.0-7.5 poor (over-limed), >=5.5 fair, else poor.
+        -- [SF-49] Continuous pH ramp (George CLOSED DESIGN 16:08). The old
+        -- discrete 0.5/1.0 bands rendered mid-pass 6.29 and overlap 6.60 as
+        -- similar tints even though the painted VALUES were right - TEST 15:54
+        -- failed on legend alone. Ramping 5.5->6.5 across fair (0..0.5) and
+        -- 6.5->7.0 across optimal (0.5..1.0) makes 6.29 read amber (~0.395)
+        -- and 6.60 read greener (~0.60). Over-limed >7.0 stays poor (0.0).
         local pH = val or 7.0
         if pH >= 6.5 and pH <= 7.0 then
-            return 1.0
-        elseif pH > 7.0 and pH <= 7.5 then
+            return 0.5 + (pH - 6.5) / (7.0 - 6.5) * 0.5
+        elseif pH > 7.0 then
             return 0.0
         elseif pH >= 5.5 then
-            return 0.5
+            return (pH - 5.5) / (6.5 - 5.5) * 0.5
         else
             return 0.0
         end
@@ -1992,6 +2022,12 @@ function SoilMapOverlay:valueToLayerColor(layerIdx, val)
         end
         return GOOD[1], GOOD[2], GOOD[3]
     end
+    -- [SF-50] pH takes the 4-stop gradient; every other layer keeps the
+    -- 3-stop health ramp. Same t from layerValueToT either way, so the
+    -- over-limed>7.0 -> t=0 rule is shared.
+    if layerIdx == 4 then
+        return pHGradient(layerValueToT(layerIdx, val))
+    end
     return healthGradient(layerValueToT(layerIdx, val))
 end
 
@@ -2102,6 +2138,12 @@ function SoilMapOverlay:getLayerColor(layerIdx, info, farmlandId)
     -- Unscouted disease shows the neutral unknown tone, never the pressure ramp.
     if layerIdx == 9 and info.shownDiseasePressure == nil then
         return self:unknownColor()
+    end
+    -- [SF-50] pH takes the 4-stop gradient; every other layer keeps the
+    -- 3-stop health ramp. Same t from layerValueToT either way, so the
+    -- over-limed>7.0 -> t=0 rule is shared.
+    if layerIdx == 4 then
+        return pHGradient(layerValueToT(layerIdx, val))
     end
     return healthGradient(layerValueToT(layerIdx, val))
 end


### PR DESCRIPTION
## Esc pH gradient and legend repair (SF-49 / SF-50)

Phase B slice 1 of Arissani's PR #899 split. This is the "real player-facing display repair" the ruling asked to preserve as one small independent correction, extracted from the contained bundle (`pr899-local` at `c776536b`) and grafted onto current `development`.

### Problem
On the Esc map, the pH layer used discrete 0.5/1.0 health bands. A mid-pass reading of ~6.29 and a headland overlap of ~6.60 rendered as near-identical tints even though the painted values were correct, so real variation was invisible and the legend looked like one flat colour.

### Fix
- **SF-49**: replace the discrete pH band mapping in `layerValueToT` with a continuous ramp. 5.5 to 6.5 spans fair (t 0 to 0.5) and 6.5 to 7.0 spans optimal (t 0.5 to 1.0), so 6.29 reads amber (~0.395) and 6.60 reads greener (~0.60). Over-limed >7.0 still maps to poor (t 0.0), unchanged.
- **SF-50**: add a pH-only 4-stop gradient (deep red, amber, bright green, deep green) and route the pH layer through it in both colour dispatch sites (`valueToLayerColor` and `getLayerColor`). Every other layer keeps the existing 3-stop health ramp. The legend swatches and the map cells both resolve through these two functions, so this fixes both surfaces.

### Scope and safety
- **Display only.** `layerValueToT` feeds nothing but the two colour dispatch functions (verified), so this changes pixels, not simulation.
- **Nothing else rides along.** The `SF-23` map-dirty rebuild-timing hunk from the same bundle file is deliberately left out; it is a painter/refresh concern and belongs to that slice. No prescription, Auto-rate rewrite, Precision Pack, bindings, or playtest code is included.
- Lua 5.1 syntax gate passes; repo lint clean.

### Not in this PR
The narrow #809 product-resolution fix and the painter/coverage corrections are separate slices, each on its own branch and PR.
