### PR TITLE
Show field fungicide resistance on the Soil Esc page

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.5.0.91</version>
+    <version>2.5.0.92</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.5.0.92</version>
+    <version>2.5.0.93</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="108">
     <author>TisonK</author>
-    <version>2.5.0.93</version>
+    <version>2.5.0.94</version>
     <modName>FS25_SoilFertilizer</modName>
     <title>
         <en>Realistic Soil &amp; Fertilizer</en>

--- a/src/ResistanceBands.lua
+++ b/src/ResistanceBands.lua
@@ -58,28 +58,27 @@ end
 ---
 -- THE GATE, and its one known limitation, stated rather than hidden.
 --
--- The brief asks this gate to key on a FIELD-LEVEL "has this field ever been scouted"
--- signal, independent of the per-outbreak diseaseDiscovered flag. NO SUCH SIGNAL EXISTS in
--- the shipped source -- diseaseDiscovered is the only scout state a field carries, and it
--- resets on every fresh infection (SoilFertilitySystem.lua:2126, :2364). That is the
--- confirm the brief owed back to Engineering, and the answer is "there is none".
+-- The gate keys on the FIELD-LEVEL "has this field ever been scouted" signal,
+-- `fieldEverScouted`, which CD-11 adds beside the per-outbreak `diseaseDiscovered` flag.
+-- The two are different questions. diseaseDiscovered asks "is the CURRENT infection
+-- identified?" and resets on every fresh onset (SoilFertilitySystem outbreak paths), which
+-- is right for disease identity. Resistance history follows the ground and does not change
+-- when a new outbreak starts, so it must not go dark with it: fieldEverScouted is set once,
+-- by the server only, on the first successful scout of a known field, and no outbreak,
+-- debug-disease, crop-cycle, sale or reset path ever clears it.
 --
--- So this gate uses diseaseDiscovered ALONE. It deliberately does NOT copy getScoutReport's
--- published expression (`field.activeDisease and not field.diseaseDiscovered`), which the
--- brief names as inverted: a field with no active disease falls straight through that and
--- reads as fully scouted. Keying on diseaseDiscovered alone FAILS CLOSED instead -- an
--- unscouted field reads UNKNOWN whether or not it currently has a disease, which is the
--- hard obligation (the server must never send a clean-looking band for unscouted ground).
---
--- THE INHERITED DEFECT, flagged so it is not mistaken for correct: because
--- diseaseDiscovered resets on every fresh infection, a farmer's resistance history goes
--- DARK exactly when a new outbreak starts, even though resistance itself persists across
--- infections and has not changed. Over-hiding, never under-hiding. Fixing it means adding a
--- field-level scouted signal to CD-9's data model, which is not this brief's to extend.
+-- It deliberately does NOT read getScoutReport's published expression
+-- (`field.activeDisease and not field.diseaseDiscovered`), which is inverted: a field with
+-- no active disease falls straight through that and reads as scouted. Reading ONLY
+-- `fieldEverScouted == true` FAILS CLOSED instead -- a never-scouted field reads UNKNOWN
+-- whether or not it currently carries a disease, which is the hard obligation (the server
+-- must never publish a clean-looking band for ground nobody has looked at). A field that
+-- carries diseaseDiscovered without the durable bit (an optimistic client mark, or a save
+-- that pre-dates the key before migration seeds it) stays UNKNOWN until the server writes.
 ---@param field table
 ---@return boolean
 function ResistanceBands.isFieldRevealed(field)
-    return (field ~= nil) and (field.diseaseDiscovered == true)
+    return (field ~= nil) and (field.fieldEverScouted == true)
 end
 
 --- True when this machine owns the raw scores: the server, a listen-server host, or single
@@ -127,10 +126,18 @@ end
 --- Client-side: attach a decoded band list onto a field table so run()'s wholesale replace
 --- carries it. Mirrors OrganicCertification.applyFieldOrganic: a field with nothing to say
 --- keeps no sub-table, so the wire never resurrects one where the model would not.
+---
+--- Also stamps `resistanceBandsReceived = true` on the field BEFORE the empty test, so an
+--- empty payload still counts as a receipt: "the server told me there is nothing on this
+--- field" is a real answer and differs from "the server has not spoken yet". The bit is
+--- client-side ephemeral: never saved, never sent, never authored by the server. It lives
+--- only on the field table a decoder just built, so a wholesale replace resets it exactly
+--- when the picture it certifies is replaced.
 ---@param field table
 ---@param flat table|nil   flat { mode, band, ... } array as produced by encodeFieldBands
 function ResistanceBands.applyFieldBands(field, flat)
     if not field then return end
+    field.resistanceBandsReceived = true
     if type(flat) ~= "table" or #flat < 2 then
         field.resistanceBands = nil
         return
@@ -187,8 +194,9 @@ end
 ---   * server or single player -- computes from the raw score it owns;
 ---   * client -- reads the band the server sent, and NEVER computes one from a raw value.
 ---
---- Returns UNKNOWN, never nil, for unscouted ground, an unsynced field, or a mode with no
---- resistance yet. Callers must treat UNKNOWN as distinct from every real band.
+--- Returns UNKNOWN, never nil, for never-scouted ground, a pure-client field the server
+--- has not yet delivered, or an unknown field. A scouted field's mode with no resistance
+--- yet reads WORKING. Callers must treat UNKNOWN as distinct from every real band.
 ---@param field table|nil
 ---@param mode string
 ---@return number   a RESISTANCE.BANDS value
@@ -205,11 +213,15 @@ function ResistanceBands.getBand(field, mode)
         return ResistanceBands.computeBand(field, mode)
     end
 
-    -- Pure client, field revealed, no band sent for this mode. LOAD-BEARING COUPLING:
-    -- encodeFieldBands publishes every mode carrying resistance on a revealed field and is
-    -- bounded by the FRAC-group count, so it has no truncation path -- silence therefore
-    -- means "zero on that mode", not "not sent". Anything that ever makes the encoder drop
-    -- a non-zero mode (a payload budget, a partial update) MUST revisit this line, or a
-    -- burned-out mode would render as WORKING on every client.
+    -- Pure client, field revealed, no band sent for this mode. Two different silences:
+    --   * the server has not delivered this field yet (no receipt): the client knows
+    --     nothing and must say so. UNKNOWN, never a guessed WORKING.
+    --   * the server delivered and had no band for this mode: LOAD-BEARING COUPLING --
+    --     encodeFieldBands publishes every mode carrying resistance on a revealed field and
+    --     is bounded by the FRAC-group count, so it has no truncation path. Silence after a
+    --     receipt therefore means "zero on that mode", which bands WORKING. Anything that
+    --     ever makes the encoder drop a non-zero mode (a payload budget, a partial update)
+    --     MUST revisit this line, or a burned-out mode would render as WORKING on clients.
+    if field.resistanceBandsReceived ~= true then return BANDS.UNKNOWN end
     return BANDS.WORKING
 end

--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -2418,23 +2418,39 @@ end
 --- outbreak must be re-scouted. Server-authoritative in MP: a client marks it locally
 --- (optimistic - discovery is monotonic) and asks the server to make it authoritative and
 --- sync it farm-wide via the field-update broadcast.
+---
+--- CD-11 also records the durable `fieldEverScouted` bit here, and ONLY here. It is the
+--- gate the resistance readout reads (ResistanceBands.isFieldRevealed) and it outlives the
+--- per-outbreak diseaseDiscovered reset, so a farmer's resistance history stays visible
+--- through a new infection. It is written by the server alone: a client may reveal the
+--- disease optimistically but never sets the durable bit, which reaches it on the next
+--- field delivery. A client whose field is already revealed but still lacks the bit (an
+--- optimistic mark that never round-tripped) re-asks the server, which performs the
+--- durable write and one field update.
 ---@param fieldId number
 ---@return table|nil report  the now-revealed scout report
 function SoilFertilitySystem:scoutField(fieldId)
     local field = self.fieldData and self.fieldData[fieldId]
     if not field then return self:getScoutReport(fieldId) end
 
+    local changed = false
     if not field.diseaseDiscovered then
         field.diseaseDiscovered = true
-        if g_currentMission and g_currentMission.missionDynamicInfo
-           and g_currentMission.missionDynamicInfo.isMultiplayer then
-            if not g_server then
-                if SoilScoutFieldEvent then
-                    g_client:getServerConnection():sendEvent(SoilScoutFieldEvent.new(fieldId))
-                end
-            elseif SoilFieldUpdateEvent then
-                SoilNetworkEvents_BroadcastFieldUpdate(fieldId, field)
+        changed = true
+    end
+    if g_server ~= nil and field.fieldEverScouted ~= true then
+        field.fieldEverScouted = true
+        changed = true
+    end
+
+    if g_currentMission and g_currentMission.missionDynamicInfo
+       and g_currentMission.missionDynamicInfo.isMultiplayer then
+        if not g_server then
+            if SoilScoutFieldEvent and (changed or field.fieldEverScouted ~= true) then
+                g_client:getServerConnection():sendEvent(SoilScoutFieldEvent.new(fieldId))
             end
+        elseif changed and SoilFieldUpdateEvent then
+            SoilNetworkEvents_BroadcastFieldUpdate(fieldId, field)
         end
     end
     return self:getScoutReport(fieldId)
@@ -3378,6 +3394,7 @@ function SoilFertilitySystem:getOrCreateField(fieldId, createIfMissing, area)
         activeDisease = nil,        -- DISEASE_DEFS id of the current named infection (nil = none)
         activeDiseaseSeverity = 1.0,-- cached yield-severity multiplier for activeDisease
         diseaseDiscovered = false,  -- discovery gate: an active infection stays UNKNOWN in every scout report until deliberately scouted (or revealed by a future dog / ProStaff report)
+        fieldEverScouted = false,   -- CD-11: durable "this field has been scouted at least once". Server-written on the first successful scout; survives every outbreak reset (resistance history follows the ground, disease identity does not)
         lastFungicide = nil,        -- last chemical applied (for resistance / UI flavor)
         resistance = {},            -- CD-9: { [mode] = score 0..max } per-MOA resistance scores
         dryDayCount = 0,
@@ -7212,6 +7229,7 @@ function SoilFertilitySystem:saveToXMLFile(xmlFile, key)
             setXMLInt(xmlFile, fieldKey .. "#fungicideDaysLeft", field.fungicideDaysLeft or 0)
             setXMLString(xmlFile, fieldKey .. "#activeDisease", field.activeDisease or "")
             setXMLInt(xmlFile, fieldKey .. "#diseaseDiscovered", field.diseaseDiscovered and 1 or 0)
+            setXMLInt(xmlFile, fieldKey .. "#fieldEverScouted", field.fieldEverScouted and 1 or 0)  -- CD-11 durable scout bit
             setXMLString(xmlFile, fieldKey .. "#lastFungicide", field.lastFungicide or "")
             -- CD-10 re-onset cooldown. Persisted because a cooldown a save-and-reload
             -- defeats is not a cooldown -- it would silently do nothing. Server-side only;
@@ -7355,6 +7373,17 @@ function SoilFertilitySystem:loadFromXMLFile(xmlFile, key)
             activeDisease = getXMLString(xmlFile, fieldKey .. "#activeDisease"),
             activeDiseaseSeverity = 1.0,
             diseaseDiscovered = (getXMLInt(xmlFile, fieldKey .. "#diseaseDiscovered") or 0) == 1,
