### PR TITLE
Show why a soil patch is blocked or ahead

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.5.0.87</version>
+    <version>2.5.0.91</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/ui/SoilMapOverlay.lua
+++ b/src/ui/SoilMapOverlay.lua
@@ -360,6 +360,9 @@ function SoilMapOverlay:requestRefresh()
     self.fieldPolyCache        = {}
     self._pdaNextBuildMs       = 0
     self._pdaActiveLayer       = -1   -- force DMV rebuild on next draw
+    -- Growth inspect re-reads on the next tooltip draw (page OPEN / REFRESH),
+    -- one frame later than whatever asked, never inside a boundary message.
+    self._growthReread         = true
 end
 
 -- ── Layer selection ───────────────────────────────────────
@@ -1154,6 +1157,92 @@ function SoilMapOverlay:screenToWorldPosition(ingameMap, screenX, screenY)
     return worldX, worldZ
 end
 
+-- ── Growth inspect (BUILD 09:40, Stage 7 v1) ─────────────
+-- The cell tooltip answers why a patch is behind or ahead. It reads the
+-- growth family's published getter LIVE at the click (and once more after a
+-- requestRefresh, deferred to the next tooltip draw), never from a stored
+-- mirror and never from a day-boundary subscriber.
+--
+-- Gates, in order, and what each one yields:
+--   family not live (Soil disabled or stood down by Precision Farming,
+--   growth_modulation not opted in, viability absent)  -> no section at all
+--   cell unscouted (field undiscovered AND not a fresh walked cell of the
+--   VIEWING farm's own mask)                             -> UNKNOWN, getter
+--                                                          never called
+--   getter nil (off-field, layer unreadable)             -> no section
+--   otherwise                                            -> the reading
+--
+-- What v1 shows: blocked or not, nitrogen and compaction as NAMED causes, the
+-- growth credit in days as of the field's last settle day, EXCELLENT / NORMAL
+-- for ground that is not blocked. A block with no named cause is reported as
+-- real with the cause not yet reported: the family may grow causes later and
+-- this surface must not pretend to a closed list. Moisture, water and the
+-- captured harvest score are never rendered here.
+
+--- The mod's own discovery gate, the same one the disease layer paints by.
+--- The field's discovered flag reveals the whole field; otherwise only a
+--- fresh walked cell of the local viewing farm's mask counts as scouted.
+---@return boolean
+function SoilMapOverlay:_isCellScouted(farmlandId, worldX, worldZ)
+    local soilSystem = self.soilSystem
+    local fieldEntry = soilSystem and soilSystem.fieldData and soilSystem.fieldData[farmlandId]
+    if fieldEntry ~= nil and fieldEntry.diseaseDiscovered then return true end
+    local scouting = soilSystem and soilSystem.spatialScouting
+    if scouting == nil or type(scouting.isArmed) ~= "function" or not scouting:isArmed() then
+        return false
+    end
+    if SpatialScouting == nil or type(SpatialScouting.cellKey) ~= "function"
+       or type(SpatialScouting.isOrdinaryFarmId) ~= "function"
+       or type(scouting.isFresh) ~= "function" then
+        return false
+    end
+    local viewingFarm = g_localPlayer and g_localPlayer.farmId
+    local day = g_currentMission and g_currentMission.environment
+        and g_currentMission.environment.currentDay
+    if not SpatialScouting.isOrdinaryFarmId(viewingFarm) or day == nil then return false end
+    local ok, fresh = pcall(function()
+        return scouting:isFresh(viewingFarm, farmlandId, SpatialScouting.cellKey(worldX, worldZ), day)
+    end)
+    return ok and fresh == true
+end
+
+--- Read the growth judgement for a selected cell. Returns a small record the
+--- tooltip renders from; never nil, so "unread" (nil on the cell) stays
+--- distinct from "read and nothing to show".
+---   { state = "off" }                       family not live, or getter nil
+---   { state = "unknown" }                   unscouted
+---   { state = "read", info = <getter>, settledDay = <day|nil> }
+---@param sel table the selectedCell record
+---@return table
+function SoilMapOverlay:_readCellGrowth(sel)
+    local OFF = { state = "off" }
+    if sel == nil or sel.farmlandId == nil then return OFF end
+    local sfm = g_currentMission and g_currentMission.soilFertilityManager
+    if sfm == nil or type(sfm.getCellGrowthInfo) ~= "function" then return OFF end
+    -- Ride Soil's own stand-down: settings off, or Precision Farming present.
+    if (sfm.settings ~= nil and sfm.settings.enabled == false) or sfm._disabledByPF then return OFF end
+    -- growth_modulation is experimental; when the gate is closed the family
+    -- is not running and this surface has nothing honest to say.
+    if ReleaseGate ~= nil and type(ReleaseGate.isSystemLive) == "function"
+       and not ReleaseGate.isSystemLive("growth_modulation") then
+        return OFF
+    end
+    if not self:_isCellScouted(sel.farmlandId, sel.worldX, sel.worldZ) then
+        return { state = "unknown" }
+    end
+    local info = sfm:getCellGrowthInfo(sel.farmlandId, sel.worldX, sel.worldZ)
+    if type(info) ~= "table" then return OFF end
+    -- As-of day: the field summary's settle day. The published summary getter
+    -- does not carry it, so this same-mod read looks at the mask's own record
+    -- and treats absence as "not settled yet".
+    local settledDay = nil
+    local v = sfm.viability
+    local summaries = v and v._summaries
+    local s = summaries and summaries[sel.farmlandId]
+    if type(s) == "table" and type(s.day) == "number" then settledDay = s.day end
+    return { state = "read", info = info, settledDay = settledDay }
+end
+
 --- Called from SoilMapHooks.onMouseEvent when the soil page is active and the
 --- user clicks the map area. Finds which soil cell was clicked and stores it
 --- as self.selectedCell for drawing the tooltip in onDraw.
@@ -1207,6 +1296,8 @@ function SoilMapOverlay:onMapClick(ingameMap, screenX, screenY)
         info         = info,
         fromZoneCell = info.fromZoneCell or false,
     }
