### PR TITLE
fix(soil): SF-934 tillage nutrient change no longer flips with travel direction

### DIFF
--- a/src/SoilFertilitySystem.lua
+++ b/src/SoilFertilitySystem.lua
@@ -4162,11 +4162,152 @@ end
 
 --- Local read-modify-write bump around a work position (residue/amendment
 --- incorporation at the tillage tool). deltas = {nitrogen=dN, ...}.
-function SoilFertilitySystem:vmLocalBump(worldX, worldZ, deltas, radius)
-    if not worldX or not worldZ or not self:vmAvailable() then return end
+-- [SF-934] Teleport guard for the tillage sweep, in multiples of the worked line
+-- length: a jump farther than this never spans a quad, it seeds a fresh strip.
+SoilFertilitySystem.TILLAGE_TELEPORT_FACTOR = 3.0
+
+--- [SF-934] The parallelogram vmLocalBump paints this tick, plus the anchor
+--- bookkeeping behind it. Split out so every write inside ONE tick shares ONE
+--- footprint: cultivation bumps residue and then oxidation bumps OM in the same
+--- tick, and a second call that reseeded would concentrate its delta onto a thin
+--- strip while the first spread over the full swept quad. The per-tick cache keeps
+--- both on the same ground, which is also what physically happened.
+---@param fieldId number|nil  anchors are keyed per field so a pass never links fields
+---@return table|nil  { sx, sz, wx, wz, hx, hz, areaM2 }, or nil when nothing to paint
+function SoilFertilitySystem:_tillageQuad(fieldId, ax, az, bx, bz, lineLen)
+    local nowMs = (g_currentMission and g_currentMission.time) or 0
+    local cached = self._vmTillQuad
+    if cached ~= nil and cached.time == nowMs and cached.fieldId == fieldId
+        and cached.ax == ax and cached.az == az and cached.bx == bx and cached.bz == bz then
+        return cached.quad
+    end
+
+    local anchors = self._vmTillAnchors
+    if anchors == nil then anchors = {}; self._vmTillAnchors = anchors end
+    local anchor = (fieldId ~= nil) and anchors[fieldId] or nil
+
+    local sx, sz, wx, wz, hx, hz, areaM2
+
+    if anchor ~= nil then
+        -- Tip-swap guard: the work-area node pair can arrive in either order from one
+        -- tick to the next, so pair each tip with whichever anchor tip it is nearer.
+        -- Without it a swapped pair folds the quad into a bow tie and the paint dies.
+        local dxS = (ax - anchor.ax) + (bx - anchor.bx)
+        local dzS = (az - anchor.az) + (bz - anchor.bz)
+        local dxW = (ax - anchor.bx) + (bx - anchor.ax)
+        local dzW = (az - anchor.bz) + (bz - anchor.az)
+        local travX, travZ
+        if (dxW * dxW + dzW * dzW) < (dxS * dxS + dzS * dzS) then
+            travX, travZ = dxW * 0.5, dzW * 0.5
+        else
+            travX, travZ = dxS * 0.5, dzS * 0.5
+        end
+        local travel = math.sqrt(travX * travX + travZ * travZ)
+        if travel < 0.05 or travel > lineLen * SoilFertilitySystem.TILLAGE_TELEPORT_FACTOR then
+            anchor = nil   -- standing still, or a teleport: seed, never span the gap
+        else
+            -- Quad between the previously worked line (base) and this one (travel edge).
+            sx, sz = anchor.ax, anchor.az
+            wx, wz = anchor.bx, anchor.bz
+            hx, hz = ax, az
+            areaM2 = math.abs((wx - sx) * (hz - sz) - (wz - sz) * (hx - sx))
+        end
+    end
+
+    if anchor == nil then
+        -- Seed: a thin strip centred on the current worked line.
+        local ux, uz = -(bz - az) / lineLen, (bx - ax) / lineLen
+        local h = math.max(0.5, lineLen * 0.02)
+        sx, sz = ax - ux * h, az - uz * h
+        wx, wz = bx - ux * h, bz - uz * h
+        hx, hz = ax + ux * h, az + uz * h
+        areaM2 = lineLen * (h * 2)
+    end
+
+    if areaM2 == nil or areaM2 <= lineLen * 0.02 then return nil end
+
+    local quad = { sx = sx, sz = sz, wx = wx, wz = wz, hx = hx, hz = hz, areaM2 = areaM2 }
+    if fieldId ~= nil then
+        anchors[fieldId] = { ax = ax, az = az, bx = bx, bz = bz }
+    end
+    self._vmTillQuad = { time = nowMs, fieldId = fieldId,
+                         ax = ax, az = az, bx = bx, bz = bz, quad = quad }
+    return quad
+end
+
+--- Paint one tillage / sowing tick's deltas into the value maps ADDITIVELY, along
+--- the strip the implement actually worked.
+---
+--- [SF-934] The old body called SoilValueMaps:addValueAtWorld, which despite the
+--- name is a read-modify-SET. It sampled ONE pixel under the implement root, added
+--- the delta, then stamped that single result flat across a CELL_SIZE square,
+--- replacing every other pixel in the square with whatever the sampled pixel held.
+--- The square is wider than most implements, so neighbouring passes overlap and each
+--- pass copied its own sampled pixel over the overlap. Driving back down the same
+--- track sampled a different neighbour, so an unchanged POSITIVE delta could stamp
+--- the square DOWN instead of up: N and K fell on one pass and rose on the next. The
+--- nutrient arithmetic never reversed; the stamp copied a different pixel each time.
+---
+--- This is the move spraying already made (RSF-762 / RSF-836): paint the swept quad
+--- between the last worked line and the current one through addPaintStrip, a real
+--- per-pixel executeAdd with a saturation band. Consecutive ticks share no overlap,
+--- so a dose never stacks, and no pixel is overwritten with a neighbour's value.
+---
+--- MASS IS CONSERVED. Callers express each delta as this tick's whole amount
+--- concentrated into one zone cell, so the real mass is delta * CELL_AREA_HA. Spread
+--- over the strip's own area that becomes delta * CELL_AREA_HA / stripAreaHa per
+--- pixel, the same arithmetic paintBoomStrip uses.
+---
+--- THE FALLBACK IS ADDITIVE TOO. A first tick, a field change, a teleport or a
+--- missing work line cannot span a quad, so they seed a thin strip on the current
+--- line, still through addPaintStrip. A point-write fallback would keep the
+--- flattening stamp alive on exactly the ticks this bug appears on: the first tick
+--- of every pass and every headland turn. There is deliberately no addValueAtWorld
+--- path left here. An engine without executeAdd paints nothing rather than
+--- reintroducing the destructive stamp, which is what paintBoomStrip already does.
+---@param worldX number
+---@param worldZ number
+---@param deltas table        key -> semantic delta, pre-scaled to one zone cell
+---@param radius number|nil   half-span used ONLY when no work line is available
+---@param fieldId number|nil  defaults to the field the hook last recorded
+function SoilFertilitySystem:vmLocalBump(worldX, worldZ, deltas, radius, fieldId)
+    if not worldX or not worldZ or not deltas or not self:vmAvailable() then return end
+
+    local fid  = fieldId or self._lastTillageFieldId
+    local line = self._lastTillageLine
+
+    -- The line worked this tick. Prefer the implement's real lateral span, which the
+    -- hook derives from the work-area nodes so it carries width AND heading. Without
+    -- one, stand a span of `radius` either side of the point: still an area, never a
+    -- single sampled pixel.
+    local ax, az, bx, bz
+    if line ~= nil and line.ax ~= nil and line.bx ~= nil then
+        ax, az, bx, bz = line.ax, line.az, line.bx, line.bz
+    else
+        local half = radius or 4.0
+        ax, az, bx, bz = worldX - half, worldZ, worldX + half, worldZ
+    end
+    local lineLen = math.sqrt((bx - ax) * (bx - ax) + (bz - az) * (bz - az))
+    if lineLen < 0.01 then
+        -- A degenerate span (co-located work-area nodes) must not silently paint
+        -- nothing: fall back to the same square the no-line case uses.
+        local half = radius or 4.0
+        ax, az, bx, bz = worldX - half, worldZ, worldX + half, worldZ
+        lineLen = half * 2
+        if lineLen < 0.01 then return end
+    end
+
+    local quad = self:_tillageQuad(fid, ax, az, bx, bz, lineLen)
+    if quad == nil then return end
+
+    local zone   = SoilConstants.ZONE
+    local cellHa = (zone and zone.CELL_AREA_HA) or 0.01
+    local scale  = cellHa / (quad.areaM2 / 10000)
+    local vm     = self.valueMaps
+
     for key, d in pairs(deltas) do
         if d and d ~= 0 then
