### PR TITLE
feat(SCS-041): additive compaction-grain return on the soil value getter

### DIFF
--- a/src/SoilFertilityManager.lua
+++ b/src/SoilFertilityManager.lua
@@ -2620,7 +2620,9 @@ end
 ---@return number|nil
 function SoilFertilityManager:getSoilValueAtWorld(key, x, z)
     if SpatialNutrients == nil or SpatialNutrients.getSoilValueAtWorld == nil then return nil end
-    local ok, v = pcall(SpatialNutrients.getSoilValueAtWorld, SpatialNutrients, self.soilSystem, key, x, z)
+    -- [SCS-041] Pass through the optional second return (metres-per-pixel grain)
+    -- without breaking one-value callers, which ignore it.
+    local ok, v, grain = pcall(SpatialNutrients.getSoilValueAtWorld, SpatialNutrients, self.soilSystem, key, x, z)
     if not ok then return nil end
-    return v
+    return v, grain
 end

--- a/src/SpatialNutrients.lua
+++ b/src/SpatialNutrients.lua
@@ -375,7 +375,12 @@ end
 ---@return number|nil
 function SpatialNutrients:getSoilValueAtWorld(selfSoilSystem, key, x, z)
     if not selfSoilSystem or not selfSoilSystem:vmAvailable() then return nil end
-    return selfSoilSystem.valueMaps:readValueAtWorld(key, x, z)
+    local value = selfSoilSystem.valueMaps:readValueAtWorld(key, x, z)
+    if value == nil then return nil end
+    -- [SCS-041] Second return: the value map's metres-per-pixel grain, so a
+    -- positional reader can size its per-cell budget honestly. One-value
+    -- callers ignore the extra return, so this stays backward compatible.
+    return value, selfSoilSystem.valueMaps:getGrainMetres()
 end
 
 -- =========================================================

--- a/src/maps/SoilValueMaps.lua
+++ b/src/maps/SoilValueMaps.lua
@@ -450,6 +450,16 @@ function SoilValueMaps:readValueAtWorld(key, worldX, worldZ)
     return decode(raw, entry.def)
 end
 
+--- [SCS-041] Metres-per-pixel grain of the value maps. Every layer shares one
+--- resolution, so this is the honest cell size a positional consumer needs to
+--- size a per-cell budget (SeasonalCropStress irrigation absorption). Returns
+--- nil when the maps are unavailable rather than a fabricated grain.
+---@return number|nil grainMetres  terrainSize / resolution, or nil
+function SoilValueMaps:getGrainMetres()
+    if not self.available or self.resolution == nil or self.resolution <= 0 then return nil end
+    return self.terrainSize / self.resolution
+end
+
 --- [SF-43] RAW (unencoded) value at a world position; nil when unavailable.
 --- The age layer must not round-trip through decode(): raw 0 and raw 255 are
 --- SENTINELS ("no record" and "the ceiling refusal"), not points on a semantic

--- a/tools/test/lua/sf23_spatial_nutrients_test.lua
+++ b/tools/test/lua/sf23_spatial_nutrients_test.lua
@@ -154,8 +154,12 @@ do
       if key == "nitrogen" then return 42 end
       return nil
     end,
+    -- [SCS-041] mirror the real SoilValueMaps grain accessor (~2 m/px).
+    getGrainMetres = function() return 2 end,
   }
   local soilSys = { valueMaps = vm, vmAvailable = function() return true end }
-  T.eq("positional N read", SN:getSoilValueAtWorld(soilSys, "nitrogen", 1, 1), 42)
+  local n, grain = SN:getSoilValueAtWorld(soilSys, "nitrogen", 1, 1)
+  T.eq("positional N read", n, 42)
+  T.eq("positional N read returns the value-map grain", grain, 2)
   T.eq("absent key -> nil", SN:getSoilValueAtWorld(soilSys, "phosphorus", 1, 1), nil)
 end


### PR DESCRIPTION
## SCS-041 SF read-contract: additive compaction-grain return

Build-order step 1 of the SCS-041 Thirsty Ground member (One Ground hydrology). SeasonalCropStress needs the value map's metres-per-pixel grain to size its per-cell irrigation absorption budget honestly, so the soil value getter now hands that grain back as an optional second return.

### Changes
- `src/maps/SoilValueMaps.lua`: new `getGrainMetres()` returning `terrainSize / resolution` (the shared per-layer grain, about 2 m/px), nil when the maps are unavailable rather than a fabricated number.
- `src/SpatialNutrients.lua`: `getSoilValueAtWorld` returns `value, grainMetres`. Returns nil (no grain) when the value itself is nil.
- `src/SoilFertilityManager.lua`: passes the grain through the existing pcall wrapper.
- `tools/test/lua/sf23_spatial_nutrients_test.lua`: mock value map now mirrors the real `getGrainMetres` API and asserts the grain return.

### Why it is safe
Purely additive. One-value callers ignore the extra return, so every existing caller is unchanged. The SCS-041 consumer reads this pcall-guarded and treats a missing manager/getter/grain as neutral, so it can land ahead of or behind this PR.

### Verification
`bash tools/test/run.sh`: sf23 green (14/0). The 2 failures in `om_213_organic_premium_test.lua` are pre-existing on `development` (reproduced with this branch stashed) and unrelated to this change.

Release stays LOCKED. In-game observation is owed at member completion, not here.