+    -- Growth read at the click: the explicit read the window allows.
+    self.selectedCell.growth = self:_readCellGrowth(self.selectedCell)
     -- Force overlay refresh so tile colors match the freshly-read tooltip data
     self.nextSampleUpdateTime = 0
     SoilLogger.debug("SoilMapOverlay: cell selected field=%s cell=[%d,%d]",
@@ -1459,6 +1550,79 @@ function SoilMapOverlay:drawCellTooltip(ingameMap, mapX, mapY, mapWidth, mapHeig
         end
     else
         return
+    end
+
+    -- ── Growth inspect rows (every layer) ─────────────────────
+    if sel.growth == nil or self._growthReread then
+        self._growthReread = false
+        sel.growth = self:_readCellGrowth(sel)
+    end
+    local growth = sel.growth
+    local growthLabel = tr("sf_growth_label", "Growth")
+    if growth.state == "unknown" then
+        addRow(growthLabel, tr("sf_growth_unknown", "Unknown, unscouted"), DIM[1], DIM[2], DIM[3])
+    elseif growth.state == "read" and type(growth.info) == "table" then
+        local gi = growth.info
+        local by = (type(gi.blockedBy) == "table") and gi.blockedBy or {}
+        local bands = (type(gi.bands) == "table") and gi.bands or {}
+        local EXC = (ViabilityMask and ViabilityMask.BAND_EXCELLENT) or "excellent"
+        local NRM = (ViabilityMask and ViabilityMask.BAND_NORMAL) or "normal"
+        local function bandText(b)
+            if b == EXC then return tr("sf_growth_excellent", "Excellent"), ttGOOD[1], ttGOOD[2], ttGOOD[3] end
+            return tr("sf_growth_normal", "Normal"), NEU[1], NEU[2], NEU[3]
+        end
+        if gi.blocked then
+            addRow(growthLabel, tr("sf_growth_blocked", "Blocked"), ttPOOR[1], ttPOOR[2], ttPOOR[3])
+            local named = false
+            if by.n then
+                addRow(tr("sf_map_layer_n", "Nitrogen (N)"), tr("sf_growth_blocked", "Blocked"), ttPOOR[1], ttPOOR[2], ttPOOR[3])
+                named = true
+            end
+            if by.compaction then
+                addRow(tr("sf_map_layer_compaction", "Compaction"), tr("sf_growth_blocked", "Blocked"), ttPOOR[1], ttPOOR[2], ttPOOR[3])
+                named = true
+            end
+            if not named then
+                -- The block is real; the family has not named a cause this
+                -- surface knows how to show. Say so rather than guess.
+                addRow(tr("sf_growth_cause", "Cause"), tr("sf_growth_cause_unreported", "Not yet reported"), ttFAIR[1], ttFAIR[2], ttFAIR[3])
+            end
+        else
+            -- Ahead or level: only nitrogen and compaction vote here.
+            local overall = NRM
+            if bands.n == EXC or bands.compaction == EXC then overall = EXC end
+            local oTxt, oR, oG, oB = bandText(overall)
+            addRow(growthLabel, oTxt, oR, oG, oB)
+            if bands.n ~= nil then
+                local t, r, g, b = bandText(bands.n)
+                addRow(tr("sf_map_layer_n", "Nitrogen (N)"), t, r, g, b)
+            end
+            if bands.compaction ~= nil then
+                local t, r, g, b = bandText(bands.compaction)
+                addRow(tr("sf_map_layer_compaction", "Compaction"), t, r, g, b)
+            end
+        end
+        -- Growth credit in days. nil is the family's neutral reading and is
+        -- shown as none, never as zero.
+        if type(gi.credit) == "number" then
+            local days = math.floor(gi.credit + 0.5)
+            local cR, cG, cB = NEU[1], NEU[2], NEU[3]
+            if days > 0 then cR, cG, cB = ttGOOD[1], ttGOOD[2], ttGOOD[3] end
+            addRow(tr("sf_growth_credit", "Growth credit"), string.format(tr("sf_growth_credit_days", "%d days"), days), cR, cG, cB)
+        else
+            addRow(tr("sf_growth_credit", "Growth credit"), tr("sf_growth_credit_none", "None"), DIM[1], DIM[2], DIM[3])
+        end
+        -- As of the field's last settle day, when the summary carries one.
+        local today = g_currentMission and g_currentMission.environment
+            and g_currentMission.environment.currentMonotonicDay
+        if type(growth.settledDay) == "number" and type(today) == "number" then
+            local ago = math.max(0, math.floor(today - growth.settledDay + 0.5))
+            local agoTxt
+            if ago == 0 then agoTxt = tr("sf_growth_settled_today", "Today")
+            elseif ago == 1 then agoTxt = tr("sf_growth_settled_day_ago", "1 day ago")
+            else agoTxt = string.format(tr("sf_growth_settled_days_ago", "%d days ago"), ago) end
+            addRow(tr("sf_growth_settled", "Settled"), agoTxt, DIM[1], DIM[2], DIM[3])
+        end
     end
 
     if #rows == 0 then return end

--- a/src/ui/SoilPDAScreen.lua
+++ b/src/ui/SoilPDAScreen.lua
@@ -88,6 +88,34 @@ local function tr(key, fallback)
     return fallback or key
 end
 
+-- ── Growth summary per field row (BUILD 09:40, Stage 7 v1) ──
+-- Field-level fractions from the growth family's published summary getter:
+-- how much of the field's area is blocked, how much is excellent. Read when
+-- the screen rebuilds its rows (open, filter toggle, its own refresh tick),
+-- never from a day-boundary subscriber. The summary is the mask's settled
+-- record, so this is a cheap table read, not a field walk.
+--
+-- Gates: Soil disabled or stood down by Precision Farming, growth_modulation
+-- not opted in, or the field not yet discovered (the same discovery flag the
+-- soil map paints by; a whole-field fraction has no per-cell compose) all
+-- yield nil, and the row keeps its nutrient status word as before.
+---@param fieldId number farmland id
+---@param fieldEntry table|nil the soil system's own field record
+---@return table|nil { blockedFrac, excellentFrac }
+local function readGrowthSummary(fieldId, fieldEntry)
+    if fieldEntry == nil or not fieldEntry.diseaseDiscovered then return nil end
+    local sfm = g_currentMission and g_currentMission.soilFertilityManager
+    if sfm == nil or type(sfm.getFieldGrowthSummary) ~= "function" then return nil end
+    if (sfm.settings ~= nil and sfm.settings.enabled == false) or sfm._disabledByPF then return nil end
+    if ReleaseGate ~= nil and type(ReleaseGate.isSystemLive) == "function"
+       and not ReleaseGate.isSystemLive("growth_modulation") then
+        return nil
+    end
+    local summary = sfm:getFieldGrowthSummary(fieldId)
+    if type(summary) ~= "table" then return nil end
+    return summary
+end
+
 -- ── Constructor ───────────────────────────────────────────
 
 function SoilPDAScreen.new()
@@ -764,10 +792,17 @@ function SoilPDAScreen:_buildFieldData()
                 end)
                 if urgOk then urgency = urgVal end
 
+                local growth = nil
+                local gOk, gVal = pcall(function()
+                    return readGrowthSummary(fieldId, sfm.soilSystem.fieldData[fieldId])
+                end)
+                if gOk then growth = gVal end
+
                 table.insert(self.fieldData, {
                     fieldId = fieldId,
                     info    = info,
                     urgency = urgency,
+                    growth  = growth,
                 })
             end
         end
@@ -1038,14 +1073,32 @@ function SoilPDAScreen:_populateFieldCell(index, cell)
         end
     end
 
-    -- Overall status
+    -- Overall status. The growth summary shares this cell (no new column in
+    -- v1): a blocked share outranks the nutrient word, an excellent share
+    -- shows only when nothing else is wrong, so the worst news always wins.
     if statusEl then
-        if entry.urgency >= 60 then
+        local growth = entry.growth
+        local blockedPct, excellentPct = nil, nil
+        if type(growth) == "table" then
+            if type(growth.blockedFrac) == "number" then
+                blockedPct = math.floor(growth.blockedFrac * 100 + 0.5)
+            end
+            if type(growth.excellentFrac) == "number" then
+                excellentPct = math.floor(growth.excellentFrac * 100 + 0.5)
+            end
+        end
+        if blockedPct ~= nil and blockedPct >= 1 then
+            statusEl:setText(string.format(tr("sf_pda_growth_blocked", "Blocked %d%%"), blockedPct))
+            statusEl:setTextColor(unpack(COLOR_POOR))
+        elseif entry.urgency >= 60 then
             statusEl:setText(tr("sf_pda_status_poor", "Poor"))
             statusEl:setTextColor(unpack(COLOR_POOR))
         elseif entry.urgency >= 25 then
             statusEl:setText(tr("sf_pda_status_fair", "Fair"))
             statusEl:setTextColor(unpack(COLOR_FAIR))
+        elseif excellentPct ~= nil and excellentPct >= 1 then
+            statusEl:setText(string.format(tr("sf_pda_growth_ahead", "Ahead %d%%"), excellentPct))
+            statusEl:setTextColor(unpack(COLOR_GOOD))
         else
             statusEl:setText(tr("sf_pda_status_good", "Good"))
             statusEl:setTextColor(unpack(COLOR_GOOD))

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1449,7 +1449,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -1423,5 +1423,22 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1461,5 +1461,22 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1412,7 +1412,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1398,5 +1398,22 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1419,7 +1419,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1401,7 +1401,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1467,5 +1467,22 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="%d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="%d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="Ahead %d%%" eh="e19aed44" />
+</elements>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1401,7 +1401,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1461,5 +1461,22 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1402,7 +1402,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1401,5 +1401,22 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1421,7 +1421,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1448,7 +1448,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1448,7 +1448,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1428,7 +1428,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1429,7 +1429,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1432,7 +1432,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1430,7 +1430,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1430,7 +1430,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1449,7 +1449,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1449,7 +1449,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1390,7 +1390,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1401,7 +1401,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1402,7 +1402,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1401,7 +1401,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1401,7 +1401,24 @@
     <e k="sf_notify_cover_winterkill" v="Cover crop winter-killed" />    <e k="sf_fieldinfo_drilling" v="Drilling" />
     <e k="sf_notify_drill_good" v="Drilling: good window ahead" />
     <e k="sf_notify_drill_risky" v="Drilling: risky, rain likely before emergence" />
-    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" /></elements>
+    <e k="sf_notify_drill_forecast_only" v="Drilling: forecast only, soil moisture unknown" />
+    <e k="sf_growth_label" v="[EN] Growth" eh="699aed86" />
+    <e k="sf_growth_blocked" v="[EN] Blocked" eh="4ecc0d90" />
+    <e k="sf_growth_excellent" v="[EN] Excellent" eh="fcc2d28a" />
+    <e k="sf_growth_normal" v="[EN] Normal" eh="960b44c5" />
+    <e k="sf_growth_unknown" v="[EN] Unknown, unscouted" eh="25f30088" />
+    <e k="sf_growth_cause" v="[EN] Cause" eh="50fc9b91" />
+    <e k="sf_growth_cause_unreported" v="[EN] Not yet reported" eh="84fb9c37" />
+    <e k="sf_growth_credit" v="[EN] Growth credit" eh="30ce7482" />
+    <e k="sf_growth_credit_days" v="[EN] %d days" eh="cdca48ec" />
+    <e k="sf_growth_credit_none" v="[EN] None" eh="6adf97f8" />
+    <e k="sf_growth_settled" v="[EN] Settled" eh="30533c6b" />
+    <e k="sf_growth_settled_today" v="[EN] Today" eh="1dd1c5fb" />
+    <e k="sf_growth_settled_day_ago" v="[EN] 1 day ago" eh="44ba1391" />
+    <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
+    <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
+    <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+</elements>
 
 
 </l10n>


### PR DESCRIPTION
## Summary
- Click an existing soil-map cell to see whether that patch is blocked or excellent, plus nitrogen, compaction, and growth credit as of the last settle.
- Unscouted cells read Unknown. The section stays off when Soil is stood down or Experimental Systems is off.
- Field-list Status can show Blocked or Ahead share. No new map layer and no new Esc page.

## Test plan
- Experimental Systems on. Esc Map Soil layer. Click a scouted cell: growth, nitrogen, compaction, credit.
- Click an unscouted cell: Unknown, unscouted.
- Field list Status: Blocked N% or Ahead N% when the family is live.
- Experimental Systems off: the growth block is hidden.