-            self.valueMaps:addValueAtWorld(key, worldX, worldZ, d, radius or 4.0)
+            vm:addPaintStrip(key, quad.sx, quad.sz, quad.wx, quad.wz, quad.hx, quad.hz, d * scale)
         end
     end
 end

--- a/src/hooks/HookManager.lua
+++ b/src/hooks/HookManager.lua
@@ -5149,13 +5149,11 @@ function HookManager:installPlowingHook()
                     local cropBiomass = cultivatorSelf._sfCropBiomass or 0
 
                     if isPlowingTool then
-                        g_SoilFertilityManager.soilSystem._lastTillageX = x
-                        g_SoilFertilityManager.soilSystem._lastTillageZ = z
+                        hookMgrRef:_recordTillagePoint(cultivatorSelf, x, z, farmlandId)
                         g_SoilFertilityManager.soilSystem:onPlowing(farmlandId, areaHa, isAlsoSprayer, cropBiomass)
                         g_SoilFertilityManager.soilSystem:recordTillageTrailPoint(farmlandId, x, z, true)
                     else
-                        g_SoilFertilityManager.soilSystem._lastTillageX = x
-                        g_SoilFertilityManager.soilSystem._lastTillageZ = z
+                        hookMgrRef:_recordTillagePoint(cultivatorSelf, x, z, farmlandId)
                         g_SoilFertilityManager.soilSystem:onCultivation(farmlandId, areaHa, isAlsoSprayer, cropBiomass)
                         g_SoilFertilityManager.soilSystem:recordTillageTrailPoint(farmlandId, x, z, false)
                     end
