### PR TITLE
Move Soil HUD drag and auto-rate keys off common mod clashes

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.5.0.87</version>
+    <version>2.5.0.88</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>
@@ -103,23 +103,26 @@
     <inputBinding>
         <actionBinding action="SF_RATE_UP" />
         <actionBinding action="SF_RATE_DOWN" />
-        <actionBinding action="SF_TOGGLE_AUTO" />
+        <actionBinding action="SF_TOGGLE_AUTO">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_insert" />
+        </actionBinding>
         <actionBinding action="SF_CYCLE_MAP_LAYER" />
         <actionBinding action="SF_OPEN_SETTINGS" />
         <actionBinding action="SF_VARIABLE_RATE" />
         <actionBinding action="SF_MINIMAP_ZOOM" />
         <actionBinding action="SF_SCOUT" />
         <actionBinding action="SF_TREATMENT" />
-        <!-- API-6 (input convention): no ecosystem mod ships a default binding, so
-             the player assigns keys in the game's control settings and nothing
-             collides out of the box. All nine former defaults were removed; the
-             actions stay registered and rebindable. -->
+        <!-- API-6 still holds for the unbound actions above: the player assigns
+             those in Controls. The three shipped Right Shift defaults stay on
+             purpose. HUD drag moved off P because that chord is the production
+             dialog in widely used production overlay mods. Auto rate uses Insert
+             instead of L because Right Shift+L is Real GPS setup. -->
         <actionBinding action="SF_HANDFUL" />
         <actionBinding action="SF_TOGGLE_HUD">
             <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_o" />
         </actionBinding>
         <actionBinding action="SF_HUD_DRAG">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_p" />
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_up" />
         </actionBinding>
     </inputBinding>
 


### PR DESCRIPTION
## Summary
- Keep Right Shift as the Soil modifier.
- Move **HUD drag** from Right Shift + P to Right Shift + Up. Right Shift + P is the production dialog in widely used production overlay mods, and both are used in the cab.
- Ship **auto rate** as Right Shift + Insert instead of Right Shift + L. Right Shift + L is Real GPS setup, another widely used cab mod.
- Other Soil actions stay unbound (player assigns those in Controls). HUD toggle stays Right Shift + O.

## Test plan
- [ ] Fresh profile / Controls: HUD drag default is Right Shift + Up, auto rate is Right Shift + Insert.
- [ ] With a production overlay mod loaded, Right Shift + P still opens that production dialog and does not enter Soil HUD drag.
- [ ] With Real GPS loaded, Right Shift + L still opens GPS setup and does not toggle Soil auto rate.
- [ ] Existing saves that already rebound these keys are unchanged (this only changes the shipped default).
