### PR TITLE
fix(SF-905): exempt wheel-flattened foliage from amendment burn

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -5343,6 +5343,11 @@ function SoilFertilitySystem:isAmendmentBurnRisk(fruitTypeIndex, growthState)
     local cutStates = fruitDesc.cutStates
     if cutStates and cutStates[gs] then return false end
     if fruitDesc.witheredState and gs == fruitDesc.witheredState then return false end
+    -- Wheel-flattened foliage ("tire tracks") is not a canopy either, so a rut on a freshly-cut
+    -- field must not take the amendment burn (#905, follow-up to #842). The engine parses
+    -- isDestructedByWheel into a single wheelDestructionState (nil until set, one state per fruit),
+    -- so this can never exempt a standing crop; on grass/meadow it lands on the cut state (no-op).
+    if fruitDesc.wheelDestructionState and gs == fruitDesc.wheelDestructionState then return false end
     if fruitName and perennialSet and perennialSet[fruitName] then
         local minH = fruitDesc.minHarvestingGrowthState
         local maxH = fruitDesc.maxHarvestingGrowthState


### PR DESCRIPTION
Closes #905 (follow-up to #842).

## Problem
`isAmendmentBurnRisk` only exempted `cutStates` and `witheredState`, so a **tire-track** cell (`isCut="false"`, `cutStates[gs]` nil) fell straight through the #842 guard. After mowing, a field is a mix of `cut` and `tiretracks` cells, and `applyFertilizer` decides the whole-field burn from a single sample point, so liming a canopy-free field took the -80% `LIME_MAX` burn whenever the sample landed in a wheel rut. This hits year-round perennials (mint, miscanthus) hardest: the cut window is their only application window, so they effectively could not be limed for the life of the stand. The same helper drives the HUD, so `Amend. burn risk: Yes` also showed in the tracks of a freshly-cut field.

## Fix
Guard on `fruitDesc.wheelDestructionState`. The engine parses `isDestructedByWheel` into a single scalar (`FruitTypeDesc.lua:149` nil-init, `:294-298` parse), can only set it on **one state per fruit** (it logs an overwrite warning otherwise), and it always lands on a track/stubble/harvested state, never a productive one. On grass/meadow it sits on the `cut` state, so it is a no-op there. It therefore cannot exempt a standing crop.

```lua
if fruitDesc.wheelDestructionState and gs == fruitDesc.wheelDestructionState then return false end
```

One file, +5 lines (guard + comment). Lua 5.1 syntax gate and lint pass.

## Not in this PR (routed to design)
Two related items the reporter flagged are design decisions, routed to Arissani via the ledger, and intentionally **not** touched here:
- `disasterDestructionState` — should a hail-flattened crop be lime-safe? (needs a `> 0` test, inits to 0 not nil)
- The single-point sample deciding a whole-field penalty (making any cut/track cell in the sprayed area exempt the pass).