### PR TITLE
feat(SCS-042): explicit topography currentness on the cache read

### DIFF
--- a/src/TopographyCache.lua
+++ b/src/TopographyCache.lua
@@ -44,11 +44,15 @@ TopographyCache.SLOPE_STEEP     = "steep"      -- >12%
 -- branch on "is the answer ready". A stale cell reads as if the ground is
 -- flat, not a sink, and its water distance is unknown (nil is honest here:
 -- the water plane moved and we have not re-measured it).
+-- [SCS-042] stale = true is the explicit currentness flag: a consumer that
+-- routes water downhill must not treat this height-zero default as a real low
+-- spot. A measured answer carries stale = false.
 TopographyCache.STALE_DEFAULT = {
     height       = 0,
     slope        = TopographyCache.SLOPE_FLAT,
     sink         = false,
     waterDist    = nil,
+    stale        = true,
 }
 
 -- ============================================================
@@ -372,6 +376,7 @@ function TopographyCache:getCellInfo(x, z)
         slope     = cell.slope,
         sink      = cell.sink,
         waterDist = self._waterDist[idx],
+        stale     = false,   -- [SCS-042] measured answer: safe to route on
     }
 end
 


### PR DESCRIPTION
## SCS-042 SF read-contract: explicit topography currentness

Build-order step 1 of the SCS-042 One-Hop Runoff member (One Ground hydrology). One-hop runoff routes surplus irrigation to the lowest neighbouring cell, so it must never mistake the height-zero shaped default of a stale/unmeasured cell for a real low spot.

### Changes
- `src/TopographyCache.lua`: `getCellInfo` answers now carry an explicit `stale` flag. `STALE_DEFAULT` (the shaped default for a stale or unmeasured cell) carries `stale = true`; a measured cell answer carries `stale = false`.

### Why it is safe
Purely additive. Existing readers (SF-76 field genesis) ignore the new field. The SCS-042 runoff resolver will require `stale == false` before treating a cell as a routable low spot, so an unmeasured cell keeps the water local by construction.

### Verification
`bash tools/test/run.sh`: SF-77 topography cache 54/0, SF-76 field genesis 23/0. The 2 failures in `om_213_organic_premium_test.lua` are pre-existing on `development` and unrelated.

Release stays LOCKED.