+            -- CD-11 durable scout bit, three states on load. Present 1/0 is the truth as
+            -- saved. ABSENT is a save from before the key existed: a field that was already
+            -- scouted then (diseaseDiscovered saved as 1) seeds true so its resistance
+            -- history does not go dark on upgrade; every other absence is false. This is
+            -- deliberately NOT `or false`, which would collapse absent and false together
+            -- and lose the seed.
+            fieldEverScouted = (function()
+                local v = getXMLInt(xmlFile, fieldKey .. "#fieldEverScouted")
+                if v ~= nil then return v == 1 end
+                return (getXMLInt(xmlFile, fieldKey .. "#diseaseDiscovered") or 0) == 1
+            end)(),
             lastFungicide = getXMLString(xmlFile, fieldKey .. "#lastFungicide"),
             hybridBlockedUntilDay = getXMLInt(xmlFile, fieldKey .. "#hybridBlockedUntilDay"),
             -- CD-9: Deserialize per-MOA resistance from comma-separated mode:score pairs
@@ -7598,6 +7627,7 @@ function SoilFertilitySystem:getSoilStateTable()
                 fungicideDaysLeft     = field.fungicideDaysLeft or 0,
                 activeDisease         = field.activeDisease or "",
                 diseaseDiscovered     = field.diseaseDiscovered or false,
+                fieldEverScouted      = field.fieldEverScouted == true,   -- CD-11 durable scout bit
                 lastFungicide         = field.lastFungicide or "",
                 hybridBlockedUntilDay = field.hybridBlockedUntilDay,   -- CD-10 re-onset cooldown
                 dryDayCount           = field.dryDayCount or 0,
@@ -7706,6 +7736,12 @@ function SoilFertilitySystem:applySoilStateTable(data)
                 activeDisease         = e.activeDisease,
                 activeDiseaseSeverity = 1.0,
                 diseaseDiscovered     = e.diseaseDiscovered or false,
+                -- CD-11 durable scout bit, three states (same rule as the XML route):
+                -- present true/false is the truth; absent seeds from diseaseDiscovered.
+                fieldEverScouted      = (function()
+                    if e.fieldEverScouted ~= nil then return e.fieldEverScouted == true end
+                    return e.diseaseDiscovered == true
+                end)(),
                 lastFungicide         = e.lastFungicide,
                 hybridBlockedUntilDay = e.hybridBlockedUntilDay,   -- CD-10 re-onset cooldown
                 resistance = (function() local rt = {}; if e.resistance and type(e.resistance) == "table" then for k, v in pairs(e.resistance) do rt[k] = v end end; return rt end)(),

--- a/src/integrations/SoilNetworkSyncBridge.lua
+++ b/src/integrations/SoilNetworkSyncBridge.lua
@@ -97,7 +97,7 @@ end
 --   fieldId, <each SCALARS value>, lastCrop, lastCrop2, lastCrop3, activeDisease,
 --   bufferCount, bufferCount x (fillTypeIndex, amount),
 --   organicState, organicStartDay, organicCertifiedDay, organicBreaches,
---   diseaseDiscovered, bandCount, bandCount x (fracMode, band)
+--   diseaseDiscovered, bandCount, bandCount x (fracMode, band), fieldEverScouted
 function SoilNetworkSyncBridge.serializeFields(fieldData)
     local arr = { 0 }   -- slot 1 reserved for the count
     local n = 0
