### PR TITLE
Keep sprayer cab panels on hide-all, and show live key hints

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.5.0.85</version>
+    <version>2.5.0.86</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.5.0.86</version>
+    <version>2.5.0.87</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/integrations/SoilMasterHUDBridge.lua
+++ b/src/integrations/SoilMasterHUDBridge.lua
@@ -126,6 +126,33 @@ function SoilMasterHUDBridge.drawStack()
     end
 end
 
+SoilMasterHUDBridge.CAB_ID = "SoilFertilizer_CabTools"
+
+--- [SF-51] In-cab TOOL readouts, kept alive through suite hide-all
+--- (BUILD 22:36; shape banked on BUILD 22:20). Hiding "HUDs" means the
+--- monitor, trails and minimap chrome - not flying blind mid-spray. This
+--- second subscription carries visibleWhenHudsHidden = true and draws ONLY
+--- while huds are hidden: when they are visible, drawStack already draws the
+--- same panels, and drawing twice would double the alpha and fight the drag
+--- handles.
+function SoilMasterHUDBridge.drawCabTools()
+    local hud = SoilMasterHUDBridge._hud
+    if hud == nil or hud.hudsHidden ~= true then return end
+    local sfm = g_SoilFertilityManager
+    if sfm == nil then return end
+    if SoilMasterHUDBridge.isFullscreen() then return end
+
+    -- The application-rate strip alone, not the whole Soil Monitor: SoilHUD:draw
+    -- would bring the monitor back, which is exactly what hide-all removes.
+    if sfm.soilHUD and sfm.soilHUD.drawSprayerRatePanel then
+        sfm.soilHUD:drawSprayerRatePanel()
+    end
+    if sfm.variableRatePanel then sfm.variableRatePanel:draw() end
+    if sfm.smartSensorPanel then sfm.smartSensorPanel:draw() end
+    if sfm.sprayerInfoPanel then sfm.sprayerInfoPanel:draw() end
+    if sfm.harvesterPanel then sfm.harvesterPanel:draw() end
+end
+
 -- Register with MasterHUD if present. Called at loadMission00Finished, after the
 -- HUD has published its g_currentMission handle (Mission00.load).
 function SoilMasterHUDBridge.register(mgr)
@@ -152,7 +179,19 @@ function SoilMasterHUDBridge.register(mgr)
 
     if ok then
         SoilMasterHUDBridge.active = true
-        SoilLogger.info("Registered soil HUD with MasterHUD (single draw loop + menu-suspend)")
+        -- [SF-51] Keep the hud handle for drawCabTools' hudsHidden check, and
+        -- register the keep-alive cab-tools subscription. pcall'd separately:
+        -- an older MasterHUD without the flag simply draws it as a normal
+        -- self-draw, and the function's own hudsHidden guard then makes it a
+        -- no-op - graceful on every version pairing.
+        SoilMasterHUDBridge._hud = hud
+        pcall(function()
+            hud:subscribe(SoilMasterHUDBridge.CAB_ID, {
+                draw = SoilMasterHUDBridge.drawCabTools,
+                visibleWhenHudsHidden = true,
+            })
+        end)
+        SoilLogger.info("Registered soil HUD with MasterHUD (single draw loop + menu-suspend + cab-tools keep-alive)")
         -- Suite layout edit reaches the Soil Monitor and every independent
         -- in-vehicle panel, including placeholders when no matching implement is
         -- currently controlled.

--- a/src/main.lua
+++ b/src/main.lua
@@ -1167,3 +1167,154 @@ print("  Realistic soil management system      ")
 print("  Type 'soilfertility' for commands     ")
 
 print("========================================")