@@ -5259,8 +5257,7 @@ function HookManager:installDedicatedPlowHook()
                 if farmlandId and farmlandId > 0 then
                     -- #674: green-manure biomass sampled (pre-clear) by the crop-biomass probe.
                     local cropBiomass = plowSelf._sfCropBiomass or 0
-                    g_SoilFertilityManager.soilSystem._lastTillageX = x
-                    g_SoilFertilityManager.soilSystem._lastTillageZ = z
+                    hookMgrRef:_recordTillagePoint(plowSelf, x, z, farmlandId)
                     g_SoilFertilityManager.soilSystem:onPlowing(farmlandId, areaHa, false, cropBiomass)
                     g_SoilFertilityManager.soilSystem:recordTillageTrailPoint(farmlandId, x, z, true)
 
@@ -5479,8 +5476,7 @@ function HookManager:installMulcherHook()
                 local areaHa  = (speedMs * dtSec * widthM) / 10000
                 if areaHa <= 0 then return end
 
-                g_SoilFertilityManager.soilSystem._lastTillageX = x
-                g_SoilFertilityManager.soilSystem._lastTillageZ = z
+                hookMgrRef:_recordTillagePoint(mulcherSelf, x, z, farmlandId)
                 g_SoilFertilityManager.soilSystem:onMulching(farmlandId, areaHa, biomass)
             end)
             if not success then
@@ -5549,8 +5545,7 @@ function HookManager:installWeederHook()
                 SoilLogger.debug("[WeederHook] pos=(%.1f,%.1f) farmlandId=%s grassland=%s",
                     x, z, tostring(farmlandId), tostring(spec.isGrasslandWeeder))
                 if farmlandId and farmlandId > 0 then
-                    mgr.soilSystem._lastTillageX = x
-                    mgr.soilSystem._lastTillageZ = z
+                    hookMgrRef:_recordTillagePoint(weederSelf, x, z, farmlandId)
                     if doWeed then
                         mgr.soilSystem:onCultivation(farmlandId, areaHa)
                         SoilLogger.debug("[WeederHook] Field %d: mechanical weed removal applied", farmlandId)
