### PR TITLE
fix(maps): clamp addPaintStrip saturation band (SF-30)

### DIFF
--- a/src/maps/SoilValueMaps.lua
+++ b/src/maps/SoilValueMaps.lua
@@ -567,6 +567,35 @@ function SoilValueMaps:addPaintStrip(key, sx, sz, wx, wz, hx, hz, delta)
         self.hasExecuteAdd = false
         return 0
     end
+
+    -- [SF-30] Saturation band: clamp the pixels the add had to skip.
+    --
+    -- The filter above deliberately excludes any pixel that would overflow the
+    -- raw range. That protects the no-data sentinel, but it means a LARGE dose
+    -- silently does nothing to ground that is already moderately stocked, while
+    -- addPaintStrip still returns the full semantic delta as if it had landed.
+    -- A pixel that cannot take the whole delta should end up AT the ceiling, not
+    -- refuse the paint. Same at the floor for a negative delta.
+    if type(m.executeSet) == "function" then
+        local sok, serr = pcall(function()
+            if rawDelta > 0 then
+                -- Everything from the add's ceiling upward saturates to RAW_MAX.
+                filter:setValueCompareParams(DensityValueCompareType.BETWEEN,
+                    math.max(rawLow, RAW_MAX - rawDelta + 1), RAW_MAX)
+                m:executeSet(RAW_MAX, filter)
+            else
+                -- Mirror at the bottom, never below the layer's own floor.
+                filter:setValueCompareParams(DensityValueCompareType.BETWEEN,
+                    rawLow, math.min(RAW_MAX, rawLow - rawDelta - 1))
+                m:executeSet(rawLow, filter)
+            end
+        end)
+        if not sok then
+            -- Non-fatal: the add already happened, this only tops up the band.
+            SoilLogger.debug("SoilValueMaps: addPaintStrip saturation clamp failed (%s)", tostring(serr))
+        end
+    end
+
     return rawDelta * upr
 end
 


### PR DESCRIPTION
**Extracts:** the SF-30 saturation-band clamp for `SoilValueMaps:addPaintStrip` from the contained #899 bundle.

**What it fixes:** `addPaintStrip` filtered out pixels that would overflow the raw range (protecting the no-data sentinel) but returned the full semantic delta as if the whole dose had landed. A large dose silently did nothing to already-stocked ground while the caller believed it applied. Now the pixels the add had to skip are clamped to the ceiling (positive delta) or the layer floor (negative delta), so the return value matches what actually landed.

**Leaves behind:** all other #899 work. No prescription/rate-control behavior, no Precision Pack, no keybindings, no console command, no playtest docs. This is a single, self-contained correction to the existing strip painter.

**Verification:** Lua 5.1 syntax gate passes; pre-commit lint clean; diff is one file, 29 insertions.