+
+
+
+-- =========================================================
+-- [SF-66] LIVE KEYBIND HINTS (BUILD 19:58)
+-- =========================================================
+-- Every on-screen surface that used to print a hard-coded default chord now
+-- runs its resolved text through here, so a player who rebound (or never
+-- bound) an action reads their OWN key instead of the shipped default.
+--
+-- Why a walker and not a gsub of known chords: the modifier is LOCALISED
+-- (Shift / Umschalt / Maj / Maiusc / Skift / Vaihto ...) across 26 files, and
+-- any enumerated vocabulary goes stale the first time a translator picks a
+-- different word. Instead we anchor on the invariant part - "+<KEY>" - and walk
+-- LEFT over letters to capture whatever this language calls the modifier.
+--
+-- Two guards keep that from eating real text, and both matter in a soil mod:
+--   * the captured word must be at least 3 letters, so the "N+K" and "P+K" that
+--     appear in nutrient copy are never touched (every real modifier name -
+--     Alt, Maj, Shift, Skift, Umschalt - clears 3);
+--   * it must start with a capital, which is true of every modifier name the
+--     game prints and false of ordinary prose.
+-- The trade is deliberate: a missed rewrite leaves today's stale hint, while a
+-- wrong rewrite corrupts a sentence, so the guards fail toward doing nothing.
+SoilLiveHint = SoilLiveHint or {}
+
+-- Stale default KEY per action, as actually printed by the shipped strings.
+SoilLiveHint.ACTION_KEYS = {
+    SF_HUD_DRAG        = "H",
+    SF_VARIABLE_RATE   = "7",
+    SF_SCOUT           = "K",
+    SF_TREATMENT       = "T",
+    SF_TOGGLE_AUTO     = "L",
+    SF_CYCLE_MAP_LAYER = "M",
+    SF_OPEN_SETTINGS   = "O",
+    SF_HANDFUL         = "G",
+}
+
+--- Live chord for an action. Order per the packet: the suite's live binding,
+--- then the proven engine overlay call, then an honest "unassigned" - never a
+--- fabricated default, which is what put a confident wrong key on screen.
+---@param actionName string
+---@return string|nil chord, nil when the action is not loaded at all
+function SoilLiveHint.chord(actionName)
+    if actionName == nil then return nil end
+    if RfLiveBinding ~= nil and RfLiveBinding.getChord ~= nil then
+        local c = RfLiveBinding.getChord(actionName)
+        if c then return c end
+    end
+    if g_inputDisplayManager ~= nil and InputAction ~= nil and InputAction[actionName] ~= nil then
+        local ok, help = pcall(function()
+            return g_inputDisplayManager:getControllerSymbolOverlays(InputAction[actionName], "", "", false)
+        end)
+        if ok and help and help.keys and #help.keys > 0 then
+            local parts = {}
+            for _, k in ipairs(help.keys) do parts[#parts + 1] = tostring(k) end
+            return table.concat(parts, "+")
+        end
+    end
+    if InputAction ~= nil and InputAction[actionName] == nil then
+        -- Action not in this session at all: leave the text alone rather than
+        -- claim it is unassigned.
+        return nil
+    end
+    if RfLiveBinding ~= nil and RfLiveBinding.UNASSIGNED ~= nil then
+        return RfLiveBinding.UNASSIGNED
+    end
+    return "unassigned"
+end
+
+--- Replace "<localised modifier>+<KEY>" with `chord`, wherever it appears.
+---@param text string
+---@param keyLetter string  the single stale key character, e.g. "H"
+---@param chord string
+---@return string
+function SoilLiveHint.swapChord(text, keyLetter, chord)
+    if type(text) ~= "string" or type(keyLetter) ~= "string" or keyLetter == "" then return text end
+    if type(chord) ~= "string" or chord == "" then return text end
+    local needle = "+" .. keyLetter
+    local out, i = {}, 1
+    while true do
+        local sPos, ePos = string.find(text, needle, i, true)
+        if sPos == nil then break end
+        -- Right edge: the key must end the token, not run into another word.
+        local after = (ePos < #text) and string.sub(text, ePos + 1, ePos + 1) or ""
+        local rightOk = (after == "") or (string.match(after, "%w") == nil)
+        -- Walk left over the localised modifier word.
+        local wStart = sPos
+        while wStart > 1 and string.match(string.sub(text, wStart - 1, wStart - 1), "%a") ~= nil do
+            wStart = wStart - 1
+        end
+        if wStart < i then wStart = i end
+        local word = string.sub(text, wStart, sPos - 1)
+        local wordOk = (#word >= 3) and (string.match(string.sub(word, 1, 1), "%u") ~= nil)
+        -- Left edge: nothing lettered may butt against the modifier word.
+        local before = (wStart > 1) and string.sub(text, wStart - 1, wStart - 1) or ""
+        local leftOk = (before == "") or (string.match(before, "%a") == nil)
+        if rightOk and wordOk and leftOk then
+            out[#out + 1] = string.sub(text, i, wStart - 1)
+            out[#out + 1] = chord
+        else
+            out[#out + 1] = string.sub(text, i, ePos)
+        end
+        i = ePos + 1
+    end
+    out[#out + 1] = string.sub(text, i)
+    return table.concat(out)
+end
+
+--- Rewrite every stale Soil chord in one string to its live binding.
+--- Cheap enough for a draw call: eight plain finds, each a no-op unless that
+--- exact token is present.
+---@param text string
+---@param actions table|nil  optional list of action names; defaults to all
+---@return string
+function SoilLiveHint.rewrite(text, actions)
+    if type(text) ~= "string" or text == "" then return text end
+    if string.find(text, "+", 1, true) == nil then return text end
+
+    -- A live chord is itself of the form "<modifier>+<KEY>", so writing one
+    -- straight into the text puts a fresh target in front of the passes that
+    -- have not run yet: bind HUD drag to Right Shift+K and the scout pass would
+    -- find the "+K" this pass just inserted and overwrite it with scout's key.
+    -- So each pass writes a sentinel containing no "+", and the real chords go
+    -- in once at the end, after all scanning is finished.
+    local marks = {}
+    local function place(name)
+        local key = SoilLiveHint.ACTION_KEYS[name]
+        if key == nil then return end
+        local c = SoilLiveHint.chord(name)
+        if c == nil then return end
+        marks[#marks + 1] = c
+        text = SoilLiveHint.swapChord(text, key, string.char(1) .. tostring(#marks) .. string.char(1))
+    end
+
+    if actions ~= nil then
+        for _, name in ipairs(actions) do place(name) end
+    else
+        for name in pairs(SoilLiveHint.ACTION_KEYS) do place(name) end
+    end
+
+    for idx = 1, #marks do
+        local token = string.char(1) .. tostring(idx) .. string.char(1)
+        local at = string.find(text, token, 1, true)
+        while at ~= nil do
+            text = string.sub(text, 1, at - 1) .. marks[idx] .. string.sub(text, at + #token)
+            at = string.find(text, token, 1, true)
+        end
+    end
+    return text
+end

--- a/src/ui/SoilGuideDialog.lua
+++ b/src/ui/SoilGuideDialog.lua
@@ -452,7 +452,15 @@ function SoilGuideDialog:_buildContent(pageNum)
             if profile then
                 local el = TextElement.new()
                 el:loadProfile(profile, true)
-                el:setText(row.k and tr(row.k, row.v or "") or (row.v or ""))
+                -- [SF-66] Guide rows quote seven different default chords
+                -- (HUD drag, variable rate, scout, treatment, auto rate, map
+                -- layer, settings). Rewrite the resolved text, so a rebound
+                -- player reads their own keys on every page and locale.
+                local rowText = row.k and tr(row.k, row.v or "") or (row.v or "")
+                if SoilLiveHint ~= nil and SoilLiveHint.rewrite ~= nil then
+                    rowText = SoilLiveHint.rewrite(rowText)
+                end
+                el:setText(rowText)
                 currentBox:addElement(el)
                 el:onGuiSetupFinished()
                 table.insert(self._contentLineEls, { box = currentBox, el = el })

--- a/src/ui/SoilHUD.lua
+++ b/src/ui/SoilHUD.lua
@@ -1834,11 +1834,14 @@ function SoilHUD:drawPanel()
     -- Hint row
     setTextAlignment(RenderText.ALIGN_CENTER)
     setTextColor(SoilHUD.C_HINT[1], SoilHUD.C_HINT[2], SoilHUD.C_HINT[3], SoilHUD.C_HINT[4])
-    if self.editMode then
-        renderText(px + pw * 0.5, cy, 0.009 * fontMult * s, g_i18n:getText("sf_hud_hint_edit"))
-    else
-        renderText(px + pw * 0.5, cy, 0.009 * fontMult * s, g_i18n:getText("sf_hud_hint_normal"))
+    -- [SF-66] Both hint strings ship "Shift+H" while the modDesc default for
+    -- SF_HUD_DRAG is Right Shift+P, so this row has been telling every player
+    -- the wrong key in every language. Rewrite to the live binding at draw.
+    local hintText = g_i18n:getText(self.editMode and "sf_hud_hint_edit" or "sf_hud_hint_normal")
+    if SoilLiveHint ~= nil and SoilLiveHint.rewrite ~= nil then
+        hintText = SoilLiveHint.rewrite(hintText, { "SF_HUD_DRAG" })
     end
+    renderText(px + pw * 0.5, cy, 0.009 * fontMult * s, hintText)
 
     -- Reset text state
     setTextBold(false)

--- a/src/ui/SoilHarvesterPanel.lua
+++ b/src/ui/SoilHarvesterPanel.lua
@@ -569,7 +569,11 @@ function SoilHarvesterPanel:draw()
     if not self.settings or not self.settings.enabled then return end
     if not g_currentMission or not g_currentMission.isRunning then return end
     local _sfm = g_SoilFertilityManager
-    if not self.editMode and _sfm and _sfm.soilHUD and not _sfm.soilHUD.visible then return end
+    -- Cab tool readouts follow the base-game HUD only. Suite hide-all and the
+    -- Soil monitor toggle must not hide a working tool panel. Vanilla HUD-hide does.
+    if not self.editMode and g_currentMission.hud
+        and type(g_currentMission.hud.getIsVisible) == "function"
+        and not g_currentMission.hud:getIsVisible() then return end
     -- Edit mode always exposes a placement placeholder, even when the runtime
     -- display preference is off or no combine is currently controlled.
     if not self.editMode and _sfm and _sfm.settings

--- a/src/ui/SoilSettingsPanel.lua
+++ b/src/ui/SoilSettingsPanel.lua
@@ -1735,6 +1735,11 @@ function SoilSettingsPanel:drawSettingRow(x, y, w, settingId, rowIdx, isAdmin)
     -- Description
     local descKey = SETTING_DESCS[settingId]
     local desc = (descKey and tr(descKey)) or ""
+    -- [SF-66] sf_desc_independentPanels quotes "Shift+H edit mode"; any other
+    -- description that grows a chord is covered by the same pass.
+    if SoilLiveHint ~= nil and SoilLiveHint.rewrite ~= nil then
+        desc = SoilLiveHint.rewrite(desc)
+    end
     self:drawText(labelX, y + rh * 0.15, TS_TINY, desc, descColor, RenderText.ALIGN_LEFT, false)
 
     -- Control (toggle or multi-select) on the right

--- a/src/ui/SoilSmartSensorPanel.lua
+++ b/src/ui/SoilSmartSensorPanel.lua
@@ -175,7 +175,11 @@ function SoilSmartSensorPanel:draw()
     -- SF custom settings panel open → hide system panels
     if sfm.settingsPanel and sfm.settingsPanel.isVisible then return end
 
-    if hud and not hud.visible and not inEditMode then return end
+    -- Cab tool readouts follow the base-game HUD only. Suite hide-all and the
+    -- Soil monitor toggle must not hide a working tool panel. Vanilla HUD-hide does.
+    if not inEditMode and g_currentMission.hud
+        and type(g_currentMission.hud.getIsVisible) == "function"
+        and not g_currentMission.hud:getIsVisible() then return end
 
     if not inEditMode then
         if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then return end

--- a/src/ui/SoilSprayerInfoPanel.lua
+++ b/src/ui/SoilSprayerInfoPanel.lua
@@ -493,7 +493,11 @@ function SoilSprayerInfoPanel:draw()
     if not self.settings or not self.settings.enabled then return end
     if not g_currentMission or not g_currentMission.isRunning then return end
     local sfm = g_SoilFertilityManager
-    if not self.editMode and sfm and sfm.soilHUD and not sfm.soilHUD.visible then return end
+    -- Cab tool readouts follow the base-game HUD only. Suite hide-all and the
+    -- Soil monitor toggle must not hide a working tool panel. Vanilla HUD-hide does.
+    if not self.editMode and g_currentMission.hud
+        and type(g_currentMission.hud.getIsVisible) == "function"
+        and not g_currentMission.hud:getIsVisible() then return end
     -- Edit mode always exposes a placement placeholder, even when the runtime
     -- display preference is off or no sprayer/spreader/slurry tool is active.
     if not self.editMode and sfm and sfm.settings

--- a/src/ui/SoilVariableRatePanel.lua
+++ b/src/ui/SoilVariableRatePanel.lua
@@ -127,7 +127,11 @@ function SoilVariableRatePanel:draw()
     -- SF custom settings panel open → hide system panels
     if sfm.settingsPanel and sfm.settingsPanel.isVisible then return end
 
-    if hud and not hud.visible and not inEditMode then return end
+    -- Cab tool readouts follow the base-game HUD only. Suite hide-all and the
+    -- Soil monitor toggle must not hide a working tool panel. Vanilla HUD-hide does.
+    if not inEditMode and g_currentMission.hud
+        and type(g_currentMission.hud.getIsVisible) == "function"
+        and not g_currentMission.hud:getIsVisible() then return end
 
     if not inEditMode then
         if g_gui and (g_gui:getIsGuiVisible() or g_gui:getIsDialogVisible()) then return end

--- a/src/ui/SoilVersionDialog.lua
+++ b/src/ui/SoilVersionDialog.lua
@@ -227,6 +227,12 @@ function SoilVersionDialog:_buildChangelogLines()
             profile = profileLine
         end
 
+        -- [SF-66] Restores the BUILD 22:36 rewrite the tree overwrite dropped:
+        -- the READ THE DIRT entry quotes "Shift+G by default" for SF_HANDFUL.
+        if SoilLiveHint ~= nil and SoilLiveHint.rewrite ~= nil then
+            displayText = SoilLiveHint.rewrite(displayText, { "SF_HANDFUL" })
+        end
+
         local el = TextElement.new()
         el:loadProfile(profile, true)
         el:setText(displayText)


### PR DESCRIPTION
## Summary
- Sprayer, spreader, and harvester cab panels stay useful when suite hide-all is on. Soil Monitor, trails, and minimap still hide.
- On-screen Soil key hints (HUD drag, handful changelog, field guide, settings copy) now show the player's live binds instead of shipped defaults. German Umschalt is not eaten.

## Test plan
- In a sprayer, Right Shift+G: rate / VRA / sprayer info stay; monitor hides.
- Rebind HUD drag and handful; HUD hint and handful changelog should follow the new keys.
- Open the Soil field guide and independent-panels setting; chords should match the live binds.