@@ -148,6 +148,8 @@ function SoilNetworkSyncBridge.serializeFields(fieldData)
         local bandFlat = ResistanceBands.encodeFieldBands(field)
         arr[#arr + 1] = math.floor(#bandFlat / 2)
         for _, v in ipairs(bandFlat) do arr[#arr + 1] = v end
+        -- CD-11: the durable scout bit rides after the bands, same order as NetworkEvents.
+        arr[#arr + 1] = field.fieldEverScouted and 1 or 0
     end
     arr[1] = n
     return arr
@@ -213,6 +215,8 @@ function SoilNetworkSyncBridge.deserializeFields(arr)
             bandFlat[#bandFlat + 1] = arr[i]; i = i + 1
         end
         ResistanceBands.applyFieldBands(field, bandFlat)
+        -- CD-11 durable scout bit, read right after the bands and put on the new table.
+        field.fieldEverScouted = (tonumber(arr[i]) or 0) == 1; i = i + 1
 
         out[fieldId] = field
     end

--- a/src/network/NetworkEvents.lua
+++ b/src/network/NetworkEvents.lua
@@ -443,6 +443,7 @@ function SoilFullSyncEvent:readStream(streamId, connection)
         local orgBreach = streamReadInt32(streamId)
         -- CD-11 bands (consume unconditionally to keep the stream aligned)
         local resBands  = ResistanceBands.readStream(streamId)
+        local everScouted = streamReadBool(streamId)   -- CD-11 durable scout bit, right after the bands
 
         -- Validate and sanitize field data
         local function validateNumber(value, min, max, default, name)
@@ -495,6 +496,7 @@ function SoilFullSyncEvent:readStream(streamId, connection)
                 activeDisease = activeDisease,
                 activeDiseaseSeverity = (activeDisease and SoilDiseaseSystem) and SoilDiseaseSystem.yieldSeverity(activeDisease) or 1.0,
                 diseaseDiscovered = diseaseDiscovered or false,
+                fieldEverScouted = everScouted == true,
                 dryDayCount = dryDays,
                 burnDaysLeft = burnDays,
                 coverageFraction = math.max(0, math.min(1, coverageFrac or 0)),
@@ -592,6 +594,8 @@ function SoilFullSyncEvent:writeStream(streamId, connection)
 
         -- CD-11: per-mode resistance bands (server-computed; never a raw score).
         ResistanceBands.writeStream(streamId, field)
+        -- CD-11: the durable scout bit rides after the bands on every field delivery.
+        streamWriteBool(streamId, field.fieldEverScouted == true)
     end
 end
 
@@ -751,6 +755,8 @@ function SoilFieldBatchSyncEvent:writeStream(streamId, connection)
 
         -- CD-11: per-mode resistance bands (server-computed; never a raw score).
         ResistanceBands.writeStream(streamId, field)
+        -- CD-11: the durable scout bit rides after the bands on every field delivery.
+        streamWriteBool(streamId, field.fieldEverScouted == true)
     end
 end
 
@@ -827,6 +833,7 @@ function SoilFieldBatchSyncEvent:readStream(streamId, connection)
         local orgBreach = streamReadInt32(streamId)
         -- CD-11 bands (consume unconditionally to keep the stream aligned)
         local resBands  = ResistanceBands.readStream(streamId)
+        local everScouted = streamReadBool(streamId)   -- CD-11 durable scout bit, right after the bands
 
         if type(fieldId) == "number" and fieldId >= 0 then
             self.batchFields[fieldId] = {
@@ -851,6 +858,7 @@ function SoilFieldBatchSyncEvent:readStream(streamId, connection)
                 activeDisease         = activeDisease,
                 activeDiseaseSeverity = (activeDisease and SoilDiseaseSystem) and SoilDiseaseSystem.yieldSeverity(activeDisease) or 1.0,
                 diseaseDiscovered     = diseaseDiscovered or false,
+                fieldEverScouted      = everScouted == true,
                 dryDayCount           = math.max(0, dryDays),
                 burnDaysLeft          = math.max(0, burnDays),
                 nutrientBuffer        = buffer,
@@ -1050,6 +1058,7 @@ function SoilFieldUpdateEvent:readStream(streamId, connection)
     local orgCert   = streamReadInt32(streamId)
     local orgBreach = streamReadInt32(streamId)
     local resBands  = ResistanceBands.readStream(streamId)
+    local everScouted = streamReadBool(streamId)   -- CD-11 durable scout bit, right after the bands
 
     -- Clamp all values to valid ranges
     self.field = {
@@ -1079,6 +1088,7 @@ function SoilFieldUpdateEvent:readStream(streamId, connection)
         activeDisease = activeDisease,
         activeDiseaseSeverity = (activeDisease and SoilDiseaseSystem) and SoilDiseaseSystem.yieldSeverity(activeDisease) or 1.0,
         diseaseDiscovered = diseaseDiscovered or false,
+        fieldEverScouted = everScouted == true,
         dryDayCount = math.max(0, dryDays),
         burnDaysLeft = math.max(0, burnDays),
         nutrientBuffer   = buffer,
@@ -1168,6 +1178,8 @@ function SoilFieldUpdateEvent:writeStream(streamId, connection)
     -- run() replaces the client's field table wholesale, so a value that does not travel
     -- is a value that gets wiped. Server-computed; a raw score never goes on the wire.
     ResistanceBands.writeStream(streamId, self.field)
+    -- CD-11: the durable scout bit rides after the bands (same order as the full/batch sync).
+    streamWriteBool(streamId, self.field.fieldEverScouted == true)
 end
 
 function SoilFieldUpdateEvent:run(connection)

--- a/src/settings/SoilSettingsGUI.lua
+++ b/src/settings/SoilSettingsGUI.lua
@@ -937,15 +937,25 @@ function SoilSettingsGUI:consoleCommandResistance(fieldId)
 
     local R = SoilConstants.RESISTANCE
     local lines = {}
-    lines[#lines+1] = string.format("=== Resistance (CD-9) -- Field %d ===", fid)
-    lines[#lines+1] = string.format("Scouted: %s%s",
-        field.diseaseDiscovered and "YES" or "NO",
-        field.diseaseDiscovered and "" or "  <- bands are gated; everything reads UNKNOWN until you SoilScout")
+    lines[#lines+1] = string.format("=== Resistance (CD-9 / CD-11) -- Field %d ===", fid)
+    -- CD-11: the reveal gate is the durable server bit, not the per-outbreak flag.
+    local everScouted = field.fieldEverScouted == true
+    lines[#lines+1] = string.format("Scouted: %s  (fieldEverScouted = %s, the durable bit the bands gate on)%s",
+        everScouted and "YES" or "NO", tostring(everScouted),
+        everScouted and "" or "  <- bands are gated; everything reads UNKNOWN until the server records a SoilScout")
+    lines[#lines+1] = string.format("Disease discovered: %s  (diseaseDiscovered, resets per outbreak; does not gate bands)",
+        field.diseaseDiscovered and "YES" or "NO")
     lines[#lines+1] = string.format("Field area: %.2f ha", field.fieldArea or 0)
-    lines[#lines+1] = string.format("Picture: %s",
-        ResistanceBands.hasServerPicture() and "server/SP (raw scores local)" or "client (bands synced from server)")
+    local serverPicture = ResistanceBands.hasServerPicture()
+    if serverPicture then
+        lines[#lines+1] = "Picture: server/SP (raw scores local)"
+    else
+        lines[#lines+1] = string.format("Picture: client (bands synced from server) -- bands %s",
+            field.resistanceBandsReceived == true
+                and "RECEIVED (a silent mode reads WORKING)"
+                or "WAITING (no field delivery yet; every mode reads UNKNOWN)")
+    end
     lines[#lines+1] = ""
-    lines[#lines+1] = "MODE  SCORE/MAX      RATIO   BAND       NEXT SPRAY   CHEMICALS"
 
     -- Walk the FRAC modes the mod actually knows about, so a clean mode still shows.
     local seen, modes = {}, {}
@@ -955,16 +965,29 @@ function SoilSettingsGUI:consoleCommandResistance(fieldId)
     end
     table.sort(modes)
 
-    for _, mode in ipairs(modes) do
-        local ceiling = ResistanceBands.ceilingForMode(mode)
-        local score   = (type(field.resistance) == "table" and field.resistance[mode]) or 0
-        local ratio   = score / ceiling
-        local band    = soilSys:getResistanceBand(fid, mode)
-        -- The CD-9 penalty a spray of this mode would take right now.
-        local mult    = 1 - (score / ceiling)
-        lines[#lines+1] = string.format("%-5s %6.3f/%-6.1f %5.0f%%   %-9s x%.2f        %s",
-            mode, score, ceiling, ratio * 100,
-            RESISTANCE_BAND_NAMES[band] or "?", mult, chemicalsForMode(mode))
+    if serverPicture then
+        lines[#lines+1] = "MODE  SCORE/MAX      RATIO   BAND       NEXT SPRAY   CHEMICALS"
+        for _, mode in ipairs(modes) do
+            local ceiling = ResistanceBands.ceilingForMode(mode)
+            local score   = (type(field.resistance) == "table" and field.resistance[mode]) or 0
+            local ratio   = score / ceiling
+            local band    = soilSys:getResistanceBand(fid, mode)
+            -- The CD-9 penalty a spray of this mode would take right now.
+            local mult    = 1 - (score / ceiling)
+            lines[#lines+1] = string.format("%-5s %6.3f/%-6.1f %5.0f%%   %-9s x%.2f        %s",
+                mode, score, ceiling, ratio * 100,
+                RESISTANCE_BAND_NAMES[band] or "?", mult, chemicalsForMode(mode))
+        end
+    else
+        -- A pure client holds bands only. No score, ratio or next-spray column is invented
+        -- from a zero the server never sent; the public getter is the whole picture here.
+        lines[#lines+1] = "MODE  BAND       CHEMICALS"
+        for _, mode in ipairs(modes) do
+            local band = soilSys:getResistanceBand(fid, mode)
+            lines[#lines+1] = string.format("%-5s %-9s  %s",
+                mode, RESISTANCE_BAND_NAMES[band] or "?", chemicalsForMode(mode))
+        end
+        lines[#lines+1] = "(raw scores, ratios and next-spray multipliers stay on the server)"
     end
 
     lines[#lines+1] = ""

--- a/src/ui/RfPdaSoilPanel.lua
+++ b/src/ui/RfPdaSoilPanel.lua
@@ -59,7 +59,7 @@ local function resolveFarmId()
     return farmId
 end
 
-local function appendFieldEntry(page, sfm, fieldId)
+local function appendFieldEntry(page, sfm, fieldId, eligible)
     local ok, info = pcall(function()
         return sfm.soilSystem:getFieldInfo(fieldId)
     end)
@@ -77,6 +77,10 @@ local function appendFieldEntry(page, sfm, fieldId)
         fieldId = fieldId,
         info = info,
         urgency = urgency or 0,
+        -- CD-11 3.5: only rows from the owned roster may carry the resistance section.
+        -- The all-fields fallback below is a diagnostic view of foreign ground and is
+        -- appended with eligible = false, so the card stays down for it.
+        resistanceEligible = eligible == true,
     })
 end
 
@@ -96,6 +100,9 @@ end
 ---@param page table RfPdaMenuPage instance
 function RfPdaSoilPanel.rebuildFieldData(page)
     page.fieldData = {}
+    -- Panel show / roster rebuild: the resistance card re-reads on its next paint even
+    -- when the selected field id has not moved (the bands may have, e.g. after a scout).
+    page._resistanceDirty = true
     local sfm = g_SoilFertilityManager
     if sfm == nil and type(getfenv) == "function" then
         local env0 = getfenv(0)
@@ -119,14 +126,14 @@ function RfPdaSoilPanel.rebuildFieldData(page)
         for fieldId, _ in pairs(sfm.soilSystem.fieldData) do
             local owner = g_farmlandManager:getFarmlandOwner(fieldId)
             if owner == farmId then
-                appendFieldEntry(page, sfm, fieldId)
+                appendFieldEntry(page, sfm, fieldId, true)
             end
         end
     end
 
     if #page.fieldData == 0 then
         for fieldId, _ in pairs(sfm.soilSystem.fieldData) do
-            appendFieldEntry(page, sfm, fieldId)
+            appendFieldEntry(page, sfm, fieldId, false)
         end
         if usedOwnedFilter and #page.fieldData > 0 then
             local msg = string.format(
@@ -548,6 +555,272 @@ function RfPdaSoilPanel.refreshRotationCard(page, entry)
     set(tipEl, tip)
 end
 
+-- ── CD-11 resistance readout (BUILD 10:52, George DESIGN 10:40) ──────────────
+--
+-- Read-only band card in the TREATMENT strip, under the three existing cards. It paints
+-- on panel show and on owned-field select only: the host re-runs refreshTreatmentPlan on
+-- its 2 s tick, so the painter remembers what it last painted and returns before any band
+-- work unless the selection moved or rebuildFieldData flagged it dirty.
+--
+-- Bands come from the public getters only (SoilFertilitySystem:getResistanceBand /
+-- getResistanceBandForChemical, modes via getModeForFillType). Raw scores, ratios and
+-- next-spray multipliers never enter this file. Meanings are fixed: UNKNOWN = not yet
+-- known, WORKING = good control, SLIPPING = reduced control, FINISHED = no control, and
+-- UNKNOWN never borrows the good-control colour. Nothing here ranks, buys, mixes, applies
+-- or writes; the only durable write in CD-11 is the server's scout bit in scoutField.
+
+local COLOR_HINT = {0.659, 0.678, 0.702, 1.0}   -- RF_HintText's own grey, for resets
+local RES_MAX_CHIPS = 7                          -- seven FRAC groups across eight jugs
+
+local function resistanceBandIds()
+    local B = SoilConstants and SoilConstants.RESISTANCE and SoilConstants.RESISTANCE.BANDS
+    if B ~= nil then return B end
+    return { UNKNOWN = -1, WORKING = 0, SLIPPING = 1, FINISHED = 2 }
+end
+
+--- The Soil manager and system, or nil when the section must stand down: manager absent,
+--- getter missing (an older Soil), Soil switched off, or Soil disabled by Precision Farming.
+--- No PF hook: the stand-down rides Soil's own flags.
+local function resistanceSource()
+    local sfm = g_currentMission and g_currentMission.soilFertilityManager
+    local sys = sfm and sfm.soilSystem
+    if sys == nil or type(sys.getResistanceBand) ~= "function" then return nil end
+    if sfm.settings ~= nil and sfm.settings.enabled == false then return nil end
+    if sfm._disabledByPF then return nil end
+    return sfm, sys
+end
+
+--- Player-facing chemical name via the existing sf_chem_<ID> keys (same as SoilScoutDialog).
+local function chemDisplayName(id)
+    if g_i18n ~= nil and g_i18n.hasText and g_i18n:hasText("sf_chem_" .. id) then
+        return g_i18n:getText("sf_chem_" .. id)
+    end
+    local s = string.lower(tostring(id)):gsub("_", " ")
+    return (s:gsub("(%a)([%w]*)", function(a, b) return string.upper(a) .. b end))
+end
+
+--- The modes the mod knows, in PHYSICAL_FUNGICIDE_ORDER first-seen order, each with the
+--- physical products that use it. Product vocabulary stays primary; the mode is its label.
+local function resistanceModeRows()
+    local rows, byMode = {}, {}
+    local order = SoilConstants and SoilConstants.PHYSICAL_FUNGICIDE_ORDER or {}
+    local getMode = SoilFertilitySystem and SoilFertilitySystem.getModeForFillType
+    if type(getMode) ~= "function" then return rows end
+    for _, id in ipairs(order) do
+        local mode = getMode(id)
+        if mode ~= nil then
+            local row = byMode[mode]
+            if row == nil then
+                row = { mode = mode, products = {} }
+                byMode[mode] = row
+                rows[#rows + 1] = row
+            end
+            row.products[#row.products + 1] = id
+        end
+    end
+    return rows
+end
+
+local function bandWord(tr, band)
+    local B = resistanceBandIds()
+    if band == B.WORKING then
+        return tr("sf_res_band_working", "Good control"), COLOR_GOOD
+    elseif band == B.SLIPPING then
+        return tr("sf_res_band_slipping", "Reduced control"), COLOR_FAIR
+    elseif band == B.FINISHED then
+        return tr("sf_res_band_finished", "No control"), COLOR_POOR
+    end
+    return tr("sf_res_band_unknown", "Not yet known"), COLOR_DIM
+end
+
+local function resEl(page, id)
+    local el = page[id]
+    if el == nil and page.getDescendantById then
+        el = page:getDescendantById(id)
+    end
+    return el
+end
+
+local function setTextColored(el, text, color)
+    if el == nil then return end
+    if el.setText then el:setText(text or "") end
+    if color ~= nil and el.setTextColor then el:setTextColor(unpack(color)) end
+end
+
+--- Paint the resistance card for the selected entry. Never throws past its caller: the
+--- host wraps it in pcall the same way it wraps the rotation card, and PRODUCTS paints on.
+---@param page table RfPdaMenuPage instance (may be a thin door without the card ids)
+---@param entry table|nil selected field entry from page.fieldData
+function RfPdaSoilPanel.refreshResistanceCard(page, entry)
+    if page == nil then return end
+    local cardEl = resEl(page, "soilResistanceCard")
+    if cardEl == nil then
+        -- Thin doors, or a door built from another mod's copy of RfPdaMenuPage.xml.
+        if not page._resistanceCardWarned then
+            page._resistanceCardWarned = true
+            print("[SoilFertilizer] resistance card ids absent on this door - skipping card (PRODUCTS unaffected)")
+        end
+        return
+    end
+
+    local fieldId  = entry and entry.fieldId or nil
+    local eligible = entry ~= nil and entry.resistanceEligible == true and fieldId ~= nil
+    local key      = eligible and fieldId or false
+
+    -- Timer fence: same field, nothing flagged dirty -> no band work at all.
+    if page._resistancePaintedKey == key and not page._resistanceDirty then return end
+    page._resistancePaintedKey = key
+    page._resistanceDirty = false
+
+    local sfm, sys = resistanceSource()
+    if not eligible or sys == nil then
+        if cardEl.setVisible then cardEl:setVisible(false) end
+        return
+    end
+    if cardEl.setVisible then cardEl:setVisible(true) end
+
+    local tr = page._rfTr or function(k, fb) return fb or k end
+    setTextColored(resEl(page, "soilResistanceTitle"), tr("sf_res_title", "Resistance"))
+    setTextColored(resEl(page, "soilResistanceNote"),
+        tr("sf_res_note", "Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area."))
+    local btn = resEl(page, "soilResistancePairsBtn")
+    if btn ~= nil and btn.setText then btn:setText(tr("sf_res_pairs_btn", "Tank pairs")) end
+
+    -- Knowledge state. Revealed is the durable server bit only (ResistanceBands.isFieldRevealed);
+    -- a pure client that has not had its first field delivery yet is told it is waiting rather
+    -- than being shown "not yet known" as if nobody had ever scouted.
+    local field    = sys.fieldData and sys.fieldData[fieldId]
+    local revealed = ResistanceBands ~= nil and type(ResistanceBands.isFieldRevealed) == "function"
+        and ResistanceBands.isFieldRevealed(field) == true
+    local pureClient = not (ResistanceBands ~= nil and type(ResistanceBands.hasServerPicture) == "function"
+        and ResistanceBands.hasServerPicture())
+    local stateText, stateColor
+    if pureClient and (field == nil or field.resistanceBandsReceived ~= true) then
+        stateText  = string.format(tr("sf_res_state_waiting", "Field %d: waiting for the server's resistance picture."), fieldId)
+        stateColor = COLOR_FAIR
+    elseif revealed then
+        stateText  = string.format(tr("sf_res_state_known", "Field %d: resistance history known."), fieldId)
+        stateColor = COLOR_HINT
+    else
+        stateText  = string.format(tr("sf_res_state_unknown", "Field %d: resistance not yet known. Scout this field to learn its history."), fieldId)
+        stateColor = COLOR_DIM
+    end
+    setTextColored(resEl(page, "soilResistanceState"), stateText, stateColor)
+
+    -- One chip per mode: header "Mode 3", the products that use it, and the band word.
+    local rows = resistanceModeRows()
+    for i = 1, RES_MAX_CHIPS do
+        local head = resEl(page, "soilResMode" .. i .. "Head")
+        local prod = resEl(page, "soilResMode" .. i .. "Prod")
+        local band = resEl(page, "soilResMode" .. i .. "Band")
+        local row  = rows[i]
+        if row == nil then
+            setTextColored(head, "")
+            setTextColored(prod, "")
+            setTextColored(band, "")
+        else
+            local names = {}
+            for _, id in ipairs(row.products) do names[#names + 1] = chemDisplayName(id) end
+            local value = sys:getResistanceBand(fieldId, row.mode)
+            local word, color = bandWord(tr, value)
+            setTextColored(head, string.format(tr("sf_res_mode", "Mode %s"), tostring(row.mode)))
+            setTextColored(prod, table.concat(names, ", "))
+            setTextColored(band, word, color)
+        end
+    end
+end
+
+--- Inspectable pair context (George: disclosure, not a second list of all 28 blends).
+--- One line per physical product: its mode, this field's band for it, and the partners the
+--- blend table allows, with the organic-approved pairs marked by APPROVED_INPUTS membership
+--- only. Reads getters and the tables; ranks, buys, mixes and applies nothing.
+---@param page table RfPdaMenuPage instance
+function RfPdaSoilPanel.showResistancePairs(page)
+    if page == nil then return end
+    local tr = page._rfTr or function(k, fb) return fb or k end
+    local entry = nil
+    for _, e in ipairs(page.fieldData or {}) do
+        if e.fieldId == page.selectedFieldId then entry = e; break end
+    end
+    local text
+    local _, sys = resistanceSource()
+    if entry == nil or entry.resistanceEligible ~= true or sys == nil then
+        text = tr("sf_res_pairs_no_field", "Select one of your fields first.")
+    else
+        local fieldId = entry.fieldId
+        local lines = {
+            string.format(tr("sf_res_pairs_title", "Tank pairs for field %d"), fieldId),
+            tr("sf_res_pairs_intro", "Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes."),
+            "",
+        }
+        local products = SoilConstants and SoilConstants.PHYSICAL_FUNGICIDE_ORDER or {}
+        local approved = SoilConstants and SoilConstants.ORGANIC and SoilConstants.ORGANIC.APPROVED_INPUTS or {}
+        local partners = {}
+        local blendsOk = SoilBlends ~= nil and type(SoilBlends.ORDER) == "table" and type(SoilBlends.getPartners) == "function"
+        if blendsOk then
+            for _, key in ipairs(SoilBlends.ORDER) do
+                local pair = SoilBlends.getPartners(key)
+                if type(pair) == "table" and pair[1] ~= nil and pair[2] ~= nil then
+                    local organic = approved[key] == true
+                    partners[pair[1]] = partners[pair[1]] or {}
+                    partners[pair[2]] = partners[pair[2]] or {}
+                    table.insert(partners[pair[1]], { id = pair[2], organic = organic })
+                    table.insert(partners[pair[2]], { id = pair[1], organic = organic })
+                end
+            end
+        end
+        local getMode = SoilFertilitySystem and SoilFertilitySystem.getModeForFillType
+        for _, id in ipairs(products) do
+            local mode = type(getMode) == "function" and getMode(id) or nil
+            local word = bandWord(tr, sys:getResistanceBandForChemical(fieldId, id))
+            local list = partners[id] or {}
+            local withText
+            if not blendsOk then
+                withText = tr("sf_res_pairs_none", "pair table not loaded")
+            elseif #list == 0 then
+                withText = tr("sf_res_pairs_nothing", "no listed partner")
+            elseif #list >= #products - 1 then
+                local organicNames = {}
+                for _, p in ipairs(list) do
+                    if p.organic then organicNames[#organicNames + 1] = chemDisplayName(p.id) end
+                end
+                withText = tr("sf_res_pairs_all", "every other fungicide")
+                if #organicNames > 0 then
+                    withText = withText .. " (" .. tr("sf_res_pairs_organic", "organic pair") .. ": "
+                        .. table.concat(organicNames, ", ") .. ")"
+                end
+            else
+                local names = {}
+                for _, p in ipairs(list) do
+                    local n = chemDisplayName(p.id)
+                    if p.organic then n = n .. " (" .. tr("sf_res_pairs_organic", "organic pair") .. ")" end
+                    names[#names + 1] = n
+                end
+                withText = table.concat(names, ", ")
+            end
+            lines[#lines + 1] = string.format(tr("sf_res_pairs_line", "%s (mode %s): %s. Pairs with %s."),
+                chemDisplayName(id), tostring(mode or "?"), word, withText)
+        end
+        text = table.concat(lines, "\n")
+    end
+    if InfoDialog ~= nil and type(InfoDialog.show) == "function" then
+        InfoDialog.show(text)
+    elseif g_gui ~= nil and g_gui.showInfoDialog then
+        g_gui:showInfoDialog({ text = text })
+    end
+end
+
+-- The page class is sourced after this file (src/main.lua order) and opens with
+-- `RfPdaMenuPage = RfPdaMenuPage or {}`, so a method placed on the table here survives.
+-- The XML resolves onClick names against the page target when the door is built
+-- (GuiElement:addCallback), long after every sourceFile has run, so the button finds it.
+RfPdaMenuPage = RfPdaMenuPage or {}
+function RfPdaMenuPage:onClickSoilResistancePairs()
+    if RfPdaSoilPanel ~= nil and type(RfPdaSoilPanel.showResistancePairs) == "function" then
+        RfPdaSoilPanel.showResistancePairs(self)
+    end
+end
+
 function RfPdaSoilPanel.refreshTreatmentPlan(page)
     local tr = page._rfTr or function(k, fb) return fb or k end
     local fieldId = page.selectedFieldId
@@ -571,6 +844,16 @@ function RfPdaSoilPanel.refreshTreatmentPlan(page)
         if not okCard and not page._rotationCardErrLogged then
             page._rotationCardErrLogged = true
             print("[SoilFertilizer] rotation card paint failed (PRODUCTS continues): " .. tostring(errCard))
+        end
+    end
+
+    -- CD-11 resistance card (BUILD 10:52). Same guard shape: a painter fault must never
+    -- take PRODUCTS down. Runs on nil entries too so the card hides when nothing is selected.
+    if type(RfPdaSoilPanel.refreshResistanceCard) == "function" then
+        local okRes, errRes = pcall(RfPdaSoilPanel.refreshResistanceCard, page, entry)
+        if not okRes and not page._resistanceCardErrLogged then
+            page._resistanceCardErrLogged = true
+            print("[SoilFertilizer] resistance card paint failed (PRODUCTS continues): " .. tostring(errRes))
         end
     end
 

--- a/tools/test/lua/network_events_roundtrip_test.lua
+++ b/tools/test/lua/network_events_roundtrip_test.lua
@@ -38,6 +38,9 @@ local function sampleField()
     coverageFraction = 0.5, compaction = 11,
     nutrientBuffer = { [12] = 4.5, [3] = 1.25 },
     activeDisease = "septoria", diseaseDiscovered = true,
+    -- CD-11: the durable scout bit is the band gate now (diseaseDiscovered alone no longer
+    -- reveals), and it must ride every field delivery after the bands.
+    fieldEverScouted = true,
     organic = { state = SoilConstants.ORGANIC.STATE_CERTIFIED, startDay = 100, certifiedDay = 220, breaches = 2 },
     -- CD-11: a saturated synthetic (10/10 -> FINISHED) and a natural at 70% of its own
     -- lower ceiling (3.5/5 -> SLIPPING). The natural is here on purpose: banded against
@@ -72,6 +75,8 @@ local function assertSampleField(name, b)
   T.eq(name .. ": fungicideDaysLeft", b.fungicideDaysLeft, 4)
   T.eq(name .. ": activeDisease", b.activeDisease, "septoria")
   T.ok(name .. ": diseaseDiscovered", b.diseaseDiscovered == true)
+  T.ok(name .. ": CD-11 fieldEverScouted survives after the bands", b.fieldEverScouted == true)
+  T.ok(name .. ": CD-11 receipt is stamped on the delivered table", b.resistanceBandsReceived == true)
   T.ok(name .. ": buffer present", b.nutrientBuffer ~= nil)
   T.near(name .. ": buffer[12]", b.nutrientBuffer[12], 4.5)
   T.near(name .. ": buffer[3]", b.nutrientBuffer[3], 1.25)

--- a/tools/test/lua/networksync_roundtrip_test.lua
+++ b/tools/test/lua/networksync_roundtrip_test.lua
@@ -24,6 +24,7 @@ do
       -- CD-11: the discovery flag (previously dropped by this bridge) and the bands whose
       -- gate reads it. M2 is natural, so 3.5 of ITS ceiling (5) is SLIPPING, not WORKING.
       diseaseDiscovered = true,
+      fieldEverScouted = true,   -- CD-11: the durable scout bit gates the bands and rides last
       resistance = { ["3"] = 10, ["M2"] = 3.5 },
       -- zoneData present on the server but deliberately not serialized:
       zoneData = { ["3_4"] = { N = 50 } },
@@ -63,6 +64,8 @@ do
   T.eq("roundtrip: CD-11 natural band survives on its OWN ceiling",
        b.resistanceBands and b.resistanceBands["M2"], SoilConstants.RESISTANCE.BANDS.SLIPPING)
   T.ok("roundtrip: no raw resistance score crossed the bridge", b.resistance == nil)
+  T.eq("roundtrip: CD-11 fieldEverScouted survives the bridge after the bands", b.fieldEverScouted, true)
+  T.ok("roundtrip: CD-11 receipt is stamped on the delivered table", b.resistanceBandsReceived == true)
   T.eq("roundtrip: dryDayCount", b.dryDayCount, 6)
   T.eq("roundtrip: burnDaysLeft", b.burnDaysLeft, 2)
   T.near("roundtrip: coverageFraction", b.coverageFraction, 0.5)

--- a/tools/test/lua/resistance_bands_cd11_test.lua
+++ b/tools/test/lua/resistance_bands_cd11_test.lua
@@ -6,14 +6,19 @@
 --   * the server bands, the client reads; a raw score never crosses the wire
 --   * UNKNOWN is a value, not an absence, and never degrades to WORKING
 --   * unscouted ground never publishes a band at all
+--   * the gate is the durable fieldEverScouted bit, not the per-outbreak diseaseDiscovered
+--     flag, so resistance history survives a fresh infection
+--   * a pure client reads UNKNOWN until the server has delivered the field once
 --!load: src/utils/Logger.lua, src/config/Constants.lua, src/config/SoilBlends.lua, src/ReleaseGate.lua, src/SoilFertilitySystem.lua, src/ResistanceBands.lua, src/HybridStrains.lua
 
 local R  = SoilConstants.RESISTANCE
 local B  = R.BANDS
 local RB = ResistanceBands
 
+-- A revealed field carries the DURABLE scout bit. diseaseDiscovered is set too because
+-- that is what a freshly scouted field looks like, but it is not what the gate reads.
 local function revealed(resistance)
-  return { diseaseDiscovered = true, resistance = resistance or {} }
+  return { diseaseDiscovered = true, fieldEverScouted = true, resistance = resistance or {} }
 end
 
 -- ── The natural/synthetic ceiling split. This is the brief's own pseudocode bug: it says
@@ -68,9 +73,9 @@ end
 -- getScoutReport's `activeDisease and not diseaseDiscovered` lets a disease-free field
 -- fall through and read as scouted.
 do
-  local unscoutedInfected = { diseaseDiscovered = false, activeDisease = "rust",
+  local unscoutedInfected = { diseaseDiscovered = false, fieldEverScouted = false, activeDisease = "rust",
                               resistance = { ["3"] = R.MAX_SYNTHETIC } }
-  local unscoutedClean    = { diseaseDiscovered = false, activeDisease = nil,
+  local unscoutedClean    = { diseaseDiscovered = false, fieldEverScouted = false, activeDisease = nil,
                               resistance = { ["3"] = R.MAX_SYNTHETIC } }
 
   T.eq("gate: unscouted + infected reads UNKNOWN", RB.computeBand(unscoutedInfected, "3"), B.UNKNOWN)
@@ -80,6 +85,25 @@ do
   T.eq("gate: a nil field reads UNKNOWN", RB.getBand(nil, "3"), B.UNKNOWN)
   T.ok("gate: UNKNOWN is distinct from every real band",
        B.UNKNOWN ~= B.WORKING and B.UNKNOWN ~= B.SLIPPING and B.UNKNOWN ~= B.FINISHED)
+
+  -- The gate is the DURABLE bit. diseaseDiscovered alone (an optimistic client mark, or a
+  -- record the migration has not seeded) does not reveal; a field with no key at all does
+  -- not reveal; a field whose current outbreak re-hid the disease but which was scouted
+  -- once before stays revealed, because resistance follows the ground, not the outbreak.
+  local discoveredOnly = { diseaseDiscovered = true, resistance = { ["3"] = R.MAX_SYNTHETIC } }
+  local absentKey      = { resistance = { ["3"] = R.MAX_SYNTHETIC } }
+  local reHidden       = { diseaseDiscovered = false, fieldEverScouted = true, activeDisease = "rust",
+                           resistance = { ["3"] = R.MAX_SYNTHETIC } }
+  T.ok("gate: isFieldRevealed reads ONLY fieldEverScouted == true (discoveredOnly)",
+       not RB.isFieldRevealed(discoveredOnly))
+  T.ok("gate: an absent key is not revealed", not RB.isFieldRevealed(absentKey))
+  T.ok("gate: a re-hidden outbreak on scouted ground stays revealed", RB.isFieldRevealed(reHidden))
+  T.eq("gate: diseaseDiscovered without the durable bit reads UNKNOWN",
+       RB.computeBand(discoveredOnly, "3"), B.UNKNOWN)
+  T.eq("gate: ...and publishes no bands", #RB.encodeFieldBands(discoveredOnly), 0)
+  T.eq("gate: a fresh outbreak does not hide learned resistance history",
+       RB.computeBand(reHidden, "3"), B.FINISHED)
+  T.eq("gate: ...and still publishes it", #RB.encodeFieldBands(reHidden), 2)
 end
 
 -- A revealed field with no resistance yet reads WORKING, not UNKNOWN: the player has
@@ -111,24 +135,31 @@ end
 -- ── Apply: the client's picture round-trips, and a client NEVER computes from raw.
 do
   local server = revealed({ ["3"] = R.MAX_SYNTHETIC, ["M2"] = R.MAX_NATURAL * 0.7 })
-  local client = { diseaseDiscovered = true }   -- no `resistance` key: clients never get one
+  local client = { diseaseDiscovered = true, fieldEverScouted = true }   -- no `resistance` key: clients never get one
+  T.ok("roundtrip: no receipt before the wire speaks", client.resistanceBandsReceived == nil)
   RB.applyFieldBands(client, RB.encodeFieldBands(server))
 
   T.eq("roundtrip: FINISHED survives the wire", client.resistanceBands["3"],  B.FINISHED)
   T.eq("roundtrip: SLIPPING survives the wire", client.resistanceBands["M2"], B.SLIPPING)
   T.ok("roundtrip: the client holds no raw scores", client.resistance == nil)
+  T.ok("roundtrip: applyFieldBands stamps the receipt", client.resistanceBandsReceived == true)
 end
 
--- A field with nothing to say keeps no sub-table, mirroring applyFieldOrganic.
+-- A field with nothing to say keeps no sub-table, mirroring applyFieldOrganic. The receipt
+-- is stamped BEFORE the empty test: "nothing on this field" is an answer, not silence.
 do
-  local f = { diseaseDiscovered = true, resistanceBands = { ["3"] = B.FINISHED } }
+  local f = { diseaseDiscovered = true, fieldEverScouted = true, resistanceBands = { ["3"] = B.FINISHED } }
   RB.applyFieldBands(f, {})
   T.ok("apply: an empty payload clears the sub-table", f.resistanceBands == nil)
+  T.ok("apply: an empty payload still counts as a receipt", f.resistanceBandsReceived == true)
+  local g = { fieldEverScouted = true }
+  RB.applyFieldBands(g, nil)
+  T.ok("apply: a nil payload still counts as a receipt", g.resistanceBandsReceived == true)
 end
 
 -- A malformed or hostile payload cannot invent a band.
 do
-  local f = { diseaseDiscovered = true }
+  local f = { diseaseDiscovered = true, fieldEverScouted = true }
   RB.applyFieldBands(f, { "3", 99, "11", -5, "7", B.SLIPPING, 42, B.WORKING })
   T.ok("apply: an out-of-range band is dropped", f.resistanceBands["3"] == nil)
   T.ok("apply: a negative band is dropped",      f.resistanceBands["11"] == nil)
@@ -147,18 +178,90 @@ do
   T.ok("getBand: hasServerPicture is true with g_server set", RB.hasServerPicture())
 
   g_server = nil  -- pure client
-  local sent = { diseaseDiscovered = true, resistanceBands = { ["3"] = B.SLIPPING } }
+  local sent = { diseaseDiscovered = true, fieldEverScouted = true,
+                 resistanceBandsReceived = true, resistanceBands = { ["3"] = B.SLIPPING } }
   T.eq("getBand: a client reads the band it was sent", RB.getBand(sent, "3"), B.SLIPPING)
 
   -- A raw score sitting on a client field must NOT be banded locally.
-  local rogue = { diseaseDiscovered = true, resistance = { ["3"] = R.MAX_SYNTHETIC } }
+  local rogue = { diseaseDiscovered = true, fieldEverScouted = true, resistanceBandsReceived = true,
+                  resistance = { ["3"] = R.MAX_SYNTHETIC } }
   T.ok("getBand: a client never bands a raw score itself", RB.getBand(rogue, "3") ~= B.FINISHED)
 
   -- Unscouted still wins over anything the field carries.
-  local hidden = { diseaseDiscovered = false, resistanceBands = { ["3"] = B.FINISHED } }
+  local hidden = { diseaseDiscovered = false, fieldEverScouted = false, resistanceBandsReceived = true,
+                   resistanceBands = { ["3"] = B.FINISHED } }
   T.eq("getBand: the gate outranks a sent band", RB.getBand(hidden, "3"), B.UNKNOWN)
 
+  -- THE RECEIPT. A pure client that has not been delivered the field yet knows nothing
+  -- about any mode and says UNKNOWN; the same silence AFTER a receipt means "zero on that
+  -- mode" and bands WORKING. Never a guessed WORKING before the server has spoken.
+  local waiting = { diseaseDiscovered = true, fieldEverScouted = true }
+  T.eq("getBand: a pure client reads UNKNOWN before receipt", RB.getBand(waiting, "3"), B.UNKNOWN)
+  RB.applyFieldBands(waiting, RB.encodeFieldBands(revealed({ ["11"] = R.MAX_SYNTHETIC })))
+  T.eq("getBand: after receipt a delivered mode reads its band", RB.getBand(waiting, "11"), B.FINISHED)
+  T.eq("getBand: after receipt a silent mode reads WORKING", RB.getBand(waiting, "3"), B.WORKING)
+  RB.applyFieldBands(waiting, {})
+  T.eq("getBand: an empty delivery is a receipt, silent mode reads WORKING", RB.getBand(waiting, "3"), B.WORKING)
+
+  -- The receipt never leaks into the server picture: a server bands raw regardless.
+  g_server = {}
+  local serverNoReceipt = revealed({ ["3"] = R.MAX_SYNTHETIC })
+  T.eq("getBand: a server picture needs no receipt", RB.getBand(serverNoReceipt, "3"), B.FINISHED)
+  T.eq("getBand: a server picture with a clean mode reads WORKING without a receipt",
+       RB.getBand(serverNoReceipt, "11"), B.WORKING)
+
   g_server = prevServer
+end
+
+-- ── The durable bit is written by scoutField on the server only, and it survives the
+-- outbreak reset that clears diseaseDiscovered.
+do
+  local prevServer, prevMission, prevClient = g_server, g_currentMission, g_client
+  local function newSys()
+    return setmetatable({ settings = { diseasePressure = true },
+                          -- no activeDisease: the report walk needs SoilDiseaseSystem, which
+                          -- this test does not load; the flags are the subject here.
+                          fieldData = { [1] = { diseaseDiscovered = false, fieldEverScouted = false,
+                                                resistance = { ["3"] = R.MAX_SYNTHETIC } } } },
+                        { __index = SoilFertilitySystem })
+  end
+
+  -- Single player / server: one scout sets both flags.
+  g_server = {}
+  g_currentMission = { missionDynamicInfo = { isMultiplayer = false } }
+  local sp = newSys()
+  sp:scoutField(1)
+  T.ok("scoutField (server): diseaseDiscovered set", sp.fieldData[1].diseaseDiscovered == true)
+  T.ok("scoutField (server): fieldEverScouted set", sp.fieldData[1].fieldEverScouted == true)
+  T.eq("scoutField (server): the band is readable right after", sp:getResistanceBand(1, "3"), B.FINISHED)
+
+  -- A fresh outbreak clears ONLY diseaseDiscovered; the history stays readable.
+  sp.fieldData[1].diseaseDiscovered = false
+  T.eq("outbreak reset: resistance history survives", sp:getResistanceBand(1, "3"), B.FINISHED)
+
+  -- Pure client: optimistic disease mark, NEVER the durable bit, and it asks the server.
+  g_server = nil
+  local sent = 0
+  g_client = { getServerConnection = function() return { sendEvent = function() sent = sent + 1 end } end }
+  g_currentMission = { missionDynamicInfo = { isMultiplayer = true } }
+  local prevEvent = SoilScoutFieldEvent
+  SoilScoutFieldEvent = { new = function(id) return { fieldId = id } end }
+  local cl = newSys()
+  cl:scoutField(1)
+  T.ok("scoutField (client): diseaseDiscovered marked optimistically", cl.fieldData[1].diseaseDiscovered == true)
+  T.ok("scoutField (client): the durable bit is NOT written by a client", cl.fieldData[1].fieldEverScouted ~= true)
+  T.eq("scoutField (client): one scout event sent", sent, 1)
+  T.eq("scoutField (client): still UNKNOWN until the server writes and delivers", cl:getResistanceBand(1, "3"), B.UNKNOWN)
+  -- Already revealed locally but the durable bit never came back: ask again, once per scout.
+  cl:scoutField(1)
+  T.eq("scoutField (client): re-asks while the durable bit is missing", sent, 2)
+  -- Once the server's delivery carried the bit, a further scout is silent.
+  cl.fieldData[1].fieldEverScouted = true
+  cl:scoutField(1)
+  T.eq("scoutField (client): no event once the bit has arrived", sent, 2)
+
+  SoilScoutFieldEvent = prevEvent
+  g_server, g_currentMission, g_client = prevServer, prevMission, prevClient
 end
 
 -- ── The system-level getter, which is the whole surface the presentation build consumes.

--- a/tools/test/lua/resistance_console_test.lua
+++ b/tools/test/lua/resistance_console_test.lua
@@ -28,6 +28,7 @@ local function newField(extra)
     resistance             = {},
     diseasePressure        = 50,
     diseaseDiscovered      = true,
+    fieldEverScouted       = true,
     nutrientBuffer         = {},
   }
   for k, v in pairs(extra or {}) do f[k] = v end
@@ -63,11 +64,55 @@ end
 
 -- An unscouted field must say so loudly rather than printing a clean-looking table.
 do
-  local out = withMod(newField({ diseaseDiscovered = false }), function()
+  local out = withMod(newField({ diseaseDiscovered = false, fieldEverScouted = false }), function()
     return SoilSettingsGUI.consoleCommandResistance(SoilSettingsGUI, "1")
   end)
   T.ok("readout: unscouted says NO", out:find("Scouted: NO") ~= nil)
   T.ok("readout: unscouted explains the gate", out:find("UNKNOWN") ~= nil)
+end
+
+-- The band printed on one mode's row (the footer legend names every band, so a whole-text
+-- find would pass for the wrong reason).
+local function modeRowHas(out, mode, word)
+  for line in (out .. "\n"):gmatch("([^\n]*)\n") do
+    if line:sub(1, #mode + 1) == mode .. " " and line:find(word, 1, true) then return true end
+  end
+  return false
+end
+
+-- CD-11: the gate is the durable bit. A field whose outbreak was found but never scouted
+-- on the server says NO, even though diseaseDiscovered is true.
+do
+  local out = withMod(newField({ diseaseDiscovered = true, fieldEverScouted = false,
+                                 resistance = { ["3"] = R.MAX_SYNTHETIC } }), function()
+    return SoilSettingsGUI.consoleCommandResistance(SoilSettingsGUI, "1")
+  end)
+  T.ok("readout: discovered-only field says Scouted: NO", out:find("Scouted: NO") ~= nil)
+  T.ok("readout: discovered-only field still shows the flag", out:find("Disease discovered: YES") ~= nil)
+  T.ok("readout: discovered-only field mode 3 reads UNKNOWN", modeRowHas(out, "3", "UNKNOWN"))
+  T.ok("readout: discovered-only field mode 3 does not read FINISHED", not modeRowHas(out, "3", "FINISHED"))
+end
+
+-- A pure client reports receipt and prints bands only: no score, ratio or next-spray
+-- column is invented from zeros the server never sent.
+do
+  local prevMgr, prevServer = g_SoilFertilityManager, g_server
+  local field = newField({ fieldEverScouted = true, resistance = { ["3"] = R.MAX_SYNTHETIC } })
+  g_SoilFertilityManager = { soilSystem = newSys(field), settings = {} }
+  g_server = nil
+  local before = SoilSettingsGUI.consoleCommandResistance(SoilSettingsGUI, "1")
+  T.ok("readout: client before delivery says WAITING", before:find("WAITING") ~= nil)
+  T.ok("readout: client before delivery mode 3 reads UNKNOWN", modeRowHas(before, "3", "UNKNOWN"))
+  T.ok("readout: client before delivery does not invent FINISHED from the raw score", not modeRowHas(before, "3", "FINISHED"))
+  T.ok("readout: client has no SCORE column", before:find("SCORE/MAX") == nil)
+  T.ok("readout: client has no NEXT SPRAY column", before:find("NEXT SPRAY") == nil)
+  ResistanceBands.applyFieldBands(field, { "3", B.FINISHED })
+  local after = SoilSettingsGUI.consoleCommandResistance(SoilSettingsGUI, "1")
+  T.ok("readout: client after delivery says RECEIVED", after:find("RECEIVED") ~= nil)
+  T.ok("readout: client after delivery mode 3 shows the delivered FINISHED", modeRowHas(after, "3", "FINISHED"))
+  T.ok("readout: client after delivery reads a silent mode as WORKING", modeRowHas(after, "11", "WORKING"))
+  T.ok("readout: client after delivery still has no SCORE column", after:find("SCORE/MAX") == nil)
+  g_SoilFertilityManager, g_server = prevMgr, prevServer
 end
 
 -- An untracked field id must not throw.

--- a/translations/translation_br.xml
+++ b/translations/translation_br.xml
@@ -1466,6 +1466,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_cs.xml
+++ b/translations/translation_cs.xml
@@ -1440,5 +1440,24 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 </l10n>

--- a/translations/translation_ct.xml
+++ b/translations/translation_ct.xml
@@ -1478,5 +1478,24 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 </l10n>

--- a/translations/translation_cz.xml
+++ b/translations/translation_cz.xml
@@ -1429,6 +1429,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_da.xml
+++ b/translations/translation_da.xml
@@ -1415,5 +1415,24 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 </l10n>

--- a/translations/translation_de.xml
+++ b/translations/translation_de.xml
@@ -1436,6 +1436,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_ea.xml
+++ b/translations/translation_ea.xml
@@ -1418,6 +1418,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_en.xml
+++ b/translations/translation_en.xml
@@ -1484,5 +1484,24 @@
     <e k="sf_growth_settled_days_ago" v="%d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="No control" eh="dd802b99" />
+    <e k="sf_res_note" v="Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="%s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="Select one of your fields first." eh="dfc6d58d" />
 </elements>
 </l10n>

--- a/translations/translation_es.xml
+++ b/translations/translation_es.xml
@@ -1418,6 +1418,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_fc.xml
+++ b/translations/translation_fc.xml
@@ -1478,5 +1478,24 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 </l10n>

--- a/translations/translation_fi.xml
+++ b/translations/translation_fi.xml
@@ -1419,6 +1419,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_fr.xml
+++ b/translations/translation_fr.xml
@@ -1418,5 +1418,24 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 </l10n>

--- a/translations/translation_hu.xml
+++ b/translations/translation_hu.xml
@@ -1438,6 +1438,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_id.xml
+++ b/translations/translation_id.xml
@@ -1465,6 +1465,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_it.xml
+++ b/translations/translation_it.xml
@@ -1465,6 +1465,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_jp.xml
+++ b/translations/translation_jp.xml
@@ -1445,6 +1445,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_kr.xml
+++ b/translations/translation_kr.xml
@@ -1446,6 +1446,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_nl.xml
+++ b/translations/translation_nl.xml
@@ -1449,6 +1449,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_no.xml
+++ b/translations/translation_no.xml
@@ -1447,6 +1447,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_pl.xml
+++ b/translations/translation_pl.xml
@@ -1447,6 +1447,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_pt.xml
+++ b/translations/translation_pt.xml
@@ -1466,6 +1466,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_ro.xml
+++ b/translations/translation_ro.xml
@@ -1466,6 +1466,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_ru.xml
+++ b/translations/translation_ru.xml
@@ -1407,6 +1407,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_sv.xml
+++ b/translations/translation_sv.xml
@@ -1418,6 +1418,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_tr.xml
+++ b/translations/translation_tr.xml
@@ -1419,6 +1419,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_uk.xml
+++ b/translations/translation_uk.xml
@@ -1418,6 +1418,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/translations/translation_vi.xml
+++ b/translations/translation_vi.xml
@@ -1418,6 +1418,25 @@
     <e k="sf_growth_settled_days_ago" v="[EN] %d days ago" eh="2ed6918e" />
     <e k="sf_pda_growth_blocked" v="[EN] Blocked %d%%" eh="acc5c966" />
     <e k="sf_pda_growth_ahead" v="[EN] Ahead %d%%" eh="e19aed44" />
+    <e k="sf_res_title" v="[EN] Resistance" eh="9db444f7" />
+    <e k="sf_res_state_unknown" v="[EN] Field %d: resistance not yet known. Scout this field to learn its history." eh="ab16e14a" />
+    <e k="sf_res_state_waiting" v="[EN] Field %d: waiting for the server's resistance picture." eh="b3c62e5b" />
+    <e k="sf_res_state_known" v="[EN] Field %d: resistance history known." eh="8717924c" />
+    <e k="sf_res_mode" v="[EN] Mode %s" eh="fdbc9304" />
+    <e k="sf_res_band_unknown" v="[EN] Not yet known" eh="8f4a0706" />
+    <e k="sf_res_band_working" v="[EN] Good control" eh="75eb95bf" />
+    <e k="sf_res_band_slipping" v="[EN] Reduced control" eh="cc4d1243" />
+    <e k="sf_res_band_finished" v="[EN] No control" eh="dd802b99" />
+    <e k="sf_res_note" v="[EN] Tank-applied fungicides build resistance on this field. Menu treatments do not use this resistance model and charge by field area." eh="effb087f" />
+    <e k="sf_res_pairs_btn" v="[EN] Tank pairs" eh="fb0e4920" />
+    <e k="sf_res_pairs_title" v="[EN] Tank pairs for field %d" eh="d2e9272f" />
+    <e k="sf_res_pairs_intro" v="[EN] Control words are this field's current bands. A pair marked organic is on the organic approved list. Nothing here ranks, buys or mixes." eh="efb73722" />
+    <e k="sf_res_pairs_line" v="[EN] %s (mode %s): %s. Pairs with %s." eh="2a537b39" />
+    <e k="sf_res_pairs_all" v="[EN] every other fungicide" eh="2eee400b" />
+    <e k="sf_res_pairs_organic" v="[EN] organic pair" eh="49f08add" />
+    <e k="sf_res_pairs_none" v="[EN] pair table not loaded" eh="abbe2edb" />
+    <e k="sf_res_pairs_nothing" v="[EN] no listed partner" eh="06752d51" />
+    <e k="sf_res_pairs_no_field" v="[EN] Select one of your fields first." eh="dfc6d58d" />
 </elements>
 
 

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -399,41 +399,44 @@
                              the map, blank.png hairline only. Existing RF_* profiles throughout.
                              If another mod's copy of this file builds the door these ids are
                              absent and the painter skips the card (PRODUCTS unaffected). -->
-                        <GuiElement profile="RF_EscCardFrame" id="soilResistanceCard" position="10px -274px" size="1130px 108px" visible="false">
-                            <Text profile="RF_ProductsTitle" id="soilResistanceTitle" position="10px -6px" size="150px 18px"/>
-                            <Text profile="RF_HintText" id="soilResistanceState" position="170px -7px" size="820px 20px"/>
-                            <Button profile="RF_FwPagerBtn" id="soilResistancePairsBtn" position="1000px -6px" size="120px 24px"
+                        <!-- BUILD 17:52: card breathes. Top -280 (10px under the three cards), 126 tall so the bottom stroke
+                             stays 10px above the HELP/BACK band (the strip already reaches under that band; nothing to grow
+                             into). 10px stroke clearance on every child, seven columns 150 wide on 10px gaps. -->
+                        <GuiElement profile="RF_EscCardFrame" id="soilResistanceCard" position="10px -280px" size="1130px 126px" visible="false">
+                            <Text profile="RF_ProductsTitle" id="soilResistanceTitle" position="10px -10px" size="150px 18px"/>
+                            <Text profile="RF_HintText" id="soilResistanceState" position="170px -11px" size="820px 20px"/>
+                            <Button profile="RF_FwPagerBtn" id="soilResistancePairsBtn" position="1000px -10px" size="120px 20px"
                                     text="" onClick="onClickSoilResistancePairs"/>
-                            <Bitmap profile="RF_EscCardRule" id="soilResistanceRule" position="10px -32px" size="1110px 1px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode1Head" position="10px -36px" size="154px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode1Prod" position="10px -50px" size="154px 28px"
+                            <Bitmap profile="RF_EscCardRule" id="soilResistanceRule" position="10px -33px" size="1110px 1px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode1Head" position="10px -40px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode1Prod" position="10px -54px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode1Band" position="10px -78px" size="154px 16px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode2Head" position="168px -36px" size="154px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode2Prod" position="168px -50px" size="154px 28px"
+                            <Text profile="RF_ProductCellDense" id="soilResMode1Band" position="10px -82px" size="150px 14px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode2Head" position="170px -40px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode2Prod" position="170px -54px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode2Band" position="168px -78px" size="154px 16px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode3Head" position="326px -36px" size="154px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode3Prod" position="326px -50px" size="154px 28px"
+                            <Text profile="RF_ProductCellDense" id="soilResMode2Band" position="170px -82px" size="150px 14px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode3Head" position="330px -40px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode3Prod" position="330px -54px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode3Band" position="326px -78px" size="154px 16px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode4Head" position="484px -36px" size="154px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode4Prod" position="484px -50px" size="154px 28px"
+                            <Text profile="RF_ProductCellDense" id="soilResMode3Band" position="330px -82px" size="150px 14px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode4Head" position="490px -40px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode4Prod" position="490px -54px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode4Band" position="484px -78px" size="154px 16px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode5Head" position="642px -36px" size="154px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode5Prod" position="642px -50px" size="154px 28px"
+                            <Text profile="RF_ProductCellDense" id="soilResMode4Band" position="490px -82px" size="150px 14px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode5Head" position="650px -40px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode5Prod" position="650px -54px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode5Band" position="642px -78px" size="154px 16px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode6Head" position="800px -36px" size="154px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode6Prod" position="800px -50px" size="154px 28px"
+                            <Text profile="RF_ProductCellDense" id="soilResMode5Band" position="650px -82px" size="150px 14px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode6Head" position="810px -40px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode6Prod" position="810px -54px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode6Band" position="800px -78px" size="154px 16px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode7Head" position="958px -36px" size="154px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode7Prod" position="958px -50px" size="154px 28px"
+                            <Text profile="RF_ProductCellDense" id="soilResMode6Band" position="810px -82px" size="150px 14px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode7Head" position="970px -40px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode7Prod" position="970px -54px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode7Band" position="958px -78px" size="154px 16px"/>
-                            <Text profile="RF_ProductCellDense" id="soilResistanceNote" position="10px -94px" size="1110px 14px"/>
+                            <Text profile="RF_ProductCellDense" id="soilResMode7Band" position="970px -82px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellDense" id="soilResistanceNote" position="10px -102px" size="1110px 14px"/>
                         </GuiElement>
                     </GuiElement>
 

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -387,6 +387,53 @@
                         </GuiElement>
                         <Text profile="RF_HintText" id="samplingInfoFallback" position="850px -24px" size="180px 160px"
                               textMaxNumLines="7" text="$l10n_rf_pda_sample_hint" visible="false"/>
+
+                        <!-- Card 4 (BUILD 10:52, CD-11): RESISTANCE. Full-width strip under the three
+                             cards, in the 114px the strip already had free below y -270. Read-only
+                             band readout painted by RfPdaSoilPanel.refreshResistanceCard on panel
+                             show and owned-field select only; hidden until a field is selected.
+                             Seven chips, one per FRAC mode: header, the products that use it, and
+                             the band word. Fixed Text plus one fs25_wideButton (no key chip) that
+                             opens the pair disclosure in InfoDialog. No SmoothList, no Bitmap over
+                             the map, blank.png hairline only. Existing RF_* profiles throughout.
+                             If another mod's copy of this file builds the door these ids are
+                             absent and the painter skips the card (PRODUCTS unaffected). -->
+                        <GuiElement profile="RF_EscCardFrame" id="soilResistanceCard" position="10px -274px" size="1130px 108px" visible="false">
+                            <Text profile="RF_ProductsTitle" id="soilResistanceTitle" position="10px -6px" size="150px 18px"/>
+                            <Text profile="RF_HintText" id="soilResistanceState" position="170px -7px" size="820px 20px"/>
+                            <Button profile="RF_FwPagerBtn" id="soilResistancePairsBtn" position="1000px -6px" size="120px 24px"
+                                    text="" onClick="onClickSoilResistancePairs"/>
+                            <Bitmap profile="RF_EscCardRule" id="soilResistanceRule" position="10px -32px" size="1110px 1px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode1Head" position="10px -36px" size="154px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode1Prod" position="10px -50px" size="154px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCellDense" id="soilResMode1Band" position="10px -78px" size="154px 16px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode2Head" position="168px -36px" size="154px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode2Prod" position="168px -50px" size="154px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCellDense" id="soilResMode2Band" position="168px -78px" size="154px 16px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode3Head" position="326px -36px" size="154px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode3Prod" position="326px -50px" size="154px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCellDense" id="soilResMode3Band" position="326px -78px" size="154px 16px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode4Head" position="484px -36px" size="154px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode4Prod" position="484px -50px" size="154px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCellDense" id="soilResMode4Band" position="484px -78px" size="154px 16px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode5Head" position="642px -36px" size="154px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode5Prod" position="642px -50px" size="154px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCellDense" id="soilResMode5Band" position="642px -78px" size="154px 16px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode6Head" position="800px -36px" size="154px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode6Prod" position="800px -50px" size="154px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCellDense" id="soilResMode6Band" position="800px -78px" size="154px 16px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode7Head" position="958px -36px" size="154px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode7Prod" position="958px -50px" size="154px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCellDense" id="soilResMode7Band" position="958px -78px" size="154px 16px"/>
+                            <Text profile="RF_ProductCellDense" id="soilResistanceNote" position="10px -94px" size="1110px 14px"/>
+                        </GuiElement>
                     </GuiElement>
 
                 </GuiElement>

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -209,8 +209,8 @@
                     <GuiElement profile="RF_TreatmentStrip" id="rfTreatmentStrip">
                         <Bitmap profile="RF_TreatmentBoxBg"/>
                         <!-- Card 1 of 3 (BUILD 12:59): TREATMENT + target levels share the
-                             -22 top line with PRODUCTS and ROTATION. Children re-based inside. -->
-                        <GuiElement profile="RF_EscCardFrame" id="soilTreatmentCard" position="10px -22px" size="200px 248px">
+                             -12 top line (BUILD 17:52 AMEND, was -22) with PRODUCTS and ROTATION. Children re-based inside. -->
+                        <GuiElement profile="RF_EscCardFrame" id="soilTreatmentCard" position="10px -12px" size="200px 248px">
                             <Text profile="RF_SectionTitle" id="soilSectionTreatment" position="10px -6px" size="180px 24px" text="$l10n_rf_pda_section_treatment"/>
                             <Text profile="RF_TreatTargetLine" id="treatTargetsHeading" position="10px -40px" size="180px 20px"/>
                             <Text profile="RF_TreatTargetLine" id="treatTargetN" position="10px -62px" size="180px 20px"/>
@@ -236,7 +236,7 @@
                              This edit is in ALL NINE door copies on purpose. The Esc page is
                              built by whichever mod loads first, from its own copy, so a change
                              in Soil alone would be overwritten by whoever won the race. -->
-                        <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px" size="620px 248px">
+                        <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -12px" size="620px 248px">
                             <!-- BUILD 09:19 (PB-05). Brian read "Wait: amending now can burn t..." on
                                  this strip: the sentence that says an apply will scorch the crop was
                                  cut before its own verb.
@@ -330,7 +330,7 @@
                              850px -88px / 290px 248px - never grows left into PRODUCTS.
                              Soil grey via RF_TreatmentBoxBg (mock blue vetoed). Fixed Text only,
                              no SmoothList. Read-only: no apply-rotation controls. -->
-                        <GuiElement profile="RF_EscCardFrame" id="soilRotationCard" position="850px -22px" size="290px 248px">
+                        <GuiElement profile="RF_EscCardFrame" id="soilRotationCard" position="850px -12px" size="290px 248px">
                             <!-- Zone split (BUILD 16:19): ROTATION glance on top, then 14px of air
                                  with one 1px hairline, then WHAT IF. Same recipe as the middle card
                                  so the two read as one family. All bodies inset X 0 -> 10, widths
@@ -399,44 +399,44 @@
                              the map, blank.png hairline only. Existing RF_* profiles throughout.
                              If another mod's copy of this file builds the door these ids are
                              absent and the painter skips the card (PRODUCTS unaffected). -->
-                        <!-- BUILD 17:52: card breathes. Top -280 (10px under the three cards), 126 tall so the bottom stroke
-                             stays 10px above the HELP/BACK band (the strip already reaches under that band; nothing to grow
-                             into). 10px stroke clearance on every child, seven columns 150 wide on 10px gaps. -->
-                        <GuiElement profile="RF_EscCardFrame" id="soilResistanceCard" position="10px -280px" size="1130px 126px" visible="false">
+                        <!-- BUILD 17:52 AMEND (Y): card breathes. Top -270 (10px under the three cards, now at -12), 136 tall so the
+                             bottom stroke stays 10px above the HELP/BACK band (the strip already reaches under that band; nothing to
+                             grow into). 10px stroke clearance, 10px rule to heads, 10px bands to note, seven columns 150 wide on 10px gaps. -->
+                        <GuiElement profile="RF_EscCardFrame" id="soilResistanceCard" position="10px -270px" size="1130px 136px" visible="false">
                             <Text profile="RF_ProductsTitle" id="soilResistanceTitle" position="10px -10px" size="150px 18px"/>
                             <Text profile="RF_HintText" id="soilResistanceState" position="170px -11px" size="820px 20px"/>
                             <Button profile="RF_FwPagerBtn" id="soilResistancePairsBtn" position="1000px -10px" size="120px 20px"
                                     text="" onClick="onClickSoilResistancePairs"/>
-                            <Bitmap profile="RF_EscCardRule" id="soilResistanceRule" position="10px -33px" size="1110px 1px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode1Head" position="10px -40px" size="150px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode1Prod" position="10px -54px" size="150px 28px"
+                            <Bitmap profile="RF_EscCardRule" id="soilResistanceRule" position="10px -35px" size="1110px 1px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode1Head" position="10px -46px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode1Prod" position="10px -60px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode1Band" position="10px -82px" size="150px 14px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode2Head" position="170px -40px" size="150px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode2Prod" position="170px -54px" size="150px 28px"
+                            <Text profile="RF_ProductCellDense" id="soilResMode1Band" position="10px -88px" size="150px 14px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode2Head" position="170px -46px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode2Prod" position="170px -60px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode2Band" position="170px -82px" size="150px 14px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode3Head" position="330px -40px" size="150px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode3Prod" position="330px -54px" size="150px 28px"
+                            <Text profile="RF_ProductCellDense" id="soilResMode2Band" position="170px -88px" size="150px 14px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode3Head" position="330px -46px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode3Prod" position="330px -60px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode3Band" position="330px -82px" size="150px 14px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode4Head" position="490px -40px" size="150px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode4Prod" position="490px -54px" size="150px 28px"
+                            <Text profile="RF_ProductCellDense" id="soilResMode3Band" position="330px -88px" size="150px 14px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode4Head" position="490px -46px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode4Prod" position="490px -60px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode4Band" position="490px -82px" size="150px 14px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode5Head" position="650px -40px" size="150px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode5Prod" position="650px -54px" size="150px 28px"
+                            <Text profile="RF_ProductCellDense" id="soilResMode4Band" position="490px -88px" size="150px 14px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode5Head" position="650px -46px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode5Prod" position="650px -60px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode5Band" position="650px -82px" size="150px 14px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode6Head" position="810px -40px" size="150px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode6Prod" position="810px -54px" size="150px 28px"
+                            <Text profile="RF_ProductCellDense" id="soilResMode5Band" position="650px -88px" size="150px 14px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode6Head" position="810px -46px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode6Prod" position="810px -60px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode6Band" position="810px -82px" size="150px 14px"/>
-                            <Text profile="RF_ProductColHeaderDense" id="soilResMode7Head" position="970px -40px" size="150px 14px"/>
-                            <Text profile="RF_ProductCellEffect" id="soilResMode7Prod" position="970px -54px" size="150px 28px"
+                            <Text profile="RF_ProductCellDense" id="soilResMode6Band" position="810px -88px" size="150px 14px"/>
+                            <Text profile="RF_ProductColHeaderDense" id="soilResMode7Head" position="970px -46px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilResMode7Prod" position="970px -60px" size="150px 28px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Text profile="RF_ProductCellDense" id="soilResMode7Band" position="970px -82px" size="150px 14px"/>
-                            <Text profile="RF_ProductCellDense" id="soilResistanceNote" position="10px -102px" size="1110px 14px"/>
+                            <Text profile="RF_ProductCellDense" id="soilResMode7Band" position="970px -88px" size="150px 14px"/>
+                            <Text profile="RF_ProductCellDense" id="soilResistanceNote" position="10px -112px" size="1110px 14px"/>
                         </GuiElement>
                     </GuiElement>
 

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -159,19 +159,20 @@
                     <GuiElement profile="RF_TableRegionShell">
                         <Bitmap profile="RF_TableWrapBg"/>
 
+                        <!-- BUILD 16:56: RF_Soil* carve-outs (text -2) are Soil-table only; CS/MDM keep the shared profiles. -->
                         <!-- F12: all headers centered; AREA/STATUS/Fertilizer body centered.
                              IDs: Lua _applyChromeL10n rebinds when CS/WC created the Esc door. -->
-                        <Text profile="RF_ColHeader" id="soilColField"  text="$l10n_sf_pda_col_field"  position="12px -8px"    size="102px 24px"/>
-                        <Text profile="RF_ColHeader" id="soilColArea"   text="$l10n_rf_pda_col_area"   position="120px -8px"   size="102px 24px"/>
-                        <Text profile="RF_ColHeader" text="N"                       position="230px -8px"   size="84px 24px"/>
-                        <Text profile="RF_ColHeader" text="P"                       position="322px -8px"   size="84px 24px"/>
-                        <Text profile="RF_ColHeader" text="K"                       position="414px -8px"   size="84px 24px"/>
-                        <Text profile="RF_ColHeader" id="soilColPH" text="pH"       position="506px -8px"   size="72px 24px"/>
-                        <Text profile="RF_ColHeader" id="soilColStatus" text="$l10n_sf_pda_col_status" position="586px -8px"   size="108px 24px"/>
-                        <Text profile="RF_ColHeader" id="soilColFert"   text="$l10n_rf_pda_col_fert"   position="702px -8px"  size="106px 24px"/>
-                        <Text profile="RF_ColHeader" id="soilColWeed"    text="$l10n_sf_pda_col_weeds"   position="816px -8px"  size="94px 24px"/>
-                        <Text profile="RF_ColHeader" id="soilColPest"    text="$l10n_sf_pda_col_pests"   position="918px -8px"  size="94px 24px"/>
-                        <Text profile="RF_ColHeader" id="soilColDisease" text="$l10n_sf_pda_col_disease" position="1020px -8px"  size="120px 24px"/>
+                        <Text profile="RF_SoilColHeader" id="soilColField"  text="$l10n_sf_pda_col_field"  position="12px -8px"    size="102px 24px"/>
+                        <Text profile="RF_SoilColHeader" id="soilColArea"   text="$l10n_rf_pda_col_area"   position="120px -8px"   size="102px 24px"/>
+                        <Text profile="RF_SoilColHeader" text="N"                       position="230px -8px"   size="84px 24px"/>
+                        <Text profile="RF_SoilColHeader" text="P"                       position="322px -8px"   size="84px 24px"/>
+                        <Text profile="RF_SoilColHeader" text="K"                       position="414px -8px"   size="84px 24px"/>
+                        <Text profile="RF_SoilColHeader" id="soilColPH" text="pH"       position="506px -8px"   size="72px 24px"/>
+                        <Text profile="RF_SoilColHeader" id="soilColStatus" text="$l10n_sf_pda_col_status" position="586px -8px"   size="108px 24px"/>
+                        <Text profile="RF_SoilColHeader" id="soilColFert"   text="$l10n_rf_pda_col_fert"   position="702px -8px"  size="106px 24px"/>
+                        <Text profile="RF_SoilColHeader" id="soilColWeed"    text="$l10n_sf_pda_col_weeds"   position="816px -8px"  size="94px 24px"/>
+                        <Text profile="RF_SoilColHeader" id="soilColPest"    text="$l10n_sf_pda_col_pests"   position="918px -8px"  size="94px 24px"/>
+                        <Text profile="RF_SoilColHeader" id="soilColDisease" text="$l10n_sf_pda_col_disease" position="1020px -8px"  size="120px 24px"/>
 
                         <GuiElement profile="fs25_subCategoryListContainer" position="0px -32px"
                                     absoluteSizeOffset="0px 40px">
@@ -180,17 +181,17 @@
                                         endClipperElementName="rfListEnd">
                                 <ListItem profile="RF_ListRowTall" onClick="onClickFieldRow">
                                     <Bitmap profile="RF_RowBg" name="alternating"/>
-                                    <Text profile="RF_CellLeft"   name="fieldRowId"     position="12px 0px"   size="102px 48px"/>
-                                    <Text profile="RF_CellCenter" name="fieldRowArea"   position="120px 0px"  size="102px 48px"/>
-                                    <Text profile="RF_CellRight"  name="fieldRowN"      position="230px 0px"  size="84px 48px"/>
-                                    <Text profile="RF_CellRight"  name="fieldRowP"      position="322px 0px"  size="84px 48px"/>
-                                    <Text profile="RF_CellRight"  name="fieldRowK"      position="414px 0px"  size="84px 48px"/>
-                                    <Text profile="RF_CellRight"  name="fieldRowPH"     position="506px 0px"  size="72px 48px"/>
-                                    <Text profile="RF_StatusCell" name="fieldRowStatus" position="586px 0px" size="108px 48px"/>
+                                    <Text profile="RF_SoilCellLeft"   name="fieldRowId"     position="12px 0px"   size="102px 48px"/>
+                                    <Text profile="RF_SoilCellCenter" name="fieldRowArea"   position="120px 0px"  size="102px 48px"/>
+                                    <Text profile="RF_SoilCellRight"  name="fieldRowN"      position="230px 0px"  size="84px 48px"/>
+                                    <Text profile="RF_SoilCellRight"  name="fieldRowP"      position="322px 0px"  size="84px 48px"/>
+                                    <Text profile="RF_SoilCellRight"  name="fieldRowK"      position="414px 0px"  size="84px 48px"/>
+                                    <Text profile="RF_SoilCellRight"  name="fieldRowPH"     position="506px 0px"  size="72px 48px"/>
+                                    <Text profile="RF_SoilStatusCell" name="fieldRowStatus" position="586px 0px" size="108px 48px"/>
                                     <Text profile="RF_FertChip"   name="fieldRowFert"   position="702px 0px" size="106px 48px"/>
-                                    <Text profile="RF_CellRight"  name="fieldRowWeed"    position="816px 0px" size="94px 48px"/>
-                                    <Text profile="RF_CellRight"  name="fieldRowPest"    position="918px 0px" size="94px 48px"/>
-                                    <Text profile="RF_CellRight"  name="fieldRowDisease" position="1020px 0px" size="120px 48px"/>
+                                    <Text profile="RF_SoilCellRight"  name="fieldRowWeed"    position="816px 0px" size="94px 48px"/>
+                                    <Text profile="RF_SoilCellRight"  name="fieldRowPest"    position="918px 0px" size="94px 48px"/>
+                                    <Text profile="RF_SoilCellRight"  name="fieldRowDisease" position="1020px 0px" size="120px 48px"/>
                                 </ListItem>
                             </SmoothList>
                             <Bitmap profile="fs25_secondaryMenuStartClipper" name="rfListStart"/>

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -532,7 +532,7 @@
 
     <!-- Table viewport reserve. -->
     <Profile name="RF_TableRegionShell" extends="emptyPanel" with="anchorStretchingYStretchingX pivotTopLeft">
-        <absoluteSizeOffset value="0px 372px"/>
+        <absoluteSizeOffset value="0px 420px"/>
         <position value="0px 0px"/>
     </Profile>
 
@@ -560,7 +560,7 @@
 
     <!-- Treatment / CS detail: clipChildren keeps PRODUCTS inside strip. -->
     <Profile name="RF_TreatmentStrip" extends="emptyPanel" with="anchorBottomStretchingX pivotBottomLeft">
-        <height value="384px"/>
+        <height value="432px"/>
         <position value="0px 0px"/>
         <clipChildren value="true"/>
     </Profile>
@@ -694,8 +694,25 @@
         <textSelectedColor value="0.95 0.95 0.95 1"/>
     </Profile>
 
-    <Profile name="RF_FertChip" extends="fs25_textDefault" with="anchorTopLeft">
+    <!-- BUILD 16:56: Soil fields table only (text -2 so RESISTANCE has room). CS/MDM tables keep the shared profiles above. -->
+    <Profile name="RF_SoilColHeader" extends="RF_ColHeader">
         <textSize value="17px"/>
+    </Profile>
+    <Profile name="RF_SoilCellLeft" extends="RF_CellLeft">
+        <textSize value="18px"/>
+    </Profile>
+    <Profile name="RF_SoilCellCenter" extends="RF_CellCenter">
+        <textSize value="18px"/>
+    </Profile>
+    <Profile name="RF_SoilCellRight" extends="RF_CellRight">
+        <textSize value="18px"/>
+    </Profile>
+    <Profile name="RF_SoilStatusCell" extends="RF_StatusCell">
+        <textSize value="15px"/>
+    </Profile>
+
+    <Profile name="RF_FertChip" extends="fs25_textDefault" with="anchorTopLeft">
+        <textSize value="15px"/>
         <textBold value="true"/>
         <textUpperCase value="true"/>
         <textAlignment value="center"/>


### PR DESCRIPTION
## Summary
- On the Soil Esc page, an owned field now shows which fungicide modes still offer good, reduced, or no control, plus tank pairs. Unscouted fields read not yet known. Read-only: nothing ranks, buys, mixes, or applies.
- The fields table is one row shorter and a little smaller so Resistance has room. Treatment, Products, and Rotation stay above it with even gaps.
- Scout history is saved. Clients wait for the server picture before showing control words. Experimental / release gating is unchanged.

## Test plan
- Esc, Realistic Farming, Soil. Select an owned field: Resistance card under Treatment, 10px gaps, not sitting on Help/Back.
- Unscouted field: not yet known. After scouting: Good / Reduced / No control per mode. Tank pairs opens the partner list.
- Dedicated server + client: client stays unknown until the first delivery, then matches the server words.
- Map cell click still shows blocked / ahead growth. Experimental Systems off: growth block hidden; Resistance still follows its existing gate.