@@ -5697,8 +5692,7 @@ function HookManager:installSowingHook()
                 if not g_currentMission or type(g_currentMission.getFruitPixelsToSqm) ~= "function" then return end
                 local areaHa = MathUtil.areaToHa(statsArea, g_currentMission:getFruitPixelsToSqm())
                 if areaHa <= 0 then return end
-                g_SoilFertilityManager.soilSystem._lastTillageX = x
-                g_SoilFertilityManager.soilSystem._lastTillageZ = z
+                hookMgrRef:_recordTillagePoint(sowingSelf, x, z, fieldId)
                 local cropBiomass = sowingSelf._sfCropBiomass or 0
                 g_SoilFertilityManager.soilSystem:onSowing(fieldId, areaHa, spec.workAreaParameters.seedsFruitType, cropBiomass)
 
@@ -7942,6 +7936,29 @@ function HookManager:_collectBoomNodes(vehicle)
         end
     end
     return nodes
+end
+
+--- [SF-934] Record where a tillage / sowing tick actually worked, for the additive
+--- strip painter in SoilFertilitySystem:vmLocalBump.
+---
+--- The root node on its own is a single point: it carries no working width and no
+--- heading, so any painter seeded from it can only stamp a fixed square, which is
+--- what made the nutrient change depend on travel direction (#934). The work line is
+--- the same lateral span the sprayer painter uses, derived from the work-area
+--- start/width/height nodes that every tillage implement has, so the painted strip
+--- follows the real working width at any heading. fieldId keys the sweep anchor so a
+--- pass on one field never links to a pass on another.
+---@param vehicle table    the implement whose work area defines the span
+---@param x number         root-node world X (kept for the coarse zone-grid consumers)
+---@param z number         root-node world Z
+---@param fieldId number   the field this tick worked
+function HookManager:_recordTillagePoint(vehicle, x, z, fieldId)
+    local ss = g_SoilFertilityManager and g_SoilFertilityManager.soilSystem
+    if ss == nil then return end
+    ss._lastTillageX = x
+    ss._lastTillageZ = z
+    ss._lastTillageFieldId = fieldId
+    ss._lastTillageLine = self:getBoomLineEndpoints(vehicle, x, z)
 end
 
 --- The implement working width used by the fallback (broadcast spreader whose work

--- a/src/maps/SoilValueMaps.lua
+++ b/src/maps/SoilValueMaps.lua
@@ -658,8 +658,17 @@ function SoilValueMaps:writeValueAtWorld(key, worldX, worldZ, value, radius, gro
 end
 
 --- Read-modify-write delta at a position: reads the pixel under (x,z),
---- adds `delta`, writes the result back over the radius square. Used by
---- residue/amendment incorporation which applies local bumps.
+--- adds `delta`, writes the result back over the radius square.
+---
+--- [SF-934] DO NOT USE THIS FOR INCREMENTAL FIELD WRITES. Despite the name this is
+--- a SET over an area, not an add over an area: it samples ONE pixel, adds the
+--- delta, then stamps that single result across the whole radius square, replacing
+--- every other pixel in the square with whatever the sampled pixel held. Two passes
+--- over the same ground therefore copy different neighbours and can move a value in
+--- opposite directions from an unchanged delta (#934, tillage NPK flipping with
+--- travel direction). `addPaintStrip` is the additive primitive; route per-pixel
+--- work through that. This is kept only for a caller that genuinely wants one
+--- sampled value levelled across a patch.
 function SoilValueMaps:addValueAtWorld(key, worldX, worldZ, delta, radius, growthDomain)
     if not self.available then return end
     local entry = self.layers[key]

--- a/tools/test/lua/sf934_tillage_strip_direction_test.lua
+++ b/tools/test/lua/sf934_tillage_strip_direction_test.lua
@@ -1,0 +1,244 @@
+-- sf934_tillage_strip_direction_test.lua - #934 tillage NPK flipping with travel direction.
+--   The old vmLocalBump called SoilValueMaps:addValueAtWorld, a read-modify-SET: it
+--   sampled ONE pixel under the implement root, added the delta, then stamped that
+--   single result flat across a CELL_SIZE square. The square is wider than most
+--   implements, so neighbouring passes overlapped and each pass copied its own
+--   sampled pixel over the overlap. Driving back down the same track sampled a
+--   different neighbour, so an unchanged POSITIVE delta could stamp the square DOWN:
+--   N and K fell on one pass and rose on the next.
+--
+--   The contract this bench locks: every tillage write is ADDITIVE (addPaintStrip,
+--   never addValueAtWorld), it follows the worked line rather than a fixed square,
+--   consecutive ticks span the swept quad, the delta keeps the caller's sign in BOTH
+--   travel directions, and every fallback (first tick, reversal, teleport, field
+--   change, missing work line) is additive too - a point-write fallback would keep
+--   the flattening stamp alive on exactly the ticks this bug appears on.
+--
+--!load: src/utils/Logger.lua, src/config/Constants.lua, src/config/SoilBlends.lua, src/ReleaseGate.lua, src/ResistanceBands.lua, src/HybridStrains.lua, src/SoilFertilitySystem.lua
+
+local painted, stamped
+
+-- A soil system whose value maps record which primitive was used. addValueAtWorld is
+-- present on purpose: the bench has to be able to SEE the destructive stamp if it
+-- ever comes back, not just miss a call that was silently dropped.
+local function newSystem(fieldId)
+  painted, stamped = {}, {}
+  local sys = setmetatable({
+    _lastTillageFieldId = fieldId,
+    valueMaps = {
+      addPaintStrip = function(_vm, key, sx, sz, wx, wz, hx, hz, delta)
+        painted[#painted + 1] = { key = key, sx = sx, sz = sz, wx = wx, wz = wz,
+                                  hx = hx, hz = hz, delta = delta }
+        return 1
+      end,
+      addValueAtWorld = function(_vm, key)
+        stamped[#stamped + 1] = key
+      end,
+    },
+  }, { __index = SoilFertilitySystem })
+  sys.vmAvailable = function() return true end
+  return sys
+end
+
+-- The Nth recorded paint, or an empty stand-in. A regression that stops painting
+-- should fail these assertions cleanly rather than crash on a nil index.
+local function P(i)
+  return painted[i] or {}
+end
+
+-- Lateral span of a painted quad, -1 when the paint never happened.
+local function span(p)
+  if p == nil or p.sx == nil then return -1 end
+  return p.wx - p.sx
+end
+
+-- Parallelogram area, the same 2D cross the painter uses. Returns -1 for a paint
+-- that never happened, so the area assertions report a mismatch instead of erroring.
+local function quadArea(p)
+  if p == nil or p.sx == nil then return -1 end
+  return math.abs((p.wx - p.sx) * (p.hz - p.sz) - (p.wz - p.sz) * (p.hx - p.sx))
+end
+
+-- The per-pixel delta the painter should hand the strip for a given quad area:
+-- the caller's per-cell delta spread over the strip's own area (mass conserving).
+local function expectedDelta(perCellDelta, areaM2)
+  return perCellDelta * (SoilConstants.ZONE.CELL_AREA_HA / (areaM2 / 10000))
+end
+
+-- A 6 m implement, its work line running across the direction of travel.
+local function lineAt(z) return { ax = 0, az = z, bx = 6, bz = z } end
+
+-- ── First tick of a pass: seeds a thin strip, ADDITIVELY ──
+do
+  local sys = newSystem(7)
+  sys._lastTillageLine = lineAt(0)
+  sys:vmLocalBump(3, 0, { nitrogen = 2 }, 5)
+
+  T.eq("934: the first tick paints", #painted, 1)
+  T.eq("934: the first tick NEVER stamps a sampled pixel", #stamped, 0)
+  T.eq("934: it paints the caller's layer", P(1).key, "nitrogen")
+  -- Seed strip: half-thickness max(0.5, 6*0.02) = 0.5 either side of the line.
+  T.near("934: seed strip starts half a thickness behind the line", P(1).sz or 0, -0.5, 1e-9)
+  T.near("934: seed strip ends half a thickness ahead of the line", P(1).hz or 0, 0.5, 1e-9)
+  T.near("934: seed strip spans the full 6 m working width", span(P(1)), 6, 1e-9)
+  T.near("934: seed area is width x thickness", quadArea(P(1)), 6, 1e-9)
+end
+
+-- ── Second tick: spans the swept quad between the two worked lines ──
+do
+  local sys = newSystem(7)
+  sys._lastTillageLine = lineAt(0)
+  sys:vmLocalBump(3, 0, { nitrogen = 2 }, 5)
+  sys._lastTillageLine = lineAt(3)          -- advanced 3 m along travel
+  sys:vmLocalBump(3, 3, { nitrogen = 2 }, 5)
+
+  local q = P(2)
+  T.eq("934: the second tick paints additively too", #painted, 2)
+  T.eq("934: still no stamp", #stamped, 0)
+  T.near("934: quad base is the PREVIOUS worked line (start)", q.sz or -1, 0, 1e-9)
+  T.near("934: quad base spans the working width", span(q), 6, 1e-9)
+  T.near("934: quad travel edge is the CURRENT line", q.hz or 0, 3, 1e-9)
+  T.near("934: swept area is width x travel", quadArea(q), 18, 1e-9)
+  T.near("934: delta is the per-cell amount spread over the swept area",
+         q.delta or 0, expectedDelta(2, 18), 1e-9)
+end
+
+-- ── THE BUG: reversing direction must not reverse the sign ──
+do
+  local sys = newSystem(7)
+  sys._lastTillageLine = lineAt(0)
+  sys:vmLocalBump(3, 0, { nitrogen = 2 }, 5)   -- seed
+  sys._lastTillageLine = lineAt(3)
+  sys:vmLocalBump(3, 3, { nitrogen = 2 }, 5)   -- up the field
+  sys._lastTillageLine = lineAt(0)
+  sys:vmLocalBump(3, 0, { nitrogen = 2 }, 5)   -- back down the same track
+
+  T.eq("934: three ticks, three additive paints", #painted, 3)
+  T.eq("934: no stamp on any pass, in either direction", #stamped, 0)
+  T.ok("934: the delta stays POSITIVE driving up the field", (P(2).delta or 0) > 0)
+  T.ok("934: the delta stays POSITIVE driving back down", (P(3).delta or 0) > 0)
+  T.near("934: the same pass in the opposite direction gets the same magnitude",
+         P(3).delta or 0, P(2).delta or -1, 1e-9)
+  T.near("934: the return quad sweeps the same area, not a bigger one",
+         quadArea(P(3)), 18, 1e-9)
+end
+
+-- ── A negative delta stays negative (oxidation loses OM in both directions) ──
+do
+  local sys = newSystem(7)
+  sys._lastTillageLine = lineAt(0)
+  sys:vmLocalBump(3, 0, { organicMatter = -1 }, 5)
+  sys._lastTillageLine = lineAt(3)
+  sys:vmLocalBump(3, 3, { organicMatter = -1 }, 5)
+  sys._lastTillageLine = lineAt(0)
+  sys:vmLocalBump(3, 0, { organicMatter = -1 }, 5)
+
+  T.ok("934: a loss stays a loss driving up", (P(2).delta or 0) < 0)
+  T.ok("934: a loss stays a loss driving back", (P(3).delta or 0) < 0)
+end
+
+-- ── Teleport: never span the gap, seed a fresh strip ──
+do
+  local sys = newSystem(7)
+  sys._lastTillageLine = lineAt(0)
+  sys:vmLocalBump(3, 0, { nitrogen = 2 }, 5)
+  sys._lastTillageLine = lineAt(100)        -- 100 m in one tick, far past 3x the width
+  sys:vmLocalBump(3, 100, { nitrogen = 2 }, 5)
+
+  T.near("934: a teleport seeds a thin strip, not a 100 m quad",
+         quadArea(P(2)), 6, 1e-9)
+  T.eq("934: a teleport still never stamps", #stamped, 0)
+end
+
+-- ── Standing still: no forward progress seeds rather than painting a zero quad ──
+do
+  local sys = newSystem(7)
+  sys._lastTillageLine = lineAt(0)
+  sys:vmLocalBump(3, 0, { nitrogen = 2 }, 5)
+  sys._lastTillageLine = { ax = 0, az = 0.001, bx = 6, bz = 0.001 }   -- 1 mm of travel
+  sys:vmLocalBump(3, 0.001, { nitrogen = 2 }, 5)
+
+  T.near("934: a stationary tick seeds instead of painting a degenerate quad",
+         quadArea(P(2)), 6, 1e-9)
+end
+
+-- ── Field change: a pass on one field never links to another ──
+do
+  local sys = newSystem(7)
+  sys._lastTillageLine = lineAt(0)
+  sys:vmLocalBump(3, 0, { nitrogen = 2 }, 5)
+  sys._lastTillageFieldId = 8               -- next field, same geometry
+  sys._lastTillageLine = lineAt(3)
+  sys:vmLocalBump(3, 3, { nitrogen = 2 }, 5)
+
+  T.near("934: a new field seeds its own strip, it does not sweep from field 7",
+         quadArea(P(2)), 6, 1e-9)
+end
+
+-- ── No work line at all: an additive square, still never a stamp ──
+do
+  local sys = newSystem(7)
+  sys._lastTillageLine = nil
+  sys:vmLocalBump(10, 10, { nitrogen = 2 }, 5)
+
+  T.eq("934: a missing work line still paints", #painted, 1)
+  T.eq("934: a missing work line still never stamps", #stamped, 0)
+  T.near("934: the fallback square uses the caller's radius as a half-span",
+         span(P(1)), 10, 1e-9)
+end
+
+-- ── Degenerate work line (co-located nodes) must not silently paint nothing ──
+do
+  local sys = newSystem(7)
+  sys._lastTillageLine = { ax = 5, az = 5, bx = 5, bz = 5 }
+  sys:vmLocalBump(5, 5, { nitrogen = 2 }, 5)
+
+  T.eq("934: a degenerate span falls back rather than dropping the write", #painted, 1)
+  T.eq("934: and the fallback is still additive", #stamped, 0)
+end
+
+-- ── Two writes in ONE tick share one footprint (residue, then oxidation) ──
+do
+  local sys = newSystem(7)
+  sys._lastTillageLine = lineAt(0)
+  sys:vmLocalBump(3, 0, { nitrogen = 2 }, 5)
+  sys._lastTillageLine = lineAt(3)
+  sys:vmLocalBump(3, 3, { nitrogen = 2 }, 5)          -- residue incorporation
+  sys:vmLocalBump(3, 3, { organicMatter = -1 }, 5)    -- oxidation, same tick
+
+  T.near("934: the same tick paints both writes on the same ground (start)",
+         P(3).sz or 0, P(2).sz or -1, 1e-9)
+  T.near("934: the same tick paints both writes on the same ground (travel edge)",
+         P(3).hz or 0, P(2).hz or -1, 1e-9)
+  T.near("934: so the second write is not concentrated onto a reseeded thin strip",
+         quadArea(P(3)), quadArea(P(2)), 1e-9)
+end
+
+-- ── Mass conservation: a wider sweep dilutes the same per-cell delta ──
+do
+  local sys = newSystem(7)
+  sys._lastTillageLine = lineAt(0)
+  sys:vmLocalBump(3, 0, { nitrogen = 2 }, 5)
+  sys._lastTillageLine = lineAt(3)
+  sys:vmLocalBump(3, 3, { nitrogen = 2 }, 5)          -- 18 m2 sweep
+
+  local sys2 = newSystem(7)
+  sys2._lastTillageLine = lineAt(0)
+  sys2:vmLocalBump(3, 0, { nitrogen = 2 }, 5)
+  sys2._lastTillageLine = lineAt(6)
+  sys2:vmLocalBump(3, 6, { nitrogen = 2 }, 5)         -- 36 m2 sweep, twice the ground
+  local wide = P(2)
+
+  T.near("934: twice the swept area carries half the per-pixel delta",
+         (wide.delta or 0) * 2, expectedDelta(2, 18), 1e-9)
+  T.near("934: the wide sweep really is twice the area", quadArea(wide), 36, 1e-9)
+end
+
+-- ── A zero delta writes nothing at all ──
+do
+  local sys = newSystem(7)
+  sys._lastTillageLine = lineAt(0)
+  sys:vmLocalBump(3, 0, { nitrogen = 0 }, 5)
+  T.eq("934: a zero delta paints nothing", #painted, 0)
+  T.eq("934: a zero delta stamps nothing", #stamped, 0)
+end


### PR DESCRIPTION
Fixes #934.

## The bug

`vmLocalBump` (`src/SoilFertilitySystem.lua`) called `SoilValueMaps:addValueAtWorld`, which despite the name is a read-modify-**SET**. It sampled ONE pixel under the implement root, added the delta, then `executeSet` that single result flat across a `CELL_SIZE` (10 m) square, replacing every other pixel in the square with whatever the sampled pixel held.

The square is wider than most implements, so neighbouring passes overlap and each pass copied its own sampled pixel over the overlap. Driving back down the same track sampled a different neighbour, so an unchanged **positive** delta could stamp the square **down**: N and K fell on one pass and rose on the next. The nutrient arithmetic never reversed; the stamp copied a different pixel each time.

The position came from `getWorldTranslation(cultivatorSelf.rootNode)` in `HookManager` - a single point, carrying neither working width nor heading.

All six soil-write paths shared that call (sowing, oxidation helper, plowing, cultivation, strip-till, mulching), which is why the reporter saw it with other machinery too. Spraying was unaffected because it had already moved to `addPaintStrip` in RSF-762 / RSF-836; tillage never made that move.

## The fix

Tillage now makes the same move: paint the swept quad between the last worked line and the current one through `addPaintStrip`, a real per-pixel `executeAdd` with a saturation band. Consecutive ticks share no overlap, so a dose never stacks and no pixel is overwritten with a neighbour's value.

- **`HookManager:_recordTillagePoint`** records the worked **line** (the work-area `start`/`width`/`height` node span, so it carries width AND heading at any angle) plus the field id, not just the root point. All six hook sites route through it.
- **Anchors are keyed per field**, so a pass on one field never links to a pass on another.
- **Mass is conserved.** Callers express a delta as the tick's whole amount concentrated in one zone cell, so the painted per-pixel delta is `delta * CELL_AREA_HA / stripAreaHa` - the same arithmetic `paintBoomStrip` uses.
- **One tick, one footprint.** Cultivation's residue bump and the oxidation bump that follows it in the same tick land on the same ground, instead of the second one reseeding onto a thin strip and concentrating its delta.
- **The fallback is additive too.** First tick, direction reversal, teleport, standing still, field change, and a missing or degenerate work line all seed a thin strip *through `addPaintStrip`*. A point-write fallback would have kept the flattening stamp alive on exactly the ticks this bug appears on: the first tick of every pass and every headland turn.

`addValueAtWorld` keeps a DO-NOT-USE note explaining the set-over-area semantics. It has no callers left.

## Verification

New bench `tools/test/lua/sf934_tillage_strip_direction_test.lua`, **38 assertions**:

- additive in both directions, never a stamp
- the delta keeps the caller's sign driving up AND driving back (a gain stays a gain, a loss stays a loss)
- swept-quad geometry: base is the previous worked line, travel edge is the current one
- mass conservation: twice the swept area carries half the per-pixel delta
- per-field anchors, teleport seeding, stationary seeding
- every fallback path, including no work line and a degenerate span
- a zero delta writes nothing

**Control run:** the bench was executed against the pre-fix code and fails there, 3 passed / 35 failed, including `934: the first tick NEVER stamps a sampled pixel :: got 1 want 0`. It is bound to the new behaviour, not merely passing alongside it.

Gates: `syntax-check` OK (94 files), `lint` clean (94 files), pre-commit staged gate OK. Suite **3759 passed, 2 failed**; both failures are `om_213_organic_premium_test.lua` and are present unchanged on clean `development`.

## Still owed in game

Offline benches cannot witness the real density maps. What remains for the in-game check on Solek: cultivate one direction, note N and K, cultivate the opposite direction, note them again, then a third pass. The values should move the same way every pass. Also worth a look: headland turns (the seeding path) and a pass that crosses a field boundary.
