### PR TITLE
fix(seespray): centre honours the See & Spray no-target decision

### DIFF
--- a/src/specializations/SFNozzleEffects.lua
+++ b/src/specializations/SFNozzleEffects.lua
@@ -327,6 +327,15 @@ function SFNozzleEffects:onPostLoad(savegame)
         return
     end
 
+    -- Real index of the centre VWW section. Nozzles remap the centre to sentinel
+    -- sectionIndex 0 (so it skips the section.isActive gate), but deposition gating needs
+    -- the centre's TRUE section index so getIsWorkAreaActive can suppress it too when See &
+    -- Spray finds no target - otherwise the centre leaks product while the boom holds.
+    spec.centerSectionIndex = nil
+    for _, section in ipairs(spec_vww.sections) do
+        if section.isCenter then spec.centerSectionIndex = section.index; break end
+    end
+
     local minWidth = 1
     if spec_vww.sectionNodes and #spec_vww.sectionNodes > 0 then
         local sn     = spec_vww.sectionNodes[1]
@@ -545,17 +554,23 @@ function SFNozzleEffects:onUpdate(dt, isActiveForInput, isActiveForInputIgnoreSe
     -- Aggregate the per-nozzle See & Spray decision into a per-section flag so
     -- getIsWorkAreaActive can gate the ACTUAL ground deposition per section (not just the
     -- fluid usage). A section is suppressed when it has nozzles and none are active (no
-    -- target confirmed / crossed the field boundary). Sections with no nozzle - e.g. the
-    -- centre always-on zone (sectionIndex 0) - get no entry and keep spraying.
+    -- target confirmed / crossed the field boundary). The centre nozzle (sentinel
+    -- sectionIndex 0) is tracked separately as centerActive so its See & Spray decision
+    -- gates the centre work area too, instead of the centre always leaking product.
     local sectionActive = {}
+    local centerActive  = nil
     for _, ed in ipairs(spec.sprayerEffects) do
         local idx = ed.sectionIndex
         if idx ~= nil and idx ~= 0 then
             if sectionActive[idx] == nil then sectionActive[idx] = false end
             if ed.isActive then sectionActive[idx] = true end
+        elseif idx == 0 then
+            if centerActive == nil then centerActive = false end
+            if ed.isActive then centerActive = true end
         end
     end
     spec.sectionActive = sectionActive
+    spec.centerActive  = centerActive
 
     -- Animate shader fade transitions for any nozzle with an effect node.
     for _, effectData in ipairs(spec.sprayerEffects) do
@@ -830,7 +845,16 @@ function SFNozzleEffects:getIsWorkAreaActive(superFunc, workArea)
     if not hasAny then return true end
 
     local idx = workArea.sectionIndex
-    if idx ~= nil and spec.sectionActive ~= nil and spec.sectionActive[idx] == false then
+    if idx ~= nil and spec.sectionActive ~= nil and spec.sectionActive[idx] ~= nil then
+        -- A tracked outer boom section: honour its aggregated See & Spray decision.
+        if spec.sectionActive[idx] == false then return false end
+        return true
+    end
+    -- The centre spray area (its real section index, or an undivided / no-section work
+    -- area): honour the centre nozzle's See & Spray decision so the centre stops depositing
+    -- on a no-target cell instead of leaking product while the outer boom holds. Safe
+    -- default (spray) when there is no centre nozzle to consult (centerActive == nil).
+    if spec.centerActive == false and (idx == nil or idx == spec.centerSectionIndex) then
         return false
     end
     return true


### PR DESCRIPTION
## Problem
On a sprayer with See & Spray purchased (verified on the Agrio DinoII), herbicide/fungicide/pesticide only sprayed from the centre section across the whole field, independent of where weeds/disease actually were. All sections flashed on turn-on, then collapsed to centre.

## Root cause
The per-nozzle See & Spray decision was computed correctly for every nozzle, centre included (a debug trace showed the centre reading disease 9.1 vs threshold 10, i.e. suppress). But the deposition aggregation in onUpdate deliberately excluded the centre (sentinel sectionIndex 0), so spec.sectionActive held no centre entry and getIsWorkAreaActive fell through to return true for the centre work area. The centre therefore kept depositing product on a no-target field while the outer sections correctly held. Visible result: only the mid section sprayed.

## Fix
- Record the centre VWW section real index at load (spec.centerSectionIndex).
- Track the centre nozzle decision separately as spec.centerActive in the per-section aggregation.
- Gate the centre work area (its real section index, or a no-section work area) on centerActive in getIsWorkAreaActive. Safe default (spray) when there is no centre nozzle.

Fertiliser is unaffected (it always reports active, so the whole boom sprays as before).

## Testing
Verified in-game on the Agrio DinoII: below-threshold field, the whole boom now holds (centre no longer leaks); forcing disease over threshold (SoilSetDisease 50) sprays the full boom including centre.